### PR TITLE
Use -f flag in go get for golint

### DIFF
--- a/testing/bin/fmtpolice
+++ b/testing/bin/fmtpolice
@@ -31,7 +31,7 @@ _lint_verbose() {
 
 _install_linter() {
   if [[ ! -x "${GOPATH}/bin/golint" ]] ; then
-    go get -u github.com/golang/lint/golint
+    go get -u -f github.com/golang/lint/golint
   fi
 }
 


### PR DESCRIPTION
- forces `go get -u` not to verify that each package has been checked out from the source control repository implied by its import path