### PR TITLE
Implement BuildImage cancellation

### DIFF
--- a/client.go
+++ b/client.go
@@ -339,7 +339,7 @@ func (c *Client) do(method, path string, data interface{}, forceJSON bool) ([]by
 	return body, resp.StatusCode, nil
 }
 
-func (c *Client) stream(method, path string, setRawTerminal, rawJSONStream bool, headers map[string]string, in io.Reader, stdout, stderr io.Writer) error {
+func (c *Client) stream(method, path string, setRawTerminal, rawJSONStream bool, headers map[string]string, in io.Reader, stdout, stderr io.Writer, cancelled <-chan struct{}) error {
 	if (method == "POST" || method == "PUT") && in == nil {
 		in = bytes.NewReader(nil)
 	}

--- a/container.go
+++ b/container.go
@@ -741,7 +741,7 @@ func (c *Client) Logs(opts LogsOptions) error {
 		opts.Tail = "all"
 	}
 	path := "/containers/" + opts.Container + "/logs?" + queryString(opts)
-	return c.stream("GET", path, opts.RawTerminal, false, nil, nil, opts.OutputStream, opts.ErrorStream)
+	return c.stream("GET", path, opts.RawTerminal, false, nil, nil, opts.OutputStream, opts.ErrorStream, nil)
 }
 
 // ResizeContainerTTY resizes the terminal to the given height and width.
@@ -771,7 +771,7 @@ func (c *Client) ExportContainer(opts ExportContainerOptions) error {
 		return &NoSuchContainer{ID: opts.ID}
 	}
 	url := fmt.Sprintf("/containers/%s/export", opts.ID)
-	return c.stream("GET", url, true, false, nil, nil, opts.OutputStream, nil)
+	return c.stream("GET", url, true, false, nil, nil, opts.OutputStream, nil, nil)
 }
 
 // NoSuchContainer is the error returned when a given container does not exist.

--- a/image.go
+++ b/image.go
@@ -237,7 +237,7 @@ func (c *Client) PushImage(opts PushImageOptions, auth AuthConfiguration) error 
 	opts.Name = ""
 	path := "/images/" + name + "/push?" + queryString(&opts)
 	headers := headersWithAuth(auth)
-	return c.stream("POST", path, true, opts.RawJSONStream, headers, nil, opts.OutputStream, nil)
+	return c.stream("POST", path, true, opts.RawJSONStream, headers, nil, opts.OutputStream, nil, nil)
 }
 
 // PullImageOptions present the set of options available for pulling an image
@@ -266,7 +266,7 @@ func (c *Client) PullImage(opts PullImageOptions, auth AuthConfiguration) error 
 
 func (c *Client) createImage(qs string, headers map[string]string, in io.Reader, w io.Writer, rawJSONStream bool) error {
 	path := "/images/create?" + qs
-	return c.stream("POST", path, true, rawJSONStream, headers, in, w, nil)
+	return c.stream("POST", path, true, rawJSONStream, headers, in, w, nil, nil)
 }
 
 // LoadImageOptions represents the options for LoadImage Docker API Call
@@ -280,7 +280,7 @@ type LoadImageOptions struct {
 //
 // See http://goo.gl/Y8NNCq for more details.
 func (c *Client) LoadImage(opts LoadImageOptions) error {
-	return c.stream("POST", "/images/load", true, false, nil, opts.InputStream, nil, nil)
+	return c.stream("POST", "/images/load", true, false, nil, opts.InputStream, nil, nil, nil)
 }
 
 // ExportImageOptions represent the options for ExportImage Docker API call
@@ -295,7 +295,7 @@ type ExportImageOptions struct {
 //
 // See http://goo.gl/mi6kvk for more details.
 func (c *Client) ExportImage(opts ExportImageOptions) error {
-	return c.stream("GET", fmt.Sprintf("/images/%s/get", opts.Name), true, false, nil, nil, opts.OutputStream, nil)
+	return c.stream("GET", fmt.Sprintf("/images/%s/get", opts.Name), true, false, nil, nil, opts.OutputStream, nil, nil)
 }
 
 // ImportImageOptions present the set of informations available for importing
@@ -383,7 +383,7 @@ func (c *Client) BuildImage(opts BuildImageOptions) error {
 	}
 
 	return c.stream("POST", fmt.Sprintf("/build?%s",
-		queryString(&opts)), true, opts.RawJSONStream, headers, opts.InputStream, opts.OutputStream, nil)
+		queryString(&opts)), true, opts.RawJSONStream, headers, opts.InputStream, opts.OutputStream, nil, nil)
 }
 
 // TagImageOptions present the set of options to tag an image.

--- a/image.go
+++ b/image.go
@@ -352,6 +352,9 @@ type BuildImageOptions struct {
 	Auth                AuthConfiguration  `qs:"-"` // for older docker X-Registry-Auth header
 	AuthConfigs         AuthConfigurations `qs:"-"` // for newer docker X-Registry-Config header
 	ContextDir          string             `qs:"-"`
+	// User controlled channel to allow cancellation. If nil, cancellation is
+	// not possible. Otherwise, cancellation happens if the channel is closed.
+	Cancel <-chan struct{}
 }
 
 // BuildImage builds an image from a tarball's url or a Dockerfile in the input
@@ -383,7 +386,7 @@ func (c *Client) BuildImage(opts BuildImageOptions) error {
 	}
 
 	return c.stream("POST", fmt.Sprintf("/build?%s",
-		queryString(&opts)), true, opts.RawJSONStream, headers, opts.InputStream, opts.OutputStream, nil, nil)
+		queryString(&opts)), true, opts.RawJSONStream, headers, opts.InputStream, opts.OutputStream, nil, opts.Cancel)
 }
 
 // TagImageOptions present the set of options to tag an image.


### PR DESCRIPTION
This prototypes BuildImage cancellation.

It's split into three commits which should make the implementation clear.

Unfortunately it doesn't work for now until docker itself implements cancellation.

Fixes #182

See https://github.com/docker/docker/pull/9774

This feature will not work until https://github.com/docker/docker/pull/9774 or something like it is merged.