### PR TITLE
Add support for tag in DockerServer.pullImage (testing)

### DIFF
--- a/client.go
+++ b/client.go
@@ -322,13 +322,13 @@ func (c *Client) do(method, path string, data interface{}, forceJSON bool) ([]by
 	} else {
 		resp, err = c.HTTPClient.Do(req)
 	}
-	defer resp.Body.Close()
 	if err != nil {
 		if strings.Contains(err.Error(), "connection refused") {
 			return nil, -1, ErrConnectionRefused
 		}
 		return nil, -1, err
 	}
+	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return nil, -1, err
@@ -380,13 +380,13 @@ func (c *Client) stream(method, path string, setRawTerminal, rawJSONStream bool,
 	} else {
 		resp, err = c.HTTPClient.Do(req)
 	}
-	defer resp.Body.Close()
 	if err != nil {
 		if strings.Contains(err.Error(), "connection refused") {
 			return ErrConnectionRefused
 		}
 		return err
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
 		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {

--- a/client.go
+++ b/client.go
@@ -322,13 +322,13 @@ func (c *Client) do(method, path string, data interface{}, forceJSON bool) ([]by
 	} else {
 		resp, err = c.HTTPClient.Do(req)
 	}
+	defer resp.Body.Close()
 	if err != nil {
 		if strings.Contains(err.Error(), "connection refused") {
 			return nil, -1, ErrConnectionRefused
 		}
 		return nil, -1, err
 	}
-	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return nil, -1, err
@@ -380,13 +380,13 @@ func (c *Client) stream(method, path string, setRawTerminal, rawJSONStream bool,
 	} else {
 		resp, err = c.HTTPClient.Do(req)
 	}
+	defer resp.Body.Close()
 	if err != nil {
 		if strings.Contains(err.Error(), "connection refused") {
 			return ErrConnectionRefused
 		}
 		return err
 	}
-	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
 		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {

--- a/testing/server.go
+++ b/testing/server.go
@@ -623,12 +623,16 @@ func (s *DockerServer) buildImage(w http.ResponseWriter, r *http.Request) {
 
 func (s *DockerServer) pullImage(w http.ResponseWriter, r *http.Request) {
 	fromImageName := r.URL.Query().Get("fromImage")
+	tag := r.URL.Query().Get("tag")
 	image := docker.Image{
 		ID: s.generateID(),
 	}
 	s.iMut.Lock()
 	s.images = append(s.images, image)
 	if fromImageName != "" {
+		if tag != "" {
+			fromImageName = fmt.Sprintf("%s:%s", fromImageName, tag)
+		}
 		s.imgIDs[fromImageName] = image.ID
 	}
 	s.iMut.Unlock()

--- a/testing/server_test.go
+++ b/testing/server_test.go
@@ -820,6 +820,23 @@ func TestPullImage(t *testing.T) {
 	}
 }
 
+func TestPullImageWithTag(t *testing.T) {
+	server := DockerServer{imgIDs: make(map[string]string)}
+	server.buildMuxer()
+	recorder := httptest.NewRecorder()
+	request, _ := http.NewRequest("POST", "/images/create?fromImage=base&tag=tag", nil)
+	server.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusOK {
+		t.Errorf("PullImage: wrong status. Want %d. Got %d.", http.StatusOK, recorder.Code)
+	}
+	if len(server.images) != 1 {
+		t.Errorf("PullImage: Want 1 image. Got %d.", len(server.images))
+	}
+	if _, ok := server.imgIDs["base:tag"]; !ok {
+		t.Error("PullImage: Repository should not be empty.")
+	}
+}
+
 func TestPushImage(t *testing.T) {
 	server := DockerServer{imgIDs: map[string]string{"tsuru/python": "a123"}}
 	server.buildMuxer()


### PR DESCRIPTION
If tag is set in URL Query, `pullImage` should save `fromImageName` + `tag`.