### PR TITLE
fix Cpuset bug. In docker API, should be 'Cpuset', not 'CpuSet'

### DIFF
--- a/container.go
+++ b/container.go
@@ -172,7 +172,7 @@ type Config struct {
 	Memory          int64               `json:"Memory,omitempty" yaml:"Memory,omitempty"`
 	MemorySwap      int64               `json:"MemorySwap,omitempty" yaml:"MemorySwap,omitempty"`
 	CPUShares       int64               `json:"CpuShares,omitempty" yaml:"CpuShares,omitempty"`
-	CPUSet          string              `json:"CpuSet,omitempty" yaml:"CpuSet,omitempty"`
+	CPUSet          string              `json:"Cpuset,omitempty" yaml:"Cpuset,omitempty"`
 	AttachStdin     bool                `json:"AttachStdin,omitempty" yaml:"AttachStdin,omitempty"`
 	AttachStdout    bool                `json:"AttachStdout,omitempty" yaml:"AttachStdout,omitempty"`
 	AttachStderr    bool                `json:"AttachStderr,omitempty" yaml:"AttachStderr,omitempty"`


### PR DESCRIPTION
fix Cpuset bug. In docker API, should be 'Cpuset', not 'CpuSet'.

see [here](https://docs.docker.com/reference/api/docker_remote_api_v1.15/#create-a-container).
