### PR TITLE
TestingServer: Container Kill and Create Container keeping image by tag

### DIFF
--- a/testing/server.go
+++ b/testing/server.go
@@ -90,6 +90,7 @@ func (s *DockerServer) buildMuxer() {
 	s.mux.Path("/containers/{id:.*}/json").Methods("GET").HandlerFunc(s.handlerWrapper(s.inspectContainer))
 	s.mux.Path("/containers/{id:.*}/top").Methods("GET").HandlerFunc(s.handlerWrapper(s.topContainer))
 	s.mux.Path("/containers/{id:.*}/start").Methods("POST").HandlerFunc(s.handlerWrapper(s.startContainer))
+	s.mux.Path("/containers/{id:.*}/kill").Methods("POST").HandlerFunc(s.handlerWrapper(s.stopContainer))
 	s.mux.Path("/containers/{id:.*}/stop").Methods("POST").HandlerFunc(s.handlerWrapper(s.stopContainer))
 	s.mux.Path("/containers/{id:.*}/pause").Methods("POST").HandlerFunc(s.handlerWrapper(s.pauseContainer))
 	s.mux.Path("/containers/{id:.*}/unpause").Methods("POST").HandlerFunc(s.handlerWrapper(s.unpauseContainer))
@@ -269,8 +270,7 @@ func (s *DockerServer) createContainer(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	image, err := s.findImage(config.Image)
-	if err != nil {
+	if _, err := s.findImage(config.Image); err != nil {
 		http.Error(w, err.Error(), http.StatusNotFound)
 		return
 	}
@@ -305,7 +305,7 @@ func (s *DockerServer) createContainer(w http.ResponseWriter, r *http.Request) {
 			ExitCode:  0,
 			StartedAt: time.Now(),
 		},
-		Image: image,
+		Image: config.Image,
 		NetworkSettings: &docker.NetworkSettings{
 			IPAddress:   fmt.Sprintf("172.16.42.%d", mathrand.Int()%250+2),
 			IPPrefixLen: 24,

--- a/testing/server_test.go
+++ b/testing/server_test.go
@@ -473,6 +473,23 @@ func TestStopContainer(t *testing.T) {
 	}
 }
 
+func TestKillContainer(t *testing.T) {
+	server := DockerServer{}
+	addContainers(&server, 1)
+	server.containers[0].State.Running = true
+	server.buildMuxer()
+	recorder := httptest.NewRecorder()
+	path := fmt.Sprintf("/containers/%s/kill", server.containers[0].ID)
+	request, _ := http.NewRequest("POST", path, nil)
+	server.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusNoContent {
+		t.Errorf("KillContainer: wrong status code. Want %d. Got %d.", http.StatusNoContent, recorder.Code)
+	}
+	if server.containers[0].State.Running {
+		t.Error("KillContainer: did not stop the container")
+	}
+}
+
 func TestStopContainerWithNotifyChannel(t *testing.T) {
 	ch := make(chan *docker.Container, 1)
 	server := DockerServer{}


### PR DESCRIPTION
I am using your wonderful library and too the Testing server at my tests. I just discovered two small bugs: 
- Container kill is missed
- Create container, sets the image ID intend of the image tag.

Thanks!
