### PR TITLE
Excludes is not part of docker/pkg/archive

### DIFF
--- a/tar.go
+++ b/tar.go
@@ -27,7 +27,7 @@ func createTarStream(srcPath string) (io.ReadCloser, error) {
 		return nil, err
 	}
 	tarOpts := &archive.TarOptions{
-		Excludes:    excludes,
+		ExcludePatterns:    excludes,
 		Compression: archive.Uncompressed,
 		NoLchown:    true,
 	}


### PR DESCRIPTION
Running `go get github.com/fsouza/go-dockerclient`

returns

github.com/fsouza/go-dockerclient
../../../github.com/fsouza/go-dockerclient/tar.go:30: unknown archive.TarOptions field 'Excludes' in struct literal

This updates with the code docker archive Library
