### PR TITLE
Write to output in DockerClient.stream using fmt.Fprint instead of fmt.F...

### DIFF
--- a/client.go
+++ b/client.go
@@ -164,7 +164,7 @@ func (c *Client) stream(method, path string, headers map[string]string, in io.Re
 				return err
 			}
 			if m.Stream != "" {
-				fmt.Fprintln(out, m.Stream)
+				fmt.Fprint(out, m.Stream)
 			} else if m.Progress != "" {
 				fmt.Fprintf(out, "%s %s\r", m.Status, m.Progress)
 			} else if m.Error != "" {


### PR DESCRIPTION
...println.

This causes the streamed output to be exactly what the docker daemon sent, avoiding
spurious newlines in streamed build output.
