### PR TITLE
support for multiplexing log streaming in api v1.6

### DIFF
--- a/client.go
+++ b/client.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/dotcloud/docker/term"
+	"github.com/dotcloud/docker/utils"
 	"io"
 	"io/ioutil"
 	"net"
@@ -182,7 +183,12 @@ func (c *Client) hijack(method, path string, setRawTerminal bool, in *os.File, e
 	defer rwc.Close()
 	errStdout := make(chan error, 1)
 	go func() {
-		_, err := io.Copy(out, br)
+		var err error
+		if setRawTerminal {
+			_, err = io.Copy(out, br)
+		} else {
+			_, err = utils.StdCopy(out, out, br)
+		}
 		errStdout <- err
 	}()
 	if in != nil && setRawTerminal && term.IsTerminal(in.Fd()) && os.Getenv("NORAW") == "" {


### PR DESCRIPTION
http://docs.docker.io/en/latest/api/docker_remote_api_v1.6/#attach-to-a-container

without this change, the AttachToContainer call will return random characters in the log stream. i am yet to figure out how to make the tests pass with this one:

```
--- FAIL: TestAttachToContainerLogs (0.00 seconds)
        container_test.go:516: Unrecognized input header
--- FAIL: TestAttachToContainer (0.00 seconds)
        container_test.go:568: Unrecognized input header
FAIL
exit status 1
FAIL    github.com/fsouza/go-dockerclient       0.026s
```
