### PR TITLE
client: add TLS support, fixes #184

### DIFF
--- a/client.go
+++ b/client.go
@@ -460,30 +460,49 @@ func (c *Client) hijack(method, path string, success chan struct{}, setRawTermin
 		protocol = "tcp"
 		address = c.endpointURL.Host
 	}
-	dial, err := net.Dial(protocol, address)
-	if err != nil {
-		return err
+
+	var dial net.Conn
+	if c.TLSConfig != nil && protocol != "unix" {
+		dial, err = tlsDial(protocol, address, c.TLSConfig)
+		if err != nil {
+			return err
+		}
+	} else {
+		dial, err = net.Dial(protocol, address)
+		if err != nil {
+			return err
+		}
 	}
-	defer dial.Close()
+
 	clientconn := httputil.NewClientConn(dial, nil)
+	defer clientconn.Close()
+
 	clientconn.Do(req)
 	if success != nil {
 		success <- struct{}{}
 		<-success
 	}
+
 	rwc, br := clientconn.Hijack()
+	defer rwc.Close()
+
 	errs := make(chan error, 2)
 	exit := make(chan bool)
+
+	// output
 	go func() {
 		defer close(exit)
 		var err error
 		if setRawTerminal {
+			// When TTY is ON, use regular copy
 			_, err = io.Copy(stdout, br)
 		} else {
 			_, err = stdCopy(stdout, stderr, br)
 		}
 		errs <- err
 	}()
+
+	// input
 	go func() {
 		var err error
 		if in != nil {
@@ -494,6 +513,7 @@ func (c *Client) hijack(method, path string, success chan struct{}, setRawTermin
 		}).CloseWrite()
 		errs <- err
 	}()
+
 	<-exit
 	return <-errs
 }

--- a/tls.go
+++ b/tls.go
@@ -1,0 +1,100 @@
+// Copyright 2014 go-dockerclient authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+// The content is borrowed from Docker's own source code to provide a simple
+// tls based dialer
+
+package docker
+
+import (
+	"crypto/tls"
+	"errors"
+	"net"
+	"strings"
+	"time"
+)
+
+type tlsClientCon struct {
+	*tls.Conn
+	rawConn net.Conn
+}
+
+func (c *tlsClientCon) CloseWrite() error {
+	// Go standard tls.Conn doesn't provide the CloseWrite() method so we do it
+	// on its underlying connection.
+	if cwc, ok := c.rawConn.(interface {
+		CloseWrite() error
+	}); ok {
+		return cwc.CloseWrite()
+	}
+	return nil
+}
+
+func tlsDialWithDialer(dialer *net.Dialer, network, addr string, config *tls.Config) (net.Conn, error) {
+	// We want the Timeout and Deadline values from dialer to cover the
+	// whole process: TCP connection and TLS handshake. This means that we
+	// also need to start our own timers now.
+	timeout := dialer.Timeout
+
+	if !dialer.Deadline.IsZero() {
+		deadlineTimeout := dialer.Deadline.Sub(time.Now())
+		if timeout == 0 || deadlineTimeout < timeout {
+			timeout = deadlineTimeout
+		}
+	}
+
+	var errChannel chan error
+
+	if timeout != 0 {
+		errChannel = make(chan error, 2)
+		time.AfterFunc(timeout, func() {
+			errChannel <- errors.New("")
+		})
+	}
+
+	rawConn, err := dialer.Dial(network, addr)
+	if err != nil {
+		return nil, err
+	}
+
+	colonPos := strings.LastIndex(addr, ":")
+	if colonPos == -1 {
+		colonPos = len(addr)
+	}
+	hostname := addr[:colonPos]
+
+	// If no ServerName is set, infer the ServerName
+	// from the hostname we're connecting to.
+	if config.ServerName == "" {
+		// Make a copy to avoid polluting argument or default.
+		c := *config
+		c.ServerName = hostname
+		config = &c
+	}
+
+	conn := tls.Client(rawConn, config)
+
+	if timeout == 0 {
+		err = conn.Handshake()
+	} else {
+		go func() {
+			errChannel <- conn.Handshake()
+		}()
+
+		err = <-errChannel
+	}
+
+	if err != nil {
+		rawConn.Close()
+		return nil, err
+	}
+
+	// This is Docker difference with standard's crypto/tls package: returned a
+	// wrapper which holds both the TLS and raw connections.
+	return &tlsClientCon{conn, rawConn}, nil
+}
+
+func tlsDial(network, addr string, config *tls.Config) (net.Conn, error) {
+	return tlsDialWithDialer(new(net.Dialer), network, addr, config)
+}


### PR DESCRIPTION
Without this we cannot use authenticated connection over TCP, only UNIX
socket is currently supported.