### PR TITLE
Add rename container

### DIFF
--- a/container.go
+++ b/container.go
@@ -239,6 +239,25 @@ type Container struct {
 	ExecIDs    []string          `json:"ExecIDs,omitempty" yaml:"ExecIDs,omitempty"`
 }
 
+// RenameContainerOptions specify parameters to the RenameContainer function.
+//
+// See http://goo.gl/L00hoj for more details.
+type RenameContainerOptions struct {
+	// ID of container to rename
+	ID string `qs:"-"`
+
+	// New name
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+}
+
+// RenameContainer updates and existing containers name
+//
+// See http://goo.gl/L00hoj for more details.
+func (c *Client) RenameContainer(opts RenameContainerOptions) error {
+	_, _, err := c.do("POST", fmt.Sprintf("/containers/"+opts.ID+"/rename?%s", queryString(opts)), nil, false)
+	return err
+}
+
 // InspectContainer returns information about a container by its ID.
 //
 // See http://goo.gl/CxVuJ5 for more details.

--- a/container_test.go
+++ b/container_test.go
@@ -1542,3 +1542,26 @@ func TestTopContainerWithPsArgs(t *testing.T) {
 		t.Errorf("TopContainer: Expected URI to have %q. Got %q.", expectedURI, fakeRT.requests[0].URL.String())
 	}
 }
+
+func TestRenameContainer(t *testing.T) {
+	fakeRT := &FakeRoundTripper{message: "", status: http.StatusOK}
+	client := newTestClient(fakeRT)
+	opts := RenameContainerOptions{ID: "something_old", Name: "something_new"}
+	err := client.RenameContainer(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := fakeRT.requests[0]
+	if req.Method != "POST" {
+		t.Errorf("RenameContainer: wrong HTTP method. Want %q. Got %q.", "POST", req.Method)
+	}
+	expectedURL, _ := url.Parse(client.getURL("/containers/something_old/rename?name=something_new"))
+	if gotPath := req.URL.Path; gotPath != expectedURL.Path {
+		t.Errorf("RenameContainer: Wrong path in request. Want %q. Got %q.", expectedURL.Path, gotPath)
+	}
+	expectedValues := expectedURL.Query()["name"]
+	actualValues := req.URL.Query()["name"]
+	if len(actualValues) != 1 || expectedValues[0] != actualValues[0] {
+		t.Errorf("RenameContainer: Wrong params in request. Want %q. Got %q.", expectedValues, actualValues)
+	}
+}


### PR DESCRIPTION
Docker 1.5 now supports renaming a container: https://docs.docker.com/reference/api/docker_remote_api_v1.17/#rename-a-container