### PR TITLE
Creating assertable error types.

### DIFF
--- a/client.go
+++ b/client.go
@@ -25,12 +25,23 @@ import (
 
 const userAgent = "go-dockerclient"
 
-var (
-	// ErrInvalidEndpoint is returned when the endpoint is not a valid HTTP URL.
-	ErrInvalidEndpoint = errors.New("invalid endpoint")
+// ErrorInvalidEndpoint is returned when the endpoint is not a valid HTTP URL.
+type ErrorInvalidEndpoint struct {
+	DockerClientError
 
-	// ErrConnectionRefused is returned when the client cannot connect to the given endpoint.
-	ErrConnectionRefused = errors.New("cannot connect to Docker endpoint")
+	Message string
+}
+
+// ErrorConnectionRefused is returned when the client cannot connect to the given endpoint.
+type ErrorConnectionRefused struct {
+	DockerClientError
+
+	Message string
+}
+
+var (
+	ErrInvalidEndpoint   = &ErrorInvalidEndpoint{Message: "invalid endpoint"}
+	ErrConnectionRefused = &ErrorConnectionRefused{Message: "cannot connect to Docker endpoint"}
 
 	apiVersion_1_12, _ = NewApiVersion("1.12")
 )

--- a/error.go
+++ b/error.go
@@ -1,0 +1,11 @@
+package docker
+
+// Abstract-like base struct for assertable errors
+type DockerClientError struct {
+	Message string
+}
+
+// Error() implements the error interface
+func (d *DockerClientError) Error() string {
+	return d.Message
+}

--- a/event.go
+++ b/event.go
@@ -6,7 +6,6 @@ package docker
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -41,14 +40,25 @@ const (
 	retryInitialWaitTime  = 10.
 )
 
-var (
-	// ErrNoListeners is the error returned when no listeners are available
-	// to receive an event.
-	ErrNoListeners = errors.New("no listeners present to receive event")
+// ErrorNoListeners is the error returned when no listeners are available
+// to receive an event.
+type ErrorNoListeners struct {
+	DockerClientError
 
-	// ErrListenerAlreadyExists is the error returned when the listerner already
-	// exists.
-	ErrListenerAlreadyExists = errors.New("listener already exists for docker events")
+	Message string
+}
+
+// ErrorListenerAlreadyExists is the error returned when the listerner already
+// exists.
+type ErrorListenerAlreadyExists struct {
+	DockerClientError
+
+	Message string
+}
+
+var (
+	ErrNoListeners           = &ErrorNoListeners{Message: "no listeners present to receive event"}
+	ErrListenerAlreadyExists = &ErrorListenerAlreadyExists{Message: "listener already exists for docker events"}
 )
 
 // AddEventListener adds a new listener to container events in the Docker API.

--- a/image.go
+++ b/image.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -66,17 +65,33 @@ type ImagePre012 struct {
 	Size            int64     `json:"size,omitempty"`
 }
 
+// ErrorNoSuchImage is the error returned when the image does not exist.
+type ErrorNoSuchImage struct {
+	DockerClientError
+
+	Message string
+}
+
+// ErrorMissingRepo is the error returned when the remote repository is
+// missing.
+type ErrorMissingRepo struct {
+	DockerClientError
+
+	Message string
+}
+
+// ErrorMissingOutputStream is the error returned when no output stream
+// is provided to some calls, like BuildImage.
+type ErrorMissingOutputStream struct {
+	DockerClientError
+
+	Message string
+}
+
 var (
-	// ErrNoSuchImage is the error returned when the image does not exist.
-	ErrNoSuchImage = errors.New("no such image")
-
-	// ErrMissingRepo is the error returned when the remote repository is
-	// missing.
-	ErrMissingRepo = errors.New("missing remote repository e.g. 'github.com/user/repo'")
-
-	// ErrMissingOutputStream is the error returned when no output stream
-	// is provided to some calls, like BuildImage.
-	ErrMissingOutputStream = errors.New("missing output stream")
+	ErrNoSuchImage         = &ErrorNoSuchImage{Message: "no such image"}
+	ErrMissingRepo         = &ErrorMissingRepo{Message: "missing remote repository e.g. 'github.com/user/repo'"}
+	ErrMissingOutputStream = &ErrorMissingOutputStream{Message: "missing output stream"}
 )
 
 // ListImages returns the list of available images in the server.


### PR DESCRIPTION
I'd like to be able to assert the type of error, rather than checking against the return from `err.Error()`. E.g:

``` go
con, err = d.CreateContainer(create)
if err != nil {
    if _, ok := err.(*docker.ErrorNoSuchImage); ok {
        pullImage("an/image")
    }
}
```

vs

``` go
con, err = d.CreateContainer(create)
if err != nil {
    if err.Error() == "no such image" {
        pullImage("an/image")
    }
}
```
