### PR TITLE
Deadlock workaround

### DIFF
--- a/event.go
+++ b/event.go
@@ -182,8 +182,8 @@ func (eventState *eventMonitoringState) monitorEvents(c *Client) {
 				eventState.terminate()
 				return
 			}
+			eventState.updateLastSeen(ev)
 			go eventState.sendEvent(ev)
-			go eventState.updateLastSeen(ev)
 		case err = <-eventState.errC:
 			if err == ErrNoListeners {
 				eventState.terminate()


### PR DESCRIPTION
Attempting workaround for deadlock reported in https://github.com/fsouza/go-dockerclient/issues/203; no need for updateLastSeen to be called from a goroutine.

I've used this in my [fork of registrator](https://github.com/blalor/registrator) for a few days and I haven't seen the deadlock that @gambol99 and I have experienced.  After looking through the code, I see no need for `eventState.updateLastSeen` to be called in a goroutine.  I also thought it more appropriate that that be handled before dispatching the event.