### PR TITLE
Fix spelling of NewVersionedTLSClient with depricated original function

### DIFF
--- a/client.go
+++ b/client.go
@@ -174,7 +174,7 @@ func NewVersionedClient(endpoint string, apiVersionString string) (*Client, erro
 	}, nil
 }
 
-// DEPRECATED: Please use NewVersionedTLSClient.
+// NewVersionnedTLSClient has been DEPRECATED, please use NewVersionedTLSClient.
 func NewVersionnedTLSClient(endpoint string, cert, key, ca, apiVersionString string) (*Client, error) {
 	return NewVersionedTLSClient(endpoint, cert, key, ca, apiVersionString)
 }

--- a/client.go
+++ b/client.go
@@ -174,9 +174,14 @@ func NewVersionedClient(endpoint string, apiVersionString string) (*Client, erro
 	}, nil
 }
 
-// NewVersionnedTLSClient returns a Client instance ready for TLS communications with the givens
-// server endpoint, key and certificates, using a specific remote API version.
+// DEPRECATED: Please use NewVersionedTLSClient.
 func NewVersionnedTLSClient(endpoint string, cert, key, ca, apiVersionString string) (*Client, error) {
+	return NewVersionedTLSClient(endpoint, cert, key, ca, apiVersionString)
+}
+
+// NewVersionedTLSClient returns a Client instance ready for TLS communications with the givens
+// server endpoint, key and certificates, using a specific remote API version.
+func NewVersionedTLSClient(endpoint string, cert, key, ca, apiVersionString string) (*Client, error) {
 	u, err := parseEndpoint(endpoint)
 	if err != nil {
 		return nil, err

--- a/client_test.go
+++ b/client_test.go
@@ -93,7 +93,7 @@ func TestNewTLSVersionedClient(t *testing.T) {
 	keyPath := "testing/data/key.pem"
 	caPath := "testing/data/ca.pem"
 	endpoint := "https://localhost:4243"
-	client, err := NewVersionnedTLSClient(endpoint, certPath, keyPath, caPath, "1.14")
+	client, err := NewVersionedTLSClient(endpoint, certPath, keyPath, caPath, "1.14")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -113,7 +113,7 @@ func TestNewTLSVersionedClientInvalidCA(t *testing.T) {
 	keyPath := "testing/data/key.pem"
 	caPath := "testing/data/key.pem"
 	endpoint := "https://localhost:4243"
-	_, err := NewVersionnedTLSClient(endpoint, certPath, keyPath, caPath, "1.14")
+	_, err := NewVersionedTLSClient(endpoint, certPath, keyPath, caPath, "1.14")
 	if err == nil {
 		t.Errorf("Expected invalid ca at %s", caPath)
 	}


### PR DESCRIPTION
This is a really small bug, but it gave me a headache until I finally copy/paste the method from godoc.

This is a proposal to deprecate the existing `NewVersionnedTLSClient` and point it to the renamed function `NewVersionedTLSClient` which is consistent with the spelling of `NewVersionedClient`.

Cheers!