### PR TITLE
Unix socket

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -71,7 +71,7 @@ func TestGetURL(t *testing.T) {
 		{"http://localhost:4243", "/", "http://localhost:4243/"},
 		{"http://localhost:4243", "/containers/ps", "http://localhost:4243/containers/ps"},
 		{"http://localhost:4243/////", "/", "http://localhost:4243/"},
-		{"unix:///var/run/docker.socket", "/", "unix:///var/run/docker.socket/"},
+		{"unix:///var/run/docker.socket", "/containers", "/containers"},
 	}
 	for _, tt := range tests {
 		client, _ := NewClient(tt.endpoint)
@@ -155,4 +155,8 @@ type dumb struct {
 	Y      float64
 	Z      int     `qs:"zee"`
 	Person *person `qs:"p"`
+}
+
+type fakeEndpointURL struct {
+	Scheme string
 }

--- a/container.go
+++ b/container.go
@@ -5,7 +5,6 @@
 package docker
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"github.com/dotcloud/docker"
@@ -264,38 +263,6 @@ func (c *Client) AttachToContainer(opts AttachToContainerOptions) error {
 	opts.RawTerminal = false
 	path := "/containers/" + container + "/attach?" + queryString(opts)
 	return c.hijack("POST", path, raw, stdin, stderr, stdout)
-}
-
-// CopyFromContainerOptions is the set of options that can be used when
-// copying files or folders from a container.
-//
-// See http://docs.docker.io/en/latest/api/docker_remote_api_v1.6/#copy-files-or-folders-from-a-container
-// for more details.
-type CopyFromContainerOptions struct {
-	Container    string
-	Resource     string
-	OutputStream io.Writer
-}
-
-// CopyFromContainer copy files or folders from a container, using a given resource.
-//
-// See http://docs.docker.io/en/latest/api/docker_remote_api_v1.6/#copy-files-or-folders-from-a-container
-func (c *Client) CopyFromContainer(opts CopyFromContainerOptions) error {
-	container := opts.Container
-	if container == "" {
-		return &NoSuchContainer{ID: container}
-	}
-	stdout := opts.OutputStream
-	url := fmt.Sprintf("/containers/%s/copy", container)
-	body, status, err := c.do("POST", url, opts)
-	if status == http.StatusNotFound {
-		return &NoSuchContainer{ID: opts.Container}
-	}
-	if err != nil {
-		return err
-	}
-	io.Copy(stdout, bytes.NewBuffer(body))
-	return nil
 }
 
 // ExportContainer export the contents of container id as tar archive

--- a/image_test.go
+++ b/image_test.go
@@ -316,10 +316,7 @@ func TestImportImageFromUrl(t *testing.T) {
 
 func TestImportImageFromInput(t *testing.T) {
 	fakeRT := &FakeRoundTripper{message: "", status: http.StatusOK}
-	client := Client{
-		endpoint: "http://localhost:4243",
-		client:   &http.Client{Transport: fakeRT},
-	}
+	client := newTestClient(fakeRT)
 	in := bytes.NewBufferString("tar content")
 	var buf bytes.Buffer
 	opts := ImportImageOptions{Source: "-", Repository: "testimage"}

--- a/misc_test.go
+++ b/misc_test.go
@@ -19,10 +19,7 @@ func TestVersion(t *testing.T) {
      "GoVersion":"go1.0.3"
 }`
 	fakeRT := FakeRoundTripper{message: body, status: http.StatusOK}
-	client := Client{
-		endpoint: "http://localhost:4243/",
-		client:   &http.Client{Transport: &fakeRT},
-	}
+	client := newTestClient(&fakeRT)
 	expected := docker.APIVersion{
 		Version:   "0.2.2",
 		GitCommit: "5a2a5cc+CHANGES",
@@ -46,12 +43,8 @@ func TestVersion(t *testing.T) {
 }
 
 func TestVersionError(t *testing.T) {
-	client := Client{
-		endpoint: "http://localhost:4242",
-		client: &http.Client{
-			Transport: &FakeRoundTripper{message: "internal error", status: http.StatusInternalServerError},
-		},
-	}
+	fakeRT := &FakeRoundTripper{message: "internal error", status: http.StatusInternalServerError}
+	client := newTestClient(fakeRT)
 	version, err := client.Version()
 	if version != nil {
 		t.Errorf("Version(): expected <nil> value, got %#v.", version)
@@ -72,10 +65,7 @@ func TestInfo(t *testing.T) {
      "SwapLimit":false
 }`
 	fakeRT := FakeRoundTripper{message: body, status: http.StatusOK}
-	client := Client{
-		endpoint: "http://localhost:3232",
-		client:   &http.Client{Transport: &fakeRT},
-	}
+	client := newTestClient(&fakeRT)
 	expected := docker.APIInfo{
 		Containers:  11,
 		Images:      16,
@@ -103,12 +93,8 @@ func TestInfo(t *testing.T) {
 }
 
 func TestInfoError(t *testing.T) {
-	client := Client{
-		endpoint: "http://localhost:4242",
-		client: &http.Client{
-			Transport: &FakeRoundTripper{message: "internal error", status: http.StatusInternalServerError},
-		},
-	}
+	fakeRT := &FakeRoundTripper{message: "internal error", status: http.StatusInternalServerError}
+	client := newTestClient(fakeRT)
 	version, err := client.Info()
 	if version != nil {
 		t.Errorf("Info(): expected <nil> value, got %#v.", version)


### PR DESCRIPTION
Tests fixed!
Referencing https://github.com/fsouza/go-dockerclient/pull/34/files
I wonder if go-dockerclient.test should be added to `.gitignore`?
