### PR TITLE
StartContainer - propagate error from docker api (response body)

### DIFF
--- a/container.go
+++ b/container.go
@@ -752,12 +752,10 @@ type NoSuchContainer struct {
 }
 
 func (err *NoSuchContainer) Error() string {
-	switch err.Err.(type) {
-	case error:
-		return "No such container: " + err.ID + " - " + err.Err.Error()
-	default:
-		return "No such container: " + err.ID
+	if err.Err != nil {
+		return err.Err.Error()
 	}
+	return "No such container: " + err.ID
 }
 
 // ContainerAlreadyRunning is the error returned when a given container is

--- a/container.go
+++ b/container.go
@@ -386,7 +386,7 @@ func (c *Client) StartContainer(id string, hostConfig *HostConfig) error {
 	path := "/containers/" + id + "/start"
 	_, status, err := c.do("POST", path, hostConfig, true)
 	if status == http.StatusNotFound {
-		return &NoSuchContainer{ID: id}
+		return &NoSuchContainer{ID: id, Err: err}
 	}
 	if status == http.StatusNotModified {
 		return &ContainerAlreadyRunning{ID: id}
@@ -747,11 +747,17 @@ func (c *Client) ExportContainer(opts ExportContainerOptions) error {
 
 // NoSuchContainer is the error returned when a given container does not exist.
 type NoSuchContainer struct {
-	ID string
+	ID  string
+	Err error
 }
 
 func (err *NoSuchContainer) Error() string {
-	return "No such container: " + err.ID
+	switch err.Err.(type) {
+	case error:
+		return "No such container: " + err.ID + " - " + err.Err.Error()
+	default:
+		return "No such container: " + err.ID
+	}
 }
 
 // ContainerAlreadyRunning is the error returned when a given container is

--- a/container_test.go
+++ b/container_test.go
@@ -1310,7 +1310,7 @@ func TestNoSuchContainerError(t *testing.T) {
 
 func TestNoSuchContainerErrorMessage(t *testing.T) {
 	var err = &NoSuchContainer{ID: "i345", Err: errors.New("some advanced error info")}
-	expected := "No such container: i345 - some advanced error info"
+	expected := "some advanced error info"
 	if got := err.Error(); got != expected {
 		t.Errorf("NoSuchContainer: wrong message. Want %q. Got %q.", expected, got)
 	}

--- a/container_test.go
+++ b/container_test.go
@@ -7,6 +7,7 @@ package docker
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -536,7 +537,7 @@ func TestStartContainerNilHostConfig(t *testing.T) {
 func TestStartContainerNotFound(t *testing.T) {
 	client := newTestClient(&FakeRoundTripper{message: "no such container", status: http.StatusNotFound})
 	err := client.StartContainer("a2344", &HostConfig{})
-	expected := &NoSuchContainer{ID: "a2344"}
+	expected := &NoSuchContainer{ID: "a2344", Err: err.(*NoSuchContainer).Err}
 	if !reflect.DeepEqual(err, expected) {
 		t.Errorf("StartContainer: Wrong error returned. Want %#v. Got %#v.", expected, err)
 	}
@@ -1302,6 +1303,14 @@ func TestLogsNoContainer(t *testing.T) {
 func TestNoSuchContainerError(t *testing.T) {
 	var err = &NoSuchContainer{ID: "i345"}
 	expected := "No such container: i345"
+	if got := err.Error(); got != expected {
+		t.Errorf("NoSuchContainer: wrong message. Want %q. Got %q.", expected, got)
+	}
+}
+
+func TestNoSuchContainerErrorMessage(t *testing.T) {
+	var err = &NoSuchContainer{ID: "i345", Err: errors.New("some advanced error info")}
+	expected := "No such container: i345 - some advanced error info"
 	if got := err.Error(); got != expected {
 		t.Errorf("NoSuchContainer: wrong message. Want %q. Got %q.", expected, got)
 	}


### PR DESCRIPTION
It took some time to figure out why I was getting "container not found" error while trying to start just created container. Docker daemon logs helped - the `CMD` was failing, but its api gives 404 in such case, along with descriptive error still (in http response body).
So it makes sense to propagate this error to `NoSuchContainer` to save time for others.