### PR TITLE
Load / Save Images

### DIFF
--- a/image.go
+++ b/image.go
@@ -223,27 +223,27 @@ func (c *Client) PullImage(opts PullImageOptions, auth AuthConfiguration) error 
 
 // LoadImageOptions represents the options for LoadImage Docker API Call
 type LoadImageOptions struct {
-	In io.Reader
+	InputStream io.Reader
 }
 
 // LoadImage imports a tarball docker image
 //
 // See http://docs.docker.com/reference/api/docker_remote_api_v1.14/#load-a-tarball-with-a-set-of-images-and-tags-into-docker for more details
 func (c *Client) LoadImage(opts LoadImageOptions) error {
-	return c.stream("POST", "/images/load", true, false, nil, opts.In, nil, nil)
+	return c.stream("POST", "/images/load", true, false, nil, opts.InputStream, nil, nil)
 }
 
 // ExportImageOptions represent the options for ExportImage Docker API call
 type ExportImageOptions struct {
-	ImageName string
-	Out       io.Writer
+	Name         string
+	OutputStream io.Writer
 }
 
 // ExportImage exports an image (as a tar file) into the stream
 //
 // See http://docs.docker.com/reference/api/docker_remote_api_v1.14/#get-a-tarball-containing-all-images-and-tags-in-a-repository for more details
 func (c *Client) ExportImage(opts ExportImageOptions) error {
-	return c.stream("GET", fmt.Sprintf("/images/%s/get", opts.ImageName), true, false, nil, nil, opts.Out, nil)
+	return c.stream("GET", fmt.Sprintf("/images/%s/get", opts.Name), true, false, nil, nil, opts.OutputStream, nil)
 }
 
 func (c *Client) createImage(qs string, headers map[string]string, in io.Reader, w io.Writer, rawJSONStream bool) error {

--- a/image_test.go
+++ b/image_test.go
@@ -668,3 +668,37 @@ func TestIsUrl(t *testing.T) {
 		t.Errorf("isURL: wrong match. Expected %#v to not be a url. Got %#v", url, result)
 	}
 }
+
+func TestLoadImage(t *testing.T) {
+	fakeRT := &FakeRoundTripper{message: "", status: http.StatusOK}
+	client := newTestClient(fakeRT)
+
+	tar, err := os.Open("testing/data/container.tar")
+	if err != nil {
+		t.Fatal(err)
+	} else {
+		defer tar.Close()
+	}
+
+	opts := LoadImageOptions{InputStream: tar}
+
+	err = client.LoadImage(opts)
+
+	if nil != err {
+		t.Error(err)
+	}
+}
+
+func TestExportImage(t *testing.T) {
+	var buf bytes.Buffer
+
+	fakeRT := &FakeRoundTripper{message: "", status: http.StatusOK}
+	client := newTestClient(fakeRT)
+	opts := ExportImageOptions{Name: "testimage", OutputStream: &buf}
+
+	err := client.ExportImage(opts)
+
+	if nil != err {
+		t.Error(err)
+	}
+}

--- a/testing/server.go
+++ b/testing/server.go
@@ -103,6 +103,8 @@ func (s *DockerServer) buildMuxer() {
 	s.mux.Path("/images/{name:.*}/push").Methods("POST").HandlerFunc(s.handlerWrapper(s.pushImage))
 	s.mux.Path("/events").Methods("GET").HandlerFunc(s.listEvents)
 	s.mux.Path("/_ping").Methods("GET").HandlerFunc(s.handlerWrapper(s.pingDocker))
+	s.mux.Path("/images/load").Methods("POST").HandlerFunc(s.handlerWrapper(s.loadImage))
+	s.mux.Path("/images/{id:.*}/get").Methods("GET").HandlerFunc(s.handlerWrapper(s.getImage))
 }
 
 // PrepareFailure adds a new expected failure based on a URL regexp it receives
@@ -653,4 +655,14 @@ func (s *DockerServer) generateEvent() *docker.APIEvents {
 		From:   "mybase:latest",
 		Time:   time.Now().Unix(),
 	}
+}
+
+func (s *DockerServer) loadImage(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+func (s *DockerServer) getImage(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	w.Header().Set("Content-Type", "application/tar")
+
 }


### PR DESCRIPTION
Hi,

I was updating/porting doguestry (http://github.com/ingenieux/dogestry), which is a kludge to avoid dealing with private internal docker repositories [more details here](http://michaelneale.blogspot.com.br/2014/03/go-and-alternative-docker-registry.html), and I missed the commands for dealing with raw image import/export (via tarfiles), so I added it back.

Let me know if its okay for you guys. go-dockerclient has been amazing to me so far, and I'd like to thank you for this!

(I even managed to use it directly from windows into boot2docker for local docker build! \o/)
