### PR TITLE
Close event listeners on EOF

### DIFF
--- a/event.go
+++ b/event.go
@@ -49,6 +49,11 @@ var (
 	// ErrListenerAlreadyExists is the error returned when the listerner already
 	// exists.
 	ErrListenerAlreadyExists = errors.New("listener already exists for docker events")
+
+	// EOFEvent is sent when the event listener receives an EOF error.
+	EOFEvent = &APIEvents{
+		Status: "EOF",
+	}
 )
 
 // AddEventListener adds a new listener to container events in the Docker API.
@@ -111,6 +116,16 @@ func (eventState *eventMonitoringState) removeListener(listener chan<- *APIEvent
 	return nil
 }
 
+func (eventState *eventMonitoringState) closeListeners() {
+	eventState.Lock()
+	defer eventState.Unlock()
+	for _, l := range eventState.listeners {
+		close(l)
+		eventState.Add(-1)
+	}
+	eventState.listeners = nil
+}
+
 func listenerExists(a chan<- *APIEvents, list *[]chan<- *APIEvents) bool {
 	for _, b := range *list {
 		if b == a {
@@ -152,7 +167,7 @@ func (eventState *eventMonitoringState) monitorEvents(c *Client) {
 		time.Sleep(10 * time.Millisecond)
 	}
 	if err = eventState.connectWithRetry(c); err != nil {
-		eventState.terminate(err)
+		eventState.terminate()
 	}
 	for eventState.isEnabled() {
 		timeout := time.After(100 * time.Millisecond)
@@ -161,11 +176,16 @@ func (eventState *eventMonitoringState) monitorEvents(c *Client) {
 			if !ok {
 				return
 			}
+			if ev == EOFEvent {
+				eventState.closeListeners()
+				eventState.terminate()
+				return
+			}
 			go eventState.sendEvent(ev)
 			go eventState.updateLastSeen(ev)
 		case err = <-eventState.errC:
 			if err == ErrNoListeners {
-				eventState.terminate(nil)
+				eventState.terminate()
 				return
 			} else if err != nil {
 				defer func() { go eventState.monitorEvents(c) }()
@@ -225,7 +245,7 @@ func (eventState *eventMonitoringState) updateLastSeen(e *APIEvents) {
 	}
 }
 
-func (eventState *eventMonitoringState) terminate(err error) {
+func (eventState *eventMonitoringState) terminate() {
 	eventState.disableEventMonitoring()
 }
 
@@ -261,6 +281,10 @@ func (c *Client) eventHijack(startTime int64, eventChan chan *APIEvents, errChan
 			var event APIEvents
 			if err = decoder.Decode(&event); err != nil {
 				if err == io.EOF || err == io.ErrUnexpectedEOF {
+					if c.eventMonitor.isEnabled() {
+						// Signal that we're exiting.
+						eventChan <- EOFEvent
+					}
 					break
 				}
 				errChan <- err
@@ -271,7 +295,7 @@ func (c *Client) eventHijack(startTime int64, eventChan chan *APIEvents, errChan
 			if !c.eventMonitor.isEnabled() {
 				return
 			}
-			c.eventMonitor.C <- &event
+			eventChan <- &event
 		}
 	}(res, conn)
 	return nil

--- a/event_test.go
+++ b/event_test.go
@@ -53,7 +53,7 @@ func TestEventListeners(t *testing.T) {
 	for {
 		select {
 		case msg := <-listener:
-			t.Logf("Recieved: %s", *msg)
+			t.Logf("Received: %s", *msg)
 			count++
 			err = checkEvent(count, msg)
 			if err != nil {


### PR DESCRIPTION
An EOF or UnexpectedEOF error on the APIEvent decode operation typically means that the Docker daemon has stopped. In any event, it causes the HTTP response handler embedded in eventHijack to exit, which means that all existing registered listeners will no longer work, even if the daemon comes back, but the listeners themselves don't know anything has happened. This change causes the listener channels to be closed, which notifies client code that the listeners are no longer useful and new ones should be created and registered. This closes #163.
