### PR TITLE
Add ExtraHosts to HostConfig

### DIFF
--- a/container.go
+++ b/container.go
@@ -327,6 +327,7 @@ type HostConfig struct {
 	PublishAllPorts bool                   `json:"PublishAllPorts,omitempty" yaml:"PublishAllPorts,omitempty"`
 	Dns             []string               `json:"Dns,omitempty" yaml:"Dns,omitempty"` // For Docker API v1.10 and above only
 	DnsSearch       []string               `json:"DnsSearch,omitempty" yaml:"DnsSearch,omitempty"`
+	ExtraHosts      []string               `json:"ExtraHosts,omitempty" yaml:"ExtraHosts,omitempty"`
 	VolumesFrom     []string               `json:"VolumesFrom,omitempty" yaml:"VolumesFrom,omitempty"`
 	NetworkMode     string                 `json:"NetworkMode,omitempty" yaml:"NetworkMode,omitempty"`
 	RestartPolicy   RestartPolicy          `json:"RestartPolicy,omitempty" yaml:"RestartPolicy,omitempty"`


### PR DESCRIPTION
Introduced by this PR: https://github.com/docker/docker/pull/8019

You can see it in Docker's `HostConfig` struct here: https://github.com/docker/docker/blob/f98a1f1f7d9b3ef10c13fc3b6438c978b4d6aa78/runconfig/hostconfig.go#L52
