### PR TITLE
Support RawJSONStream option for PushImage

### DIFF
--- a/image.go
+++ b/image.go
@@ -187,7 +187,8 @@ type PushImageOptions struct {
 	// Registry server to push the image
 	Registry string
 
-	OutputStream io.Writer `qs:"-"`
+	OutputStream  io.Writer `qs:"-"`
+	RawJSONStream bool      `qs:"-"`
 }
 
 // AuthConfiguration represents authentication options to use in the PushImage
@@ -217,7 +218,7 @@ func (c *Client) PushImage(opts PushImageOptions, auth AuthConfiguration) error 
 
 	headers["X-Registry-Auth"] = base64.URLEncoding.EncodeToString(buf.Bytes())
 
-	return c.stream("POST", path, true, false, headers, nil, opts.OutputStream, nil)
+	return c.stream("POST", path, true, opts.RawJSONStream, headers, nil, opts.OutputStream, nil)
 }
 
 // PullImageOptions present the set of options available for pulling an image

--- a/image_test.go
+++ b/image_test.go
@@ -266,6 +266,35 @@ func TestPushImage(t *testing.T) {
 	}
 }
 
+func TestPushImageWithRawJSON(t *testing.T) {
+	body := `
+	{"status":"Pushing..."}
+	{"status":"Pushing", "progress":"1/? (n/a)", "progressDetail":{"current":1}}}
+	{"status":"Image successfully pushed"}
+	`
+	fakeRT := &FakeRoundTripper{
+		message: body,
+		status:  http.StatusOK,
+		header: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+	client := newTestClient(fakeRT)
+	var buf bytes.Buffer
+
+	err := client.PushImage(PushImageOptions{
+		Name:          "test",
+		OutputStream:  &buf,
+		RawJSONStream: true,
+	}, AuthConfiguration{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if buf.String() != body {
+		t.Errorf("PushImage: Wrong raw output. Want %q. Got %q.", body, buf.String())
+	}
+}
+
 func TestPushImageWithAuthentication(t *testing.T) {
 	fakeRT := &FakeRoundTripper{message: "Pushing 1/100", status: http.StatusOK}
 	client := newTestClient(fakeRT)


### PR DESCRIPTION
As another follow up to #142, add the RawJSONStream option to PushImageOptions so that we can get at the raw JSON stream from the Docker API if required.
