### PR TITLE
implemented DockerClient.BuildImage

### DIFF
--- a/image.go
+++ b/image.go
@@ -184,7 +184,7 @@ func (c *Client) ImportImage(opts ImportImageOptions, in io.Reader, out io.Write
 type BuildImageOptions struct {
 	Name           string    `qs:"t"`
 	Remote         string    `qs:"remote"`
-	SuppressOutput string    `qs:"q"`
+	SuppressOutput bool      `qs:"q"`
 	OutputStream   io.Writer `qs:"-"`
 }
 
@@ -197,10 +197,6 @@ func (c *Client) BuildImage(opts BuildImageOptions) error {
 	// "github.com/user/repo"
 	if opts.Name == "" {
 		opts.Name = opts.Remote
-	}
-	// Suppress output by default.
-	if opts.SuppressOutput == "" || opts.SuppressOutput != "0" || opts.SuppressOutput != "1" {
-		opts.SuppressOutput = "1"
 	}
 	if opts.OutputStream == nil {
 		return ErrMissingOutputStream

--- a/image_test.go
+++ b/image_test.go
@@ -436,7 +436,7 @@ func TestBuildImageShouldParseAllParameters(t *testing.T) {
 	opts := BuildImageOptions{
 		Name:           "testImage",
 		Remote:         "testing/data/container.tar",
-		SuppressOutput: "1",
+		SuppressOutput: true,
 		OutputStream:   &buf,
 	}
 	err := client.BuildImage(opts)
@@ -444,7 +444,7 @@ func TestBuildImageShouldParseAllParameters(t *testing.T) {
 		t.Fatal(err)
 	}
 	req := fakeRT.requests[0]
-	expected := map[string][]string{"t": {opts.Name}, "remote": {opts.Remote}, "q": {opts.SuppressOutput}}
+	expected := map[string][]string{"t": {opts.Name}, "remote": {opts.Remote}, "q": {"1"}}
 	got := map[string][]string(req.URL.Query())
 	if !reflect.DeepEqual(got, expected) {
 		t.Errorf("ImportImage: wrong query string. Want %#v. Got %#v.", expected, got)
@@ -457,7 +457,7 @@ func TestBuildImageShouldReturnErrorWhenRemoteIsMissing(t *testing.T) {
 	var buf bytes.Buffer
 	opts := BuildImageOptions{
 		Name:           "testImage",
-		SuppressOutput: "1",
+		SuppressOutput: true,
 		OutputStream:   &buf,
 	}
 	err := client.BuildImage(opts)
@@ -474,7 +474,7 @@ func TestBuildImageShouldSetTagToRemoteIfTagIsMissing(t *testing.T) {
 	var buf bytes.Buffer
 	opts := BuildImageOptions{
 		Remote:         "testing/data/container.tar",
-		SuppressOutput: "1",
+		SuppressOutput: true,
 		OutputStream:   &buf,
 	}
 	err := client.BuildImage(opts)
@@ -482,7 +482,7 @@ func TestBuildImageShouldSetTagToRemoteIfTagIsMissing(t *testing.T) {
 		t.Fatal(err)
 	}
 	req := fakeRT.requests[0]
-	expected := map[string][]string{"t": {opts.Remote}, "remote": {opts.Remote}, "q": {opts.SuppressOutput}}
+	expected := map[string][]string{"t": {opts.Remote}, "remote": {opts.Remote}, "q": {"1"}}
 	got := map[string][]string(req.URL.Query())
 	if !reflect.DeepEqual(got, expected) {
 		t.Errorf("ImportImage: wrong query string. Want %#v. Got %#v.", expected, got)
@@ -503,29 +503,7 @@ func TestBuildImageShouldEnableQuietIfQuietIsMissing(t *testing.T) {
 		t.Fatal(err)
 	}
 	req := fakeRT.requests[0]
-	expected := map[string][]string{"t": {opts.Name}, "remote": {opts.Remote}, "q": {"1"}}
-	got := map[string][]string(req.URL.Query())
-	if !reflect.DeepEqual(got, expected) {
-		t.Errorf("ImportImage: wrong query string. Want %#v. Got %#v.", expected, got)
-	}
-}
-
-func TestBuildImageShouldEnableQuietIfQuietIsInvalid(t *testing.T) {
-	fakeRT := &FakeRoundTripper{message: "", status: http.StatusOK}
-	client := newTestClient(fakeRT)
-	var buf bytes.Buffer
-	opts := BuildImageOptions{
-		Name:           "testImage",
-		Remote:         "testing/data/container.tar",
-		SuppressOutput: "invalid",
-		OutputStream:   &buf,
-	}
-	err := client.BuildImage(opts)
-	if err != nil {
-		t.Fatal(err)
-	}
-	req := fakeRT.requests[0]
-	expected := map[string][]string{"t": {opts.Name}, "remote": {opts.Remote}, "q": {"1"}}
+	expected := map[string][]string{"t": {opts.Name}, "remote": {opts.Remote}}
 	got := map[string][]string(req.URL.Query())
 	if !reflect.DeepEqual(got, expected) {
 		t.Errorf("ImportImage: wrong query string. Want %#v. Got %#v.", expected, got)
@@ -538,7 +516,7 @@ func TestBuildImageShouldReturnErrorWhenOutputStreamIsMissing(t *testing.T) {
 	opts := BuildImageOptions{
 		Name:           "testImage",
 		Remote:         "testing/data/container.tar",
-		SuppressOutput: "1",
+		SuppressOutput: true,
 	}
 	err := client.BuildImage(opts)
 	expected := ErrMissingOutputStream


### PR DESCRIPTION
Regarding https://github.com/fsouza/go-dockerclient/issues/18 I implemented the BuildImage method to create fully functional images using the [Docker Remote API](http://docs.docker.io/en/latest/api/docker_remote_api_v1.8/#build-an-image-from-dockerfile-via-stdin). My used Docker version is 0.7.6, build bc3b2ec. 

``` golang
// build image by tarball
buildImageOptions := Docker.BuildImageOptions{Name: "imageName", Remote: "github.com/user/repo", SuppressOutput: "1"}
err := DockerClient.BuildImage(buildImageOptions)
```

In generell it works like a charm, but there is one behaviour i don't like. In `client.stream` the progress, of uploading the tarball, is piped to `stdin`. That produces some new empty lines in terminal, e.g. having a server running. It would be cool to be able to suppress that output. Using the remote Api one would like to hide that, because it is not needed, unless I miss something. 
