### PR TITLE
Add RemoveImageExtended() to support 'force' param for removing images

### DIFF
--- a/image.go
+++ b/image.go
@@ -146,8 +146,8 @@ func (c *Client) RemoveImage(name string) error {
 //
 // See http://goo.gl/6V48bF for more details.
 type RemoveImageOptions struct {
-	Force         bool `qs:"force"`
-	NoPrune       bool `qs:"noprune"`
+	Force   bool `qs:"force"`
+	NoPrune bool `qs:"noprune"`
 }
 
 // RemoveImage removes an image by its name or ID.

--- a/image.go
+++ b/image.go
@@ -141,6 +141,27 @@ func (c *Client) RemoveImage(name string) error {
 	return err
 }
 
+// RemoveImageOptions present the set of options available for removing an image
+// from a registry.
+//
+// See http://goo.gl/6V48bF for more details.
+type RemoveImageOptions struct {
+	Force         bool `qs:"force"`
+	NoPrune       bool `qs:"noprune"`
+}
+
+// RemoveImage removes an image by its name or ID.
+//
+// See http://goo.gl/znj0wM for more details.
+func (c *Client) RemoveImageExtended(name string, opts RemoveImageOptions) error {
+	uri := fmt.Sprintf("/images/%s?%s", name, queryString(&opts))
+	_, status, err := c.do("DELETE", uri, nil)
+	if status == http.StatusNotFound {
+		return ErrNoSuchImage
+	}
+	return err
+}
+
 // InspectImage returns an image by its name or ID.
 //
 // See http://goo.gl/Q112NY for more details.

--- a/image.go
+++ b/image.go
@@ -150,7 +150,8 @@ type RemoveImageOptions struct {
 	NoPrune bool `qs:"noprune"`
 }
 
-// RemoveImage removes an image by its name or ID.
+// RemoveImageExtended removes an image by its name or ID.
+// Extra params can be passed, see RemoveImageOptions
 //
 // See http://goo.gl/znj0wM for more details.
 func (c *Client) RemoveImageExtended(name string, opts RemoveImageOptions) error {

--- a/image_test.go
+++ b/image_test.go
@@ -208,6 +208,29 @@ func TestRemoveImageNotFound(t *testing.T) {
 	}
 }
 
+func TestRemoveImageExtended(t *testing.T) {
+	name := "test"
+	fakeRT := &FakeRoundTripper{message: "", status: http.StatusNoContent}
+	client := newTestClient(fakeRT)
+	err := client.RemoveImageExtended(name, RemoveImageOptions{Force: true, NoPrune: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := fakeRT.requests[0]
+	expectedMethod := "DELETE"
+	if req.Method != expectedMethod {
+		t.Errorf("RemoveImage(%q): Wrong HTTP method. Want %s. Got %s.", name, expectedMethod, req.Method)
+	}
+	u, _ := url.Parse(client.getURL("/images/" + name))
+	if req.URL.Path != u.Path {
+		t.Errorf("RemoveImage(%q): Wrong request path. Want %q. Got %q.", name, u.Path, req.URL.Path)
+	}
+	expectedQuery := "force=1&noprune=1"
+	if query := req.URL.Query().Encode(); query != expectedQuery {
+		t.Errorf("PushImage: Wrong query string. Want %q. Got %q.", expectedQuery, query)
+	}
+}
+
 func TestInspectImage(t *testing.T) {
 	body := `{
      "id":"b750fe79269d2ec9a3c593ef05b4332b1d1a02a62b4accb2c21d589ff2f5f2dc",


### PR DESCRIPTION
Hi,

There is an option `force` to remove images even if there is a child container existing. http://docs.docker.com/reference/api/docker_remote_api_v1.17/#remove-an-image

I created a separate function
`func (c *Client) RemoveImageExtended(name string, opts RemoveImageOptions) error`
without breaking existing `RemoveImage` function.

What do you think? Should it be merged into existing function?