### PR TITLE
Correct Volumes type for container config

### DIFF
--- a/container.go
+++ b/container.go
@@ -169,32 +169,32 @@ func parsePort(rawPort string) (int, error) {
 // Config does not the options that are specific to starting a container on a
 // given host.  Those are contained in HostConfig
 type Config struct {
-	Hostname        string              `json:"Hostname,omitempty" yaml:"Hostname,omitempty"`
-	Domainname      string              `json:"Domainname,omitempty" yaml:"Domainname,omitempty"`
-	User            string              `json:"User,omitempty" yaml:"User,omitempty"`
-	Memory          int64               `json:"Memory,omitempty" yaml:"Memory,omitempty"`
-	MemorySwap      int64               `json:"MemorySwap,omitempty" yaml:"MemorySwap,omitempty"`
-	CPUShares       int64               `json:"CpuShares,omitempty" yaml:"CpuShares,omitempty"`
-	CPUSet          string              `json:"Cpuset,omitempty" yaml:"Cpuset,omitempty"`
-	AttachStdin     bool                `json:"AttachStdin,omitempty" yaml:"AttachStdin,omitempty"`
-	AttachStdout    bool                `json:"AttachStdout,omitempty" yaml:"AttachStdout,omitempty"`
-	AttachStderr    bool                `json:"AttachStderr,omitempty" yaml:"AttachStderr,omitempty"`
-	PortSpecs       []string            `json:"PortSpecs,omitempty" yaml:"PortSpecs,omitempty"`
-	ExposedPorts    map[Port]struct{}   `json:"ExposedPorts,omitempty" yaml:"ExposedPorts,omitempty"`
-	Tty             bool                `json:"Tty,omitempty" yaml:"Tty,omitempty"`
-	OpenStdin       bool                `json:"OpenStdin,omitempty" yaml:"OpenStdin,omitempty"`
-	StdinOnce       bool                `json:"StdinOnce,omitempty" yaml:"StdinOnce,omitempty"`
-	Env             []string            `json:"Env,omitempty" yaml:"Env,omitempty"`
-	Cmd             []string            `json:"Cmd,omitempty" yaml:"Cmd,omitempty"`
-	DNS             []string            `json:"Dns,omitempty" yaml:"Dns,omitempty"` // For Docker API v1.9 and below only
-	Image           string              `json:"Image,omitempty" yaml:"Image,omitempty"`
-	Volumes         map[string]struct{} `json:"Volumes,omitempty" yaml:"Volumes,omitempty"`
-	VolumesFrom     string              `json:"VolumesFrom,omitempty" yaml:"VolumesFrom,omitempty"`
-	WorkingDir      string              `json:"WorkingDir,omitempty" yaml:"WorkingDir,omitempty"`
-	Entrypoint      []string            `json:"Entrypoint,omitempty" yaml:"Entrypoint,omitempty"`
-	NetworkDisabled bool                `json:"NetworkDisabled,omitempty" yaml:"NetworkDisabled,omitempty"`
-	SecurityOpts    []string            `json:"SecurityOpts,omitempty" yaml:"SecurityOpts,omitempty"`
-	OnBuild         []string            `json:"OnBuild,omitempty" yaml:"OnBuild,omitempty"`
+	Hostname        string            `json:"Hostname,omitempty" yaml:"Hostname,omitempty"`
+	Domainname      string            `json:"Domainname,omitempty" yaml:"Domainname,omitempty"`
+	User            string            `json:"User,omitempty" yaml:"User,omitempty"`
+	Memory          int64             `json:"Memory,omitempty" yaml:"Memory,omitempty"`
+	MemorySwap      int64             `json:"MemorySwap,omitempty" yaml:"MemorySwap,omitempty"`
+	CPUShares       int64             `json:"CpuShares,omitempty" yaml:"CpuShares,omitempty"`
+	CPUSet          string            `json:"Cpuset,omitempty" yaml:"Cpuset,omitempty"`
+	AttachStdin     bool              `json:"AttachStdin,omitempty" yaml:"AttachStdin,omitempty"`
+	AttachStdout    bool              `json:"AttachStdout,omitempty" yaml:"AttachStdout,omitempty"`
+	AttachStderr    bool              `json:"AttachStderr,omitempty" yaml:"AttachStderr,omitempty"`
+	PortSpecs       []string          `json:"PortSpecs,omitempty" yaml:"PortSpecs,omitempty"`
+	ExposedPorts    map[Port]struct{} `json:"ExposedPorts,omitempty" yaml:"ExposedPorts,omitempty"`
+	Tty             bool              `json:"Tty,omitempty" yaml:"Tty,omitempty"`
+	OpenStdin       bool              `json:"OpenStdin,omitempty" yaml:"OpenStdin,omitempty"`
+	StdinOnce       bool              `json:"StdinOnce,omitempty" yaml:"StdinOnce,omitempty"`
+	Env             []string          `json:"Env,omitempty" yaml:"Env,omitempty"`
+	Cmd             []string          `json:"Cmd,omitempty" yaml:"Cmd,omitempty"`
+	DNS             []string          `json:"Dns,omitempty" yaml:"Dns,omitempty"` // For Docker API v1.9 and below only
+	Image           string            `json:"Image,omitempty" yaml:"Image,omitempty"`
+	Volumes         map[string]string `json:"Volumes,omitempty" yaml:"Volumes,omitempty"`
+	VolumesFrom     string            `json:"VolumesFrom,omitempty" yaml:"VolumesFrom,omitempty"`
+	WorkingDir      string            `json:"WorkingDir,omitempty" yaml:"WorkingDir,omitempty"`
+	Entrypoint      []string          `json:"Entrypoint,omitempty" yaml:"Entrypoint,omitempty"`
+	NetworkDisabled bool              `json:"NetworkDisabled,omitempty" yaml:"NetworkDisabled,omitempty"`
+	SecurityOpts    []string          `json:"SecurityOpts,omitempty" yaml:"SecurityOpts,omitempty"`
+	OnBuild         []string          `json:"OnBuild,omitempty" yaml:"OnBuild,omitempty"`
 }
 
 // Container is the type encompasing everything about a container - its config,


### PR DESCRIPTION
`Config.Volumes` is a `map[string]stuct{}` but `Container.Volumes` is a `map[string]string`.

This patch makes them match.