### PR TITLE
removed Info from misc as docker is moving it to the job api

### DIFF
--- a/client.go
+++ b/client.go
@@ -12,7 +12,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/dotcloud/docker/term"
+	"github.com/dotcloud/docker/pkg/term"
 	"github.com/dotcloud/docker/utils"
 	"io"
 	"io/ioutil"

--- a/misc.go
+++ b/misc.go
@@ -6,8 +6,6 @@ package docker
 
 import (
 	"bytes"
-	"encoding/json"
-	"github.com/dotcloud/docker"
 	"github.com/dotcloud/docker/engine"
 	"io"
 )
@@ -29,20 +27,4 @@ func (c *Client) Version() (*engine.Env, error) {
 		return nil, err
 	}
 	return remoteVersion, nil
-}
-
-// Info returns system-wide information, like the number of running containers.
-//
-// See http://goo.gl/LOmySw for more details.
-func (c *Client) Info() (*docker.APIInfo, error) {
-	body, _, err := c.do("GET", "/info", nil)
-	if err != nil {
-		return nil, err
-	}
-	var info docker.APIInfo
-	err = json.Unmarshal(body, &info)
-	if err != nil {
-		return nil, err
-	}
-	return &info, nil
 }


### PR DESCRIPTION
This fixes the issues with the latest upstream changes to the Docker api.  I'm not sure if you want to integrate this but just wanted to send it your way.  Ideally I think waiting until the Job api is stabilized would be best but I needed it to work :)
