### PR TITLE
Fix for when all listeners are unregistered and the channel is destroyed...

### DIFF
--- a/event.go
+++ b/event.go
@@ -269,7 +269,9 @@ func (c *Client) eventHijack(startTime int64, eventChan chan *APIEvents, errChan
 				if err != nil {
 					errChan <- err
 				}
-				eventChan <- &e
+				if !eventMonitor.noListeners() {
+					eventMonitor.C <- &e
+				}
 			}
 		}
 		if err := scanner.Err(); err != nil {


### PR DESCRIPTION
When all listeners on the events API are removed, the channel is closed, but the go routine that is watching that channel is still posting events to it.  This change uses the global channel instead of the locally scoped one, and has a check for when there are no active listeners it will not attempt to post events to the closed channel.
