### PR TITLE
container: Parse ExecIDs when inspecting

### DIFF
--- a/container.go
+++ b/container.go
@@ -223,6 +223,7 @@ type Container struct {
 	Volumes    map[string]string `json:"Volumes,omitempty" yaml:"Volumes,omitempty"`
 	VolumesRW  map[string]bool   `json:"VolumesRW,omitempty" yaml:"VolumesRW,omitempty"`
 	HostConfig *HostConfig       `json:"HostConfig,omitempty" yaml:"HostConfig,omitempty"`
+	ExecIDs    []string          `json:"ExecIDs,omitempty" yaml:"ExecIDs,omitempty"`
 }
 
 // InspectContainer returns information about a container by its ID.


### PR DESCRIPTION
Dunno for sure in which version this got added but I guess it doesn't matter :-)