### PR TITLE
Support forcerm param for build image

### DIFF
--- a/image.go
+++ b/image.go
@@ -264,13 +264,14 @@ func (c *Client) ImportImage(opts ImportImageOptions) error {
 // an image from a tarfile with a Dockerfile in it,the details about Dockerfile
 // see http://docs.docker.io/en/latest/reference/builder/
 type BuildImageOptions struct {
-	Name           string    `qs:"t"`
-	NoCache        bool      `qs:"nocache"`
-	SuppressOutput bool      `qs:"q"`
-	RmTmpContainer bool      `qs:"rm"`
-	InputStream    io.Reader `qs:"-"`
-	OutputStream   io.Writer `qs:"-"`
-	Remote         string    `qs:"remote"`
+	Name                string    `qs:"t"`
+	NoCache             bool      `qs:"nocache"`
+	SuppressOutput      bool      `qs:"q"`
+	RmTmpContainer      bool      `qs:"rm"`
+	ForceRmTmpContainer bool      `qs:"forcerm"`
+	InputStream         io.Reader `qs:"-"`
+	OutputStream        io.Writer `qs:"-"`
+	Remote              string    `qs:"remote"`
 }
 
 // BuildImage builds an image from a tarball's url or a Dockerfile in the input

--- a/image_test.go
+++ b/image_test.go
@@ -514,19 +514,20 @@ func TestBuildImageParameters(t *testing.T) {
 	client := newTestClient(fakeRT)
 	var buf bytes.Buffer
 	opts := BuildImageOptions{
-		Name:           "testImage",
-		NoCache:        true,
-		SuppressOutput: true,
-		RmTmpContainer: true,
-		InputStream:    &buf,
-		OutputStream:   &buf,
+		Name:                "testImage",
+		NoCache:             true,
+		SuppressOutput:      true,
+		RmTmpContainer:      true,
+		ForceRmTmpContainer: true,
+		InputStream:         &buf,
+		OutputStream:        &buf,
 	}
 	err := client.BuildImage(opts)
 	if err != nil && strings.Index(err.Error(), "build image fail") == -1 {
 		t.Fatal(err)
 	}
 	req := fakeRT.requests[0]
-	expected := map[string][]string{"t": {opts.Name}, "nocache": {"1"}, "q": {"1"}, "rm": {"1"}}
+	expected := map[string][]string{"t": {opts.Name}, "nocache": {"1"}, "q": {"1"}, "rm": {"1"}, "forcerm": {"1"}}
 	got := map[string][]string(req.URL.Query())
 	if !reflect.DeepEqual(got, expected) {
 		t.Errorf("BuildImage: wrong query string. Want %#v. Got %#v.", expected, got)


### PR DESCRIPTION
Support the `forcerm` parameter in `POST /build`: http://docs.docker.com/reference/api/docker_remote_api_v1.13/#build-an-image-from-dockerfile-via-stdin

I'd have named the struct field just `ForceRm` instead of `ForceRmTmpContainer` but followed the precedent of `RmTmpContainer`.
