### PR TITLE
Support passing HostConfig to CreateContainer as per version 1.15 of the docker API

### DIFF
--- a/container.go
+++ b/container.go
@@ -262,10 +262,11 @@ func (c *Client) ContainerChanges(id string) ([]Change, error) {
 
 // CreateContainerOptions specify parameters to the CreateContainer function.
 //
-// See http://goo.gl/mErxNp for more details.
+// See http://goo.gl/2xxQQK for more details.
 type CreateContainerOptions struct {
-	Name   string
-	Config *Config `qs:"-"`
+	Name       string
+	Config     *Config `qs:"-"`
+	HostConfig *HostConfig
 }
 
 // CreateContainer creates a new container, returning the container instance,
@@ -274,7 +275,14 @@ type CreateContainerOptions struct {
 // See http://goo.gl/mErxNp for more details.
 func (c *Client) CreateContainer(opts CreateContainerOptions) (*Container, error) {
 	path := "/containers/create?" + queryString(opts)
-	body, status, err := c.do("POST", path, opts.Config)
+	body, status, err := c.do("POST", path, struct {
+		*Config
+		HostConfig *HostConfig `json:"HostConfig,omitempty" yaml:"HostConfig,omitempty"`
+	}{
+		opts.Config,
+		opts.HostConfig,
+	})
+
 	if status == http.StatusNotFound {
 		return nil, ErrNoSuchImage
 	}

--- a/container_test.go
+++ b/container_test.go
@@ -440,6 +440,27 @@ func TestCreateContainerImageNotFound(t *testing.T) {
 	}
 }
 
+func TestCreateContainerWithHostConfig(t *testing.T) {
+	fakeRT := &FakeRoundTripper{message: "{}", status: http.StatusOK}
+	client := newTestClient(fakeRT)
+	config := Config{}
+	hostConfig := HostConfig{PublishAllPorts: true}
+	opts := CreateContainerOptions{Name: "TestCreateContainerWithHostConfig", Config: &config, HostConfig: &hostConfig}
+	_, err := client.CreateContainer(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := fakeRT.requests[0]
+	var gotBody map[string]interface{}
+	err = json.NewDecoder(req.Body).Decode(&gotBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := gotBody["HostConfig"]; !ok {
+		t.Errorf("CreateContainer: wrong body. HostConfig was not serialized")
+	}
+}
+
 func TestStartContainer(t *testing.T) {
 	fakeRT := &FakeRoundTripper{message: "", status: http.StatusOK}
 	client := newTestClient(fakeRT)


### PR DESCRIPTION
The implementation may seem a bit unintuitive: indeed, it would have been easier to add a `HostConfig` field to the `Config` struct.

What argued against doing that was:
- Only `CreateContainer` accepts this field
- Doing so would be confusing: `Container` already contains a `HostConfig` field alongside `Config`. The API users might get confused between `Container.HostConfig` and `Container.Config.HostConfig`

I also thought about adding a new `CreateConfig` type:

``` go
type CreateConfig struct {
  *Config
  HostConfig *HostConfig
}
```

And modifying the `CreateContainerOptions` to use this new type instead of `Config`, but this would break the API for all the go-dockerclient users.

That was my thought process. @fsouza , don't hesitate to give feedback if you think this should be done differently.
