### PR TITLE
Update tags for marshal/unmarshalling

### DIFF
--- a/container.go
+++ b/container.go
@@ -28,25 +28,25 @@ type ListContainersOptions struct {
 }
 
 type APIPort struct {
-	PrivatePort int64
-	PublicPort  int64
-	Type        string
-	IP          string
+	PrivatePort int64  `json:"PrivatePort,omitempty" yaml:"PrivatePort,omitempty"`
+	PublicPort  int64  `json:"PublicPort,omitempty" yaml:"PublicPort,omitempty"`
+	Type        string `json:"Type,omitempty" yaml:"Type,omitempty"`
+	IP          string `json:"IP,omitempty" yaml:"IP,omitempty"`
 }
 
 // APIContainers represents a container.
 //
 // See http://goo.gl/QeFH7U for more details.
 type APIContainers struct {
-	ID         string `json:"Id"`
-	Image      string
-	Command    string
-	Created    int64
-	Status     string
-	Ports      []APIPort
-	SizeRw     int64
-	SizeRootFs int64
-	Names      []string
+	ID         string    `json:"Id" yaml:"Id"`
+	Image      string    `json:"Image,omitempty" yaml:"Image,omitempty"`
+	Command    string    `json:"Command,omitempty" yaml:"Command,omitempty"`
+	Created    int64     `json:"Created,omitempty" yaml:"Created,omitempty"`
+	Status     string    `json:"Status,omitempty" yaml:"Status,omitempty"`
+	Ports      []APIPort `json:"Ports,omitempty" yaml:"Ports,omitempty"`
+	SizeRw     int64     `json:"SizeRw,omitempty" yaml:"SizeRw,omitempty"`
+	SizeRootFs int64     `json:"SizeRootFs,omitempty" yaml:"SizeRootFs,omitempty"`
+	Names      []string  `json:"Names,omitempty" yaml:"Names,omitempty"`
 }
 
 // ListContainers returns a slice of containers matching the given criteria.
