### PR TITLE
Allow https connections to swarm master.

### DIFF
--- a/client.go
+++ b/client.go
@@ -621,7 +621,7 @@ func parseEndpoint(endpoint string) (*url.URL, error) {
 		}
 
 		number, err := strconv.ParseInt(port, 10, 64)
-		if err == nil && number == 2376 {
+		if err == nil && (number == 2376 || number == 3376) {
 			u.Scheme = "https"
 		} else {
 			u.Scheme = "http"

--- a/client_test.go
+++ b/client_test.go
@@ -142,6 +142,7 @@ func TestNewTLSClient2376(t *testing.T) {
 		expected string
 	}{
 		{"tcp://localhost:2376", "https"},
+		{"tcp://localhost:3376", "https"},
 		{"tcp://localhost:2375", "http"},
 		{"tcp://localhost:4000", "http"},
 	}


### PR DESCRIPTION
Quick fix to allow https connections to a swarm-master.

Perhaps the logic for deciding on whether to use https; based on if a tlsconfig has been provided needs to be discussed; so to avoid a potential long list of port numbers.