### PR TITLE
Compile on windows

### DIFF
--- a/utils/utils_windows.go
+++ b/utils/utils_windows.go
@@ -1,0 +1,17 @@
+// Copyright 2014 Docker authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the DOCKER-LICENSE file.
+
+package utils
+
+import (
+	"errors"
+)
+
+type Utsname struct {
+	Release [65]byte
+}
+
+func uname() (*Utsname, error) {
+	return nil, errors.New("Kernel version detection is not available on windows")
+}


### PR DESCRIPTION
On windows the uname function did not exists so it failed to compile. This makes it return an error that kernel version detection is not available on windows just like it does on darwin.
