### PR TITLE
Fix deadlock bug in event.go:

### DIFF
--- a/event.go
+++ b/event.go
@@ -227,7 +227,7 @@ func (eventState *eventMonitoringState) sendEvent(event *APIEvents) {
 	eventState.Add(1)
 	defer eventState.Done()
 	if eventState.isEnabled() {
-		if eventState.noListeners() {
+		if len(eventState.listeners) == 0 {
 			eventState.errC <- ErrNoListeners
 			return
 		}


### PR DESCRIPTION
`noListeners` claims `eventState` lock, which is already held in one invocation. Without the `RLock` code, the method is simple enough that inlining felt like the right answer.