### PR TITLE
client.go: Error handling.

### DIFF
--- a/client.go
+++ b/client.go
@@ -88,6 +88,9 @@ func (c *Client) do(method, path string, data interface{}) ([]byte, int, error) 
 		}
 		clientconn := httputil.NewClientConn(dial, nil)
 		resp, err = clientconn.Do(req)
+		if err != nil {
+			return nil, -1, err
+		}
 		defer clientconn.Close()
 	} else {
 		resp, err = c.client.Do(req)


### PR DESCRIPTION
When the request is not properly formed, like missing image name, Docker just closes the connection without any response which results into a Panic, this will fix the issue. I will try to fill a bug upstream too, however, this fix is still required as the connection can be closed unexpectedly for a lot of reasons.