@@ -86,12 +86,12 @@ func (p Port) Proto() string {
 
 // State represents the state of a container.
 type State struct {
-	Running    bool
-	Paused     bool
-	Pid        int
-	ExitCode   int
-	StartedAt  time.Time
-	FinishedAt time.Time
+	Running    bool      `json:"Running,omitempty" yaml:"Running,omitempty"`
+	Paused     bool      `json:"Paused,omitempty" yaml:"Paused,omitempty"`
+	Pid        int       `json:"Pid,omitempty" yaml:"Pid,omitempty"`
+	ExitCode   int       `json:"ExitCode,omitempty" yaml:"ExitCode,omitempty"`
+	StartedAt  time.Time `json:"StartedAt,omitempty" yaml:"StartedAt,omitempty"`
+	FinishedAt time.Time `json:"FinishedAt,omitempty" yaml:"FinishedAt,omitempty"`
 }
 
 // String returns the string representation of a state.
@@ -106,19 +106,19 @@ func (s *State) String() string {
 }
 
 type PortBinding struct {
-	HostIp   string
-	HostPort string
+	HostIp   string `json:"HostIP,omitempty" yaml:"HostIP,omitempty"`
+	HostPort string `json:"HostPort,omitempty" yaml:"HostPort,omitempty"`
 }
 
 type PortMapping map[string]string
 
 type NetworkSettings struct {
-	IPAddress   string
-	IPPrefixLen int
-	Gateway     string
-	Bridge      string
-	PortMapping map[string]PortMapping
-	Ports       map[Port][]PortBinding
+	IPAddress   string                 `json:"IPAddress,omitempty" yaml:"IPAddress,omitempty"`
+	IPPrefixLen int                    `json:"IPPrefixLen,omitempty" yaml:"IPPrefixLen,omitempty"`
+	Gateway     string                 `json:"Gateway,omitempty" yaml:"Gateway,omitempty"`
+	Bridge      string                 `json:"Bridge,omitempty" yaml:"Bridge,omitempty"`
+	PortMapping map[string]PortMapping `json:"PortMapping,omitempty" yaml:"PortMapping,omitempty"`
+	Ports       map[Port][]PortBinding `json:"Ports,omitempty" yaml:"Ports,omitempty"`
 }
 
 func (settings *NetworkSettings) PortMappingAPI() []APIPort {
@@ -155,55 +155,55 @@ func parsePort(rawPort string) (int, error) {
 }
 
 type Config struct {
-	Hostname        string
-	Domainname      string
-	User            string
-	Memory          int64
-	MemorySwap      int64
-	CpuShares       int64
-	AttachStdin     bool
-	AttachStdout    bool
-	AttachStderr    bool
-	PortSpecs       []string
-	ExposedPorts    map[Port]struct{}
-	Tty             bool
-	OpenStdin       bool
-	StdinOnce       bool
-	Env             []string
-	Cmd             []string
-	Dns             []string // For Docker API v1.9 and below only
-	Image           string
-	Volumes         map[string]struct{}
-	VolumesFrom     string
-	WorkingDir      string
-	Entrypoint      []string
-	NetworkDisabled bool
+	Hostname        string              `json:"Hostname,omitempty" yaml:"Hostname,omitempty"`
+	Domainname      string              `json:"Domainname,omitempty" yaml:"Domainname,omitempty"`
+	User            string              `json:"User,omitempty" yaml:"User,omitempty"`
+	Memory          int64               `json:"Memory,omitempty" yaml:"Memory,omitempty"`
+	MemorySwap      int64               `json:"MemorySwap,omitempty" yaml:"MemorySwap,omitempty"`
+	CpuShares       int64               `json:"CpuShares,omitempty" yaml:"CpuShares,omitempty"`
+	AttachStdin     bool                `json:"AttachStdin,omitempty" yaml:"AttachStdin,omitempty"`
+	AttachStdout    bool                `json:"AttachStdout,omitempty" yaml:"AttachStdout,omitempty"`
+	AttachStderr    bool                `json:"AttachStderr,omitempty" yaml:"AttachStderr,omitempty"`
+	PortSpecs       []string            `json:"PortSpecs,omitempty" yaml:"PortSpecs,omitempty"`
+	ExposedPorts    map[Port]struct{}   `json:"ExposedPorts,omitempty" yaml:"ExposedPorts,omitempty"`
+	Tty             bool                `json:"Tty,omitempty" yaml:"Tty,omitempty"`
+	OpenStdin       bool                `json:"OpenStdin,omitempty" yaml:"OpenStdin,omitempty"`
+	StdinOnce       bool                `json:"StdinOnce,omitempty" yaml:"StdinOnce,omitempty"`
+	Env             []string            `json:"Env,omitempty" yaml:"Env,omitempty"`
+	Cmd             []string            `json:"Cmd,omitempty" yaml:"Cmd,omitempty"`
+	Dns             []string            `json:"Dns,omitempty" yaml:"Dns,omitempty"` // For Docker API v1.9 and below only
+	Image           string              `json:"Image,omitempty" yaml:"Image,omitempty"`
+	Volumes         map[string]struct{} `json:"Volumes,omitempty" yaml:"Volumes,omitempty"`
+	VolumesFrom     string              `json:"VolumesFrom,omitempty" yaml:"VolumesFrom,omitempty"`
+	WorkingDir      string              `json:"WorkingDir,omitempty" yaml:"WorkingDir,omitempty"`
+	Entrypoint      []string            `json:"Entrypoint,omitempty" yaml:"Entrypoint,omitempty"`
+	NetworkDisabled bool                `json:"NetworkDisabled,omitempty" yaml:"NetworkDisabled,omitempty"`
 }
 
 type Container struct {
-	ID string
+	ID string `json:"Id" yaml:"Id"`
 
-	Created time.Time
+	Created time.Time `json:"Created,omitempty" yaml:"Created,omitempty"`
 
-	Path string
-	Args []string
+	Path string   `json:"Path,omitempty" yaml:"Path,omitempty"`
+	Args []string `json:"Args,omitempty" yaml:"Args,omitempty"`
 
-	Config *Config
-	State  State
-	Image  string
+	Config *Config `json:"Config,omitempty" yaml:"Config,omitempty"`
+	State  State   `json:"State,omitempty" yaml:"State,omitempty"`
+	Image  string  `json:"Image,omitempty" yaml:"Image,omitempty"`
 
-	NetworkSettings *NetworkSettings
+	NetworkSettings *NetworkSettings `json:"NetworkSettings,omitempty" yaml:"NetworkSettings,omitempty"`
 
-	SysInitPath    string
-	ResolvConfPath string
-	HostnamePath   string
-	HostsPath      string
-	Name           string
-	Driver         string
+	SysInitPath    string `json:"SysInitPath,omitempty" yaml:"SysInitPath,omitempty"`
+	ResolvConfPath string `json:"ResolvConfPath,omitempty" yaml:"ResolvConfPath,omitempty"`
+	HostnamePath   string `json:"HostnamePath,omitempty" yaml:"HostnamePath,omitempty"`
+	HostsPath      string `json:"HostsPath,omitempty" yaml:"HostsPath,omitempty"`
+	Name           string `json:"Name,omitempty" yaml:"Name,omitempty"`
+	Driver         string `json:"Driver,omitempty" yaml:"Driver,omitempty"`
 
-	Volumes    map[string]string
-	VolumesRW  map[string]bool
-	HostConfig *HostConfig
+	Volumes    map[string]string `json:"Volumes,omitempty" yaml:"Volumes,omitempty"`
+	VolumesRW  map[string]bool   `json:"VolumesRW,omitempty" yaml:"VolumesRW,omitempty"`
+	HostConfig *HostConfig       `json:"HostConfig,omitempty" yaml:"HostConfig,omitempty"`
 }
 
 // InspectContainer returns information about a container by its ID.
@@ -279,8 +279,8 @@ func (c *Client) CreateContainer(opts CreateContainerOptions) (*Container, error
 }
 
 type KeyValuePair struct {
-	Key   string
-	Value string
+	Key   string `json:"Key,omitempty" yaml:"Key,omitempty"`
+	Value string `json:"Value,omitempty" yaml:"Value,omitempty"`
 }
 
 // RestartPolicy represents the policy for automatically restarting a container.
@@ -292,8 +292,8 @@ type KeyValuePair struct {
 //                 most MaximumRetryCount times
 //   - no: the docker daemon will not restart the container automatically
 type RestartPolicy struct {
-	Name     string
-	MaxRetry int `json:"MaximumRetryCount"`
+	Name              string `json:"Name,omitempty" yaml:"Name,omitempty"`
+	MaximumRetryCount int    `json:"MaximumRetryCount,omitempty" yaml:"MaximumRetryCount,omitempty"`
 }
 
 // AlwaysRestart returns a restart policy that tells the Docker daemon to
@@ -305,7 +305,7 @@ func AlwaysRestart() RestartPolicy {
 // RestartOnFailure returns a restart policy that tells the Docker daemon to
 // restart the container on failures, trying at most maxRetry times.
 func RestartOnFailure(maxRetry int) RestartPolicy {
-	return RestartPolicy{Name: "on-failure", MaxRetry: maxRetry}
+	return RestartPolicy{Name: "on-failure", MaximumRetryCount: maxRetry}
 }
 
 // NeverRestart returns a restart policy that tells the Docker daemon to never
@@ -315,20 +315,20 @@ func NeverRestart() RestartPolicy {
 }
 
 type HostConfig struct {
-	Binds           []string
-	CapAdd          []string
-	CapDrop         []string
-	ContainerIDFile string
-	LxcConf         []KeyValuePair
-	Privileged      bool
-	PortBindings    map[Port][]PortBinding
-	Links           []string
-	PublishAllPorts bool
-	Dns             []string // For Docker API v1.10 and above only
-	DnsSearch       []string
-	VolumesFrom     []string
-	NetworkMode     string
-	RestartPolicy   RestartPolicy
+	Binds           []string               `json:"Binds,omitempty" yaml:"Binds,omitempty"`
+	CapAdd          []string               `json:"CapAdd,omitempty" yaml:"CapAdd,omitempty"`
+	CapDrop         []string               `json:"CapDrop,omitempty" yaml:"CapDrop,omitempty"`
+	ContainerIDFile string                 `json:"ContainerIDFile,omitempty" yaml:"ContainerIDFile,omitempty"`
+	LxcConf         []KeyValuePair         `json:"LxcConf,omitempty" yaml:"LxcConf,omitempty"`
+	Privileged      bool                   `json:"Privileged,omitempty" yaml:"Privileged,omitempty"`
+	PortBindings    map[Port][]PortBinding `json:"PortBindings,omitempty" yaml:"PortBindings,omitempty"`
+	Links           []string               `json:"Links,omitempty" yaml:"Links,omitempty"`
+	PublishAllPorts bool                   `json:"PublishAllPorts,omitempty" yaml:"PublishAllPorts,omitempty"`
+	Dns             []string               `json:"Dns,omitempty" yaml:"Dns,omitempty"` // For Docker API v1.10 and above only
+	DnsSearch       []string               `json:"DnsSearch,omitempty" yaml:"DnsSearch,omitempty"`
+	VolumesFrom     []string               `json:"VolumesFrom,omitempty" yaml:"VolumesFrom,omitempty"`
+	NetworkMode     string                 `json:"NetworkMode,omitempty" yaml:"NetworkMode,omitempty"`
+	RestartPolicy   RestartPolicy          `json:"RestartPolicy,omitempty" yaml:"RestartPolicy,omitempty"`
 }
 
 // StartContainer starts a container, returning an error in case of failure.

--- a/container_test.go
+++ b/container_test.go
@@ -1389,8 +1389,8 @@ func TestAlwaysRestart(t *testing.T) {
 	if policy.Name != "always" {
 		t.Errorf("AlwaysRestart(): wrong policy name. Want %q. Got %q", "always", policy.Name)
 	}
-	if policy.MaxRetry != 0 {
-		t.Errorf("AlwaysRestart(): wrong MaxRetry. Want 0. Got %d", policy.MaxRetry)
+	if policy.MaximumRetryCount != 0 {
+		t.Errorf("AlwaysRestart(): wrong MaximumRetryCount. Want 0. Got %d", policy.MaximumRetryCount)
 	}
 }
 
@@ -1400,8 +1400,8 @@ func TestRestartOnFailure(t *testing.T) {
 	if policy.Name != "on-failure" {
 		t.Errorf("RestartOnFailure(%d): wrong policy name. Want %q. Got %q", retry, "on-failure", policy.Name)
 	}
-	if policy.MaxRetry != retry {
-		t.Errorf("RestartOnFailure(%d): wrong MaxRetry. Want %d. Got %d", retry, retry, policy.MaxRetry)
+	if policy.MaximumRetryCount != retry {
+		t.Errorf("RestartOnFailure(%d): wrong MaximumRetryCount. Want %d. Got %d", retry, retry, policy.MaximumRetryCount)
 	}
 }
 
@@ -1410,7 +1410,7 @@ func TestNeverRestart(t *testing.T) {
 	if policy.Name != "no" {
 		t.Errorf("NeverRestart(): wrong policy name. Want %q. Got %q", "always", policy.Name)
 	}
-	if policy.MaxRetry != 0 {
-		t.Errorf("NeverRestart(): wrong MaxRetry. Want 0. Got %d", policy.MaxRetry)
+	if policy.MaximumRetryCount != 0 {
+		t.Errorf("NeverRestart(): wrong MaximumRetryCount. Want 0. Got %d", policy.MaximumRetryCount)
 	}
 }

--- a/event.go
+++ b/event.go
@@ -20,10 +20,10 @@ import (
 
 // APIEvents represents an event returned by the API.
 type APIEvents struct {
-	Status string
-	ID     string
-	From   string
-	Time   int64
+	Status string `json:"Status,omitempty" yaml:"Status,omitempty"`
+	ID     string `json:"ID,omitempty" yaml:"ID,omitempty"`
+	From   string `json:"From,omitempty" yaml:"From,omitempty"`
+	Time   int64  `json:"Time,omitempty" yaml:"Time,omitempty"`
 }
 
 type eventMonitoringState struct {

--- a/image.go
+++ b/image.go
@@ -20,28 +20,26 @@ import (
 
 // APIImages represent an image returned in the ListImages call.
 type APIImages struct {
-	ID          string   `json:"Id"`
-	RepoTags    []string `json:",omitempty"`
-	Created     int64
-	Size        int64
-	VirtualSize int64
-	ParentId    string `json:",omitempty"`
-	Repository  string `json:",omitempty"`
-	Tag         string `json:",omitempty"`
+	ID          string   `json:"Id" yaml:"Id"`
+	RepoTags    []string `json:"RepoTags,omitempty" yaml:"RepoTags,omitempty"`
+	Created     int64    `json:"Created,omitempty" yaml:"Created,omitempty"`
+	Size        int64    `json:"Size,omitempty" yaml:"Size,omitempty"`
+	VirtualSize int64    `json:"VirtualSize,omitempty" yaml:"VirtualSize,omitempty"`
+	ParentId    string   `json:"ParentId,omitempty" yaml:"ParentId,omitempty"`
 }
 
 type Image struct {
-	ID              string    `json:"id"`
-	Parent          string    `json:"parent,omitempty"`
-	Comment         string    `json:"comment,omitempty"`
-	Created         time.Time `json:"created"`
-	Container       string    `json:"container,omitempty"`
-	ContainerConfig Config    `json:"containerconfig,omitempty"`
-	DockerVersion   string    `json:"dockerversion,omitempty"`
-	Author          string    `json:"author,omitempty"`
-	Config          *Config   `json:"config,omitempty"`
-	Architecture    string    `json:"architecture,omitempty"`
-	Size            int64
+	ID              string    `json:"Id" yaml:"Id"`
+	Parent          string    `json:"Parent,omitempty" yaml:"Parent,omitempty"`
+	Comment         string    `json:"Comment,omitempty" yaml:"Comment,omitempty"`
+	Created         time.Time `json:"Created,omitempty" yaml:"Created,omitempty"`
+	Container       string    `json:"Container,omitempty" yaml:"Container,omitempty"`
+	ContainerConfig Config    `json:"ContainerConfig,omitempty" yaml:"ContainerConfig,omitempty"`
+	DockerVersion   string    `json:"DockerVersion,omitempty" yaml:"DockerVersion,omitempty"`
+	Author          string    `json:"Author,omitempty" yaml:"Author,omitempty"`
+	Config          *Config   `json:"Config,omitempty" yaml:"Config,omitempty"`
+	Architecture    string    `json:"Architecture,omitempty" yaml:"Architecture,omitempty"`
+	Size            int64     `json:"Size,omitempty" yaml:"Size,omitempty"`
 }
 
 type ImagePre012 struct {
@@ -55,7 +53,7 @@ type ImagePre012 struct {
 	Author          string    `json:"author,omitempty"`
 	Config          *Config   `json:"config,omitempty"`
 	Architecture    string    `json:"architecture,omitempty"`
-	Size            int64
+	Size            int64     `json:"size,omitempty"`
 }
 
 var (
@@ -164,7 +162,7 @@ type PushImageOptions struct {
 }
 
 // AuthConfiguration represents authentication options to use in the PushImage
-// method. It represents the authencation in the Docker index server.
+// method. It represents the authentication in the Docker index server.
 type AuthConfiguration struct {
 	Username string `json:"username,omitempty"`
 	Password string `json:"password,omitempty"`


### PR DESCRIPTION
Update tags for all structs that a user may want to marshal:
- add yaml tags everywhere
- update case to match Docker's format

Rename MaxRetry -> MaximumRetryCount for consistency with Docker.

This is needed to support Kubernetes and OpenShift, both of which use go-dockerclient. We currently use a modified copy of the Container & supporting structs with the fields' json and yaml tags explicitly listed. This is so marshalling/unmarshalling works for both json and yaml, and the casing of the field names matches the way that Docker returns them.

If I missed any structs, please let me know and I'll update this PR.
