### PR TITLE
Events - handle unexpected EOF

### DIFF
--- a/event.go
+++ b/event.go
@@ -260,7 +260,7 @@ func (c *Client) eventHijack(startTime int64, eventChan chan *APIEvents, errChan
 		for {
 			var event APIEvents
 			if err = decoder.Decode(&event); err != nil {
-				if err == io.EOF {
+				if err == io.EOF || err == io.ErrUnexpectedEOF {
 					break
 				}
 				errChan <- err


### PR DESCRIPTION
An unexpected EOF error (see http://golang.org/src/pkg/io/io.go?s=1398:1450) can occur when Docker is restarted. Tested this on Docker 0.12 when streaming `/events` over a Unix domain socket.

I don't have a test case though, not sure how to add one.
