### PR TITLE
Add 'dockerfile' option to image build, according to docker api v1.17

### DIFF
--- a/image.go
+++ b/image.go
@@ -333,6 +333,7 @@ func (c *Client) ImportImage(opts ImportImageOptions) error {
 // http://goo.gl/tlPXPu.
 type BuildImageOptions struct {
 	Name                string             `qs:"t"`
+	Dockerfile          string             `qs:"dockerfile"`
 	NoCache             bool               `qs:"nocache"`
 	SuppressOutput      bool               `qs:"q"`
 	RmTmpContainer      bool               `qs:"rm"`


### PR DESCRIPTION
Hey,

In the version 1.5 of Docker they added support to specify custom Dockerfile target for builds. This is must have feature in our pipeline. See http://docs.docker.com/reference/api/docker_remote_api_v1.17/#build-image-from-a-dockerfile

Added this option to `BuildImageOptions`, tested, it works.
