### PR TITLE
Makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ env:
   - GOARCH=amd64
   - GOARCH=386
 install:
-  - go get -d ./...
+  - make testdeps
 script:
-  - go test ./...
-  - ./testing/bin/fmtpolice
+  - make test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,34 @@
+.PHONY: \
+	all \
+	deps \
+	updatedeps \
+	testdeps \
+	updatetestdeps \
+	cov \
+	test \
+	clean
+
+all: test
+
+deps:
+	go get -d -v ./...
+
+updatedeps:
+	go get -d -v -u -f ./...
+
+testdeps: deps
+	go get -d -v -t ./...
+
+updatetestdeps: updatedeps
+	go get -d -v -t -u -f ./...
+
+cov: testdeps
+	go get -v github.com/axw/gocov/gocov
+	gocov test | gocov report
+
+test: testdeps
+	go test ./...
+	./testing/bin/fmtpolice
+
+clean:
+	go clean ./...

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ updatetestdeps: updatedeps
 
 cov: testdeps
 	go get -v github.com/axw/gocov/gocov
+	go get golang.org/x/tools/cmd/cover
 	gocov test | gocov report
 
 test: testdeps

--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,10 @@ deps:
 updatedeps:
 	go get -d -v -u -f ./...
 
-testdeps: deps
+testdeps:
 	go get -d -v -t ./...
 
-updatetestdeps: updatedeps
+updatetestdeps:
 	go get -d -v -t -u -f ./...
 
 cov: testdeps

--- a/README.markdown
+++ b/README.markdown
@@ -66,5 +66,4 @@ func main() {
 
 You can run the tests with:
 
-    go get -d ./...
-    go test ./...
+    make test


### PR DESCRIPTION
You probably will reject this one because I'm sure you thought of it, but adding it in case you would find it helpful.

This is a version of what I use in all my repositories, and I think it's a good, universally understood way to show people how to run commands on a repository. The original reason I thought to add this was that I always forget to run `./testing/bin/fmtpolice` when I submit a PR, and then there are usually Travis failures. With this, `fmtpolice` becomes a known part of the testing process.