### PR TITLE
Added container's swarm node information.

### DIFF
--- a/container.go
+++ b/container.go
@@ -197,6 +197,17 @@ type Config struct {
 	OnBuild         []string            `json:"OnBuild,omitempty" yaml:"OnBuild,omitempty"`
 }
 
+// SwarmNode containers information about which Swarm node the container is on
+type SwarmNode struct {
+	ID     string            `json:"ID,omitempty" yaml:"ID,omitempty"`
+	IP     string            `json:"IP,omitempty" yaml:"IP,omitempty"`
+	Addr   string            `json:"Addr,omitempty" yaml:"Addr,omitempty"`
+	Name   string            `json:"Name,omitempty" yaml:"Name,omitempty"`
+	CPUs   int64             `json:"CPUs,omitempty" yaml:"CPUs,omitempty"`
+	Memory int64             `json:"Memory,omitempty" yaml:"Memory,omitempty"`
+	Labels map[string]string `json:"Labels,omitempty" yaml:"Labels,omitempty"`
+}
+
 // Container is the type encompasing everything about a container - its config,
 // hostconfig, etc.
 type Container struct {
@@ -210,6 +221,8 @@ type Container struct {
 	Config *Config `json:"Config,omitempty" yaml:"Config,omitempty"`
 	State  State   `json:"State,omitempty" yaml:"State,omitempty"`
 	Image  string  `json:"Image,omitempty" yaml:"Image,omitempty"`
+
+	Node *SwarmNode `json:"Node,omitempty" yaml:"Node,omitempty"`
 
 	NetworkSettings *NetworkSettings `json:"NetworkSettings,omitempty" yaml:"NetworkSettings,omitempty"`
 

--- a/container_test.go
+++ b/container_test.go
@@ -184,6 +184,21 @@ func TestInspectContainer(t *testing.T) {
                      "StartedAt": "2013-05-07T14:51:42.087658+02:00",
                      "Ghost": false
              },
+             "Node": {
+                  "ID": "4I4E:QR4I:Z733:QEZK:5X44:Q4T7:W2DD:JRDY:KB2O:PODO:Z5SR:XRB6",
+                  "IP": "192.168.99.105",
+                  "Addra": "192.168.99.105:2376",
+                  "Name": "node-01",
+                  "Cpus": 4,
+                  "Memory": 1048436736,
+                  "Labels": {
+                      "executiondriver": "native-0.2",
+                      "kernelversion": "3.18.5-tinycore64",
+                      "operatingsystem": "Boot2Docker 1.5.0 (TCL 5.4); master : a66bce5 - Tue Feb 10 23:31:27 UTC 2015",
+                      "provider": "virtualbox",
+                      "storagedriver": "aufs"
+                  }
+              },
              "Image": "b750fe79269d2ec9a3c593ef05b4332b1d1a02a62b4accb2c21d589ff2f5f2dc",
              "NetworkSettings": {
                      "IpAddress": "",


### PR DESCRIPTION
Updated so InspectContainer also includes Swarm node information.  I appreciate that this isn't apart of the official api, but swarm is becoming/will become a much bigger part of the Docker ecosystem that I think it warrants inclusion.

There may be other Swarm related information about that needs including in other methods, haven't checked fully yet :)