### PR TITLE
docs: remove APIImages.Repository from README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -30,7 +30,6 @@ func main() {
                 fmt.Println("Size: ", img.Size)
                 fmt.Println("VirtualSize: ", img.VirtualSize)
                 fmt.Println("ParentId: ", img.ParentId)
-                fmt.Println("Repository: ", img.Repository)
         }
 }
 ```


### PR DESCRIPTION
I noticed `APIImages` don't actually have this field, perhaps it used to be there?
