### PR TITLE
Update tag and push functions

### DIFF
--- a/image.go
+++ b/image.go
@@ -154,6 +154,9 @@ type PushImageOptions struct {
 	// Name of the image
 	Name string
 
+	// Tag of the image
+	Tag string
+
 	// Registry server to push the image
 	Registry string
 


### PR DESCRIPTION
Per this line, https://github.com/dotcloud/docker/blob/61b675d3bb6a645f7f4683253f78f0f9ddfe5a22/api/server/server.go#L420, the docker api server expects the `tag` param to identify the tag being applied to the image.  Without adding `Tag` to `TagImageOptions`, it is impossible to actually use `TagImage` to apply any tag other than `latest`, which appears to be the default when no tag is specified.

Per this line https://github.com/dotcloud/docker/blob/61b675d3bb6a645f7f4683253f78f0f9ddfe5a22/api/server/server.go#L590, the docker api server also accepts a `tag` parameter for push commands resulting in a push of an individual image as opposed to _all_ images for a given repository.

Also, both changes are strictly additive, so this pull request won't break any backwards compatibility with older docker api versions.
