### PR TITLE
Add support for SecurityOpts in Config

### DIFF
--- a/container.go
+++ b/container.go
@@ -193,6 +193,7 @@ type Config struct {
 	WorkingDir      string              `json:"WorkingDir,omitempty" yaml:"WorkingDir,omitempty"`
 	Entrypoint      []string            `json:"Entrypoint,omitempty" yaml:"Entrypoint,omitempty"`
 	NetworkDisabled bool                `json:"NetworkDisabled,omitempty" yaml:"NetworkDisabled,omitempty"`
+	SecurityOpts    []string            `json:"SecurityOpts,omitempty" yaml:"SecurityOpts,omitempty"`
 }
 
 // Container is the type encompasing everything about a container - its config,


### PR DESCRIPTION
Support the SecurityOpts option in Config, see: https://docs.docker.com/reference/api/docker_remote_api_v1.16/ for context.