### PR TITLE
Container Config struct Memory should be float64

### DIFF
--- a/container.go
+++ b/container.go
@@ -162,7 +162,7 @@ type Config struct {
 	Hostname        string
 	Domainname      string
 	User            string
-	Memory          int64
+	Memory          float64
 	MemorySwap      int64
 	CpuShares       int64
 	AttachStdin     bool

--- a/container_test.go
+++ b/container_test.go
@@ -132,7 +132,7 @@ func TestInspectContainer(t *testing.T) {
              "Config": {
                      "Hostname": "4fa6e0f0c678",
                      "User": "",
-                     "Memory": 0,
+                     "Memory": 2.68435456e+08,
                      "MemorySwap": 0,
                      "AttachStdin": false,
                      "AttachStdout": true,


### PR DESCRIPTION
Container Config struct Memory should be float64, otherwise unmarshall will complain on non-zero values. 

Example error:
json: cannot unmarshal number 2.68435456e+08 into Go value of type int64
