### PR TITLE
update Client#do, Client#stream, Client#hijack to take a struct for optional parameters

### DIFF
--- a/client.go
+++ b/client.go
@@ -252,7 +252,7 @@ func (c *Client) checkAPIVersion() error {
 // See http://goo.gl/stJENm for more details.
 func (c *Client) Ping() error {
 	path := "/_ping"
-	body, status, err := c.do("GET", path, nil, false)
+	body, status, err := c.do("GET", path, doOptions{})
 	if err != nil {
 		return err
 	}
@@ -263,7 +263,7 @@ func (c *Client) Ping() error {
 }
 
 func (c *Client) getServerAPIVersionString() (version string, err error) {
-	body, status, err := c.do("GET", "/version", nil, false)
+	body, status, err := c.do("GET", "/version", doOptions{})
 	if err != nil {
 		return "", err
 	}
@@ -279,10 +279,15 @@ func (c *Client) getServerAPIVersionString() (version string, err error) {
 	return version, nil
 }
 
-func (c *Client) do(method, path string, data interface{}, forceJSON bool) ([]byte, int, error) {
+type doOptions struct {
+	data      interface{}
+	forceJSON bool
+}
+
+func (c *Client) do(method, path string, doOptions doOptions) ([]byte, int, error) {
 	var params io.Reader
-	if data != nil || forceJSON {
-		buf, err := json.Marshal(data)
+	if doOptions.data != nil || doOptions.forceJSON {
+		buf, err := json.Marshal(doOptions.data)
 		if err != nil {
 			return nil, -1, err
 		}
@@ -299,7 +304,7 @@ func (c *Client) do(method, path string, data interface{}, forceJSON bool) ([]by
 		return nil, -1, err
 	}
 	req.Header.Set("User-Agent", userAgent)
-	if data != nil {
+	if doOptions.data != nil {
 		req.Header.Set("Content-Type", "application/json")
 	} else if method == "POST" {
 		req.Header.Set("Content-Type", "plain/text")
@@ -339,9 +344,18 @@ func (c *Client) do(method, path string, data interface{}, forceJSON bool) ([]by
 	return body, resp.StatusCode, nil
 }
 
-func (c *Client) stream(method, path string, setRawTerminal, rawJSONStream bool, headers map[string]string, in io.Reader, stdout, stderr io.Writer) error {
-	if (method == "POST" || method == "PUT") && in == nil {
-		in = bytes.NewReader(nil)
+type streamOptions struct {
+	setRawTerminal bool
+	rawJSONStream  bool
+	headers        map[string]string
+	in             io.Reader
+	stdout         io.Writer
+	stderr         io.Writer
+}
+
+func (c *Client) stream(method, path string, streamOptions streamOptions) error {
+	if (method == "POST" || method == "PUT") && streamOptions.in == nil {
+		streamOptions.in = bytes.NewReader(nil)
 	}
 	if path != "/version" && !c.SkipServerVersionCheck && c.expectedAPIVersion == nil {
 		err := c.checkAPIVersion()
@@ -349,7 +363,7 @@ func (c *Client) stream(method, path string, setRawTerminal, rawJSONStream bool,
 			return err
 		}
 	}
-	req, err := http.NewRequest(method, c.getURL(path), in)
+	req, err := http.NewRequest(method, c.getURL(path), streamOptions.in)
 	if err != nil {
 		return err
 	}
@@ -357,17 +371,17 @@ func (c *Client) stream(method, path string, setRawTerminal, rawJSONStream bool,
 	if method == "POST" {
 		req.Header.Set("Content-Type", "plain/text")
 	}
-	for key, val := range headers {
+	for key, val := range streamOptions.headers {
 		req.Header.Set(key, val)
 	}
 	var resp *http.Response
 	protocol := c.endpointURL.Scheme
 	address := c.endpointURL.Path
-	if stdout == nil {
-		stdout = ioutil.Discard
+	if streamOptions.stdout == nil {
+		streamOptions.stdout = ioutil.Discard
 	}
-	if stderr == nil {
-		stderr = ioutil.Discard
+	if streamOptions.stderr == nil {
+		streamOptions.stderr = ioutil.Discard
 	}
 	if protocol == "unix" {
 		dial, err := net.Dial(protocol, address)
@@ -397,8 +411,8 @@ func (c *Client) stream(method, path string, setRawTerminal, rawJSONStream bool,
 	if resp.Header.Get("Content-Type") == "application/json" {
 		// if we want to get raw json stream, just copy it back to output
 		// without decoding it
-		if rawJSONStream {
-			_, err = io.Copy(stdout, resp.Body)
+		if streamOptions.rawJSONStream {
+			_, err = io.Copy(streamOptions.stdout, resp.Body)
 			return err
 		}
 		dec := json.NewDecoder(resp.Body)
@@ -410,28 +424,37 @@ func (c *Client) stream(method, path string, setRawTerminal, rawJSONStream bool,
 				return err
 			}
 			if m.Stream != "" {
-				fmt.Fprint(stdout, m.Stream)
+				fmt.Fprint(streamOptions.stdout, m.Stream)
 			} else if m.Progress != "" {
-				fmt.Fprintf(stdout, "%s %s\r", m.Status, m.Progress)
+				fmt.Fprintf(streamOptions.stdout, "%s %s\r", m.Status, m.Progress)
 			} else if m.Error != "" {
 				return errors.New(m.Error)
 			}
 			if m.Status != "" {
-				fmt.Fprintln(stdout, m.Status)
+				fmt.Fprintln(streamOptions.stdout, m.Status)
 			}
 		}
 	} else {
-		if setRawTerminal {
-			_, err = io.Copy(stdout, resp.Body)
+		if streamOptions.setRawTerminal {
+			_, err = io.Copy(streamOptions.stdout, resp.Body)
 		} else {
-			_, err = stdCopy(stdout, stderr, resp.Body)
+			_, err = stdCopy(streamOptions.stdout, streamOptions.stderr, resp.Body)
 		}
 		return err
 	}
 	return nil
 }
 
-func (c *Client) hijack(method, path string, success chan struct{}, setRawTerminal bool, in io.Reader, stderr, stdout io.Writer, data interface{}) error {
+type hijackOptions struct {
+	success        chan struct{}
+	setRawTerminal bool
+	in             io.Reader
+	stdout         io.Writer
+	stderr         io.Writer
+	data           interface{}
+}
+
+func (c *Client) hijack(method, path string, hijackOptions hijackOptions) error {
 	if path != "/version" && !c.SkipServerVersionCheck && c.expectedAPIVersion == nil {
 		err := c.checkAPIVersion()
 		if err != nil {
@@ -440,19 +463,19 @@ func (c *Client) hijack(method, path string, success chan struct{}, setRawTermin
 	}
 
 	var params io.Reader
-	if data != nil {
-		buf, err := json.Marshal(data)
+	if hijackOptions.data != nil {
+		buf, err := json.Marshal(hijackOptions.data)
 		if err != nil {
 			return err
 		}
 		params = bytes.NewBuffer(buf)
 	}
 
-	if stdout == nil {
-		stdout = ioutil.Discard
+	if hijackOptions.stdout == nil {
+		hijackOptions.stdout = ioutil.Discard
 	}
-	if stderr == nil {
-		stderr = ioutil.Discard
+	if hijackOptions.stderr == nil {
+		hijackOptions.stderr = ioutil.Discard
 	}
 	req, err := http.NewRequest(method, c.getURL(path), params)
 	if err != nil {
@@ -480,9 +503,9 @@ func (c *Client) hijack(method, path string, success chan struct{}, setRawTermin
 	clientconn := httputil.NewClientConn(dial, nil)
 	defer clientconn.Close()
 	clientconn.Do(req)
-	if success != nil {
-		success <- struct{}{}
-		<-success
+	if hijackOptions.success != nil {
+		hijackOptions.success <- struct{}{}
+		<-hijackOptions.success
 	}
 	rwc, br := clientconn.Hijack()
 	defer rwc.Close()
@@ -491,18 +514,18 @@ func (c *Client) hijack(method, path string, success chan struct{}, setRawTermin
 	go func() {
 		defer close(exit)
 		var err error
-		if setRawTerminal {
+		if hijackOptions.setRawTerminal {
 			// When TTY is ON, use regular copy
-			_, err = io.Copy(stdout, br)
+			_, err = io.Copy(hijackOptions.stdout, br)
 		} else {
-			_, err = stdCopy(stdout, stderr, br)
+			_, err = stdCopy(hijackOptions.stdout, hijackOptions.stderr, br)
 		}
 		errs <- err
 	}()
 	go func() {
 		var err error
-		if in != nil {
-			_, err = io.Copy(rwc, in)
+		if hijackOptions.in != nil {
+			_, err = io.Copy(rwc, hijackOptions.in)
 		}
 		rwc.(interface {
 			CloseWrite() error

--- a/container.go
+++ b/container.go
@@ -56,7 +56,7 @@ type APIContainers struct {
 // See http://goo.gl/6Y4Gz7 for more details.
 func (c *Client) ListContainers(opts ListContainersOptions) ([]APIContainers, error) {
 	path := "/containers/json?" + queryString(opts)
-	body, _, err := c.do("GET", path, nil, false)
+	body, _, err := c.do("GET", path, doOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -264,7 +264,7 @@ type RenameContainerOptions struct {
 //
 // See http://goo.gl/L00hoj for more details.
 func (c *Client) RenameContainer(opts RenameContainerOptions) error {
-	_, _, err := c.do("POST", fmt.Sprintf("/containers/"+opts.ID+"/rename?%s", queryString(opts)), nil, false)
+	_, _, err := c.do("POST", fmt.Sprintf("/containers/"+opts.ID+"/rename?%s", queryString(opts)), doOptions{})
 	return err
 }
 
@@ -273,7 +273,7 @@ func (c *Client) RenameContainer(opts RenameContainerOptions) error {
 // See http://goo.gl/CxVuJ5 for more details.
 func (c *Client) InspectContainer(id string) (*Container, error) {
 	path := "/containers/" + id + "/json"
-	body, status, err := c.do("GET", path, nil, false)
+	body, status, err := c.do("GET", path, doOptions{})
 	if status == http.StatusNotFound {
 		return nil, &NoSuchContainer{ID: id}
 	}
@@ -293,7 +293,7 @@ func (c *Client) InspectContainer(id string) (*Container, error) {
 // See http://goo.gl/QkW9sH for more details.
 func (c *Client) ContainerChanges(id string) ([]Change, error) {
 	path := "/containers/" + id + "/changes"
-	body, status, err := c.do("GET", path, nil, false)
+	body, status, err := c.do("GET", path, doOptions{})
 	if status == http.StatusNotFound {
 		return nil, &NoSuchContainer{ID: id}
 	}
@@ -323,13 +323,19 @@ type CreateContainerOptions struct {
 // See http://goo.gl/mErxNp for more details.
 func (c *Client) CreateContainer(opts CreateContainerOptions) (*Container, error) {
 	path := "/containers/create?" + queryString(opts)
-	body, status, err := c.do("POST", path, struct {
-		*Config
-		HostConfig *HostConfig `json:"HostConfig,omitempty" yaml:"HostConfig,omitempty"`
-	}{
-		opts.Config,
-		opts.HostConfig,
-	}, false)
+	body, status, err := c.do(
+		"POST",
+		path,
+		doOptions{
+			data: struct {
+				*Config
+				HostConfig *HostConfig `json:"HostConfig,omitempty" yaml:"HostConfig,omitempty"`
+			}{
+				opts.Config,
+				opts.HostConfig,
+			},
+		},
+	)
 
 	if status == http.StatusNotFound {
 		return nil, ErrNoSuchImage
@@ -425,7 +431,7 @@ type HostConfig struct {
 // See http://goo.gl/iM5GYs for more details.
 func (c *Client) StartContainer(id string, hostConfig *HostConfig) error {
 	path := "/containers/" + id + "/start"
-	_, status, err := c.do("POST", path, hostConfig, true)
+	_, status, err := c.do("POST", path, doOptions{data: hostConfig, forceJSON: true})
 	if status == http.StatusNotFound {
 		return &NoSuchContainer{ID: id, Err: err}
 	}
@@ -444,7 +450,7 @@ func (c *Client) StartContainer(id string, hostConfig *HostConfig) error {
 // See http://goo.gl/EbcpXt for more details.
 func (c *Client) StopContainer(id string, timeout uint) error {
 	path := fmt.Sprintf("/containers/%s/stop?t=%d", id, timeout)
-	_, status, err := c.do("POST", path, nil, false)
+	_, status, err := c.do("POST", path, doOptions{})
 	if status == http.StatusNotFound {
 		return &NoSuchContainer{ID: id}
 	}
@@ -463,7 +469,7 @@ func (c *Client) StopContainer(id string, timeout uint) error {
 // See http://goo.gl/VOzR2n for more details.
 func (c *Client) RestartContainer(id string, timeout uint) error {
 	path := fmt.Sprintf("/containers/%s/restart?t=%d", id, timeout)
-	_, status, err := c.do("POST", path, nil, false)
+	_, status, err := c.do("POST", path, doOptions{})
 	if status == http.StatusNotFound {
 		return &NoSuchContainer{ID: id}
 	}
@@ -478,7 +484,7 @@ func (c *Client) RestartContainer(id string, timeout uint) error {
 // See http://goo.gl/AM5t42 for more details.
 func (c *Client) PauseContainer(id string) error {
 	path := fmt.Sprintf("/containers/%s/pause", id)
-	_, status, err := c.do("POST", path, nil, false)
+	_, status, err := c.do("POST", path, doOptions{})
 	if status == http.StatusNotFound {
 		return &NoSuchContainer{ID: id}
 	}
@@ -493,7 +499,7 @@ func (c *Client) PauseContainer(id string) error {
 // See http://goo.gl/eBrNSL for more details.
 func (c *Client) UnpauseContainer(id string) error {
 	path := fmt.Sprintf("/containers/%s/unpause", id)
-	_, status, err := c.do("POST", path, nil, false)
+	_, status, err := c.do("POST", path, doOptions{})
 	if status == http.StatusNotFound {
 		return &NoSuchContainer{ID: id}
 	}
@@ -522,7 +528,7 @@ func (c *Client) TopContainer(id string, psArgs string) (TopResult, error) {
 		args = fmt.Sprintf("?ps_args=%s", psArgs)
 	}
 	path := fmt.Sprintf("/containers/%s/top%s", id, args)
-	body, status, err := c.do("GET", path, nil, false)
+	body, status, err := c.do("GET", path, doOptions{})
 	if status == http.StatusNotFound {
 		return result, &NoSuchContainer{ID: id}
 	}
@@ -554,7 +560,7 @@ type KillContainerOptions struct {
 // See http://goo.gl/TFkECx for more details.
 func (c *Client) KillContainer(opts KillContainerOptions) error {
 	path := "/containers/" + opts.ID + "/kill" + "?" + queryString(opts)
-	_, status, err := c.do("POST", path, nil, false)
+	_, status, err := c.do("POST", path, doOptions{})
 	if status == http.StatusNotFound {
 		return &NoSuchContainer{ID: opts.ID}
 	}
@@ -585,7 +591,7 @@ type RemoveContainerOptions struct {
 // See http://goo.gl/ZB83ji for more details.
 func (c *Client) RemoveContainer(opts RemoveContainerOptions) error {
 	path := "/containers/" + opts.ID + "?" + queryString(opts)
-	_, status, err := c.do("DELETE", path, nil, false)
+	_, status, err := c.do("DELETE", path, doOptions{})
 	if status == http.StatusNotFound {
 		return &NoSuchContainer{ID: opts.ID}
 	}
@@ -614,7 +620,7 @@ func (c *Client) CopyFromContainer(opts CopyFromContainerOptions) error {
 		return &NoSuchContainer{ID: opts.Container}
 	}
 	url := fmt.Sprintf("/containers/%s/copy", opts.Container)
-	body, status, err := c.do("POST", url, opts, false)
+	body, status, err := c.do("POST", url, doOptions{data: opts})
 	if status == http.StatusNotFound {
 		return &NoSuchContainer{ID: opts.Container}
 	}
@@ -630,7 +636,7 @@ func (c *Client) CopyFromContainer(opts CopyFromContainerOptions) error {
 //
 // See http://goo.gl/J88DHU for more details.
 func (c *Client) WaitContainer(id string) (int, error) {
-	body, status, err := c.do("POST", "/containers/"+id+"/wait", nil, false)
+	body, status, err := c.do("POST", "/containers/"+id+"/wait", doOptions{})
 	if status == http.StatusNotFound {
 		return 0, &NoSuchContainer{ID: id}
 	}
@@ -662,7 +668,7 @@ type CommitContainerOptions struct {
 // See http://goo.gl/Jn8pe8 for more details.
 func (c *Client) CommitContainer(opts CommitContainerOptions) (*Image, error) {
 	path := "/commit?" + queryString(opts)
-	body, status, err := c.do("POST", path, opts.Run, false)
+	body, status, err := c.do("POST", path, doOptions{data: opts.Run})
 	if status == http.StatusNotFound {
 		return nil, &NoSuchContainer{ID: opts.Container}
 	}
@@ -721,7 +727,13 @@ func (c *Client) AttachToContainer(opts AttachToContainerOptions) error {
 		return &NoSuchContainer{ID: opts.Container}
 	}
 	path := "/containers/" + opts.Container + "/attach?" + queryString(opts)
-	return c.hijack("POST", path, opts.Success, opts.RawTerminal, opts.InputStream, opts.ErrorStream, opts.OutputStream, nil)
+	return c.hijack("POST", path, hijackOptions{
+		success:        opts.Success,
+		setRawTerminal: opts.RawTerminal,
+		in:             opts.InputStream,
+		stdout:         opts.OutputStream,
+		stderr:         opts.ErrorStream,
+	})
 }
 
 // LogsOptions represents the set of options used when getting logs from a
@@ -753,7 +765,11 @@ func (c *Client) Logs(opts LogsOptions) error {
 		opts.Tail = "all"
 	}
 	path := "/containers/" + opts.Container + "/logs?" + queryString(opts)
-	return c.stream("GET", path, opts.RawTerminal, false, nil, nil, opts.OutputStream, opts.ErrorStream)
+	return c.stream("GET", path, streamOptions{
+		setRawTerminal: opts.RawTerminal,
+		stdout:         opts.OutputStream,
+		stderr:         opts.ErrorStream,
+	})
 }
 
 // ResizeContainerTTY resizes the terminal to the given height and width.
@@ -761,7 +777,7 @@ func (c *Client) ResizeContainerTTY(id string, height, width int) error {
 	params := make(url.Values)
 	params.Set("h", strconv.Itoa(height))
 	params.Set("w", strconv.Itoa(width))
-	_, _, err := c.do("POST", "/containers/"+id+"/resize?"+params.Encode(), nil, false)
+	_, _, err := c.do("POST", "/containers/"+id+"/resize?"+params.Encode(), doOptions{})
 	return err
 }
 
@@ -783,7 +799,10 @@ func (c *Client) ExportContainer(opts ExportContainerOptions) error {
 		return &NoSuchContainer{ID: opts.ID}
 	}
 	url := fmt.Sprintf("/containers/%s/export", opts.ID)
-	return c.stream("GET", url, true, false, nil, nil, opts.OutputStream, nil)
+	return c.stream("GET", url, streamOptions{
+		setRawTerminal: true,
+		stdout:         opts.OutputStream,
+	})
 }
 
 // NoSuchContainer is the error returned when a given container does not exist.

--- a/exec.go
+++ b/exec.go
@@ -90,7 +90,7 @@ type ExecInspect struct {
 // See http://goo.gl/8izrzI for more details
 func (c *Client) CreateExec(opts CreateExecOptions) (*Exec, error) {
 	path := fmt.Sprintf("/containers/%s/exec", opts.Container)
-	body, status, err := c.do("POST", path, opts, false)
+	body, status, err := c.do("POST", path, doOptions{data: opts})
 	if status == http.StatusNotFound {
 		return nil, &NoSuchContainer{ID: opts.Container}
 	}
@@ -119,7 +119,7 @@ func (c *Client) StartExec(id string, opts StartExecOptions) error {
 	path := fmt.Sprintf("/exec/%s/start", id)
 
 	if opts.Detach {
-		_, status, err := c.do("POST", path, opts, false)
+		_, status, err := c.do("POST", path, doOptions{data: opts})
 		if status == http.StatusNotFound {
 			return &NoSuchExec{ID: id}
 		}
@@ -129,7 +129,14 @@ func (c *Client) StartExec(id string, opts StartExecOptions) error {
 		return nil
 	}
 
-	return c.hijack("POST", path, opts.Success, opts.RawTerminal, opts.InputStream, opts.ErrorStream, opts.OutputStream, opts)
+	return c.hijack("POST", path, hijackOptions{
+		success:        opts.Success,
+		setRawTerminal: opts.RawTerminal,
+		in:             opts.InputStream,
+		stdout:         opts.OutputStream,
+		stderr:         opts.ErrorStream,
+		data:           opts,
+	})
 }
 
 // ResizeExecTTY resizes the tty session used by the exec command id. This API
@@ -143,7 +150,7 @@ func (c *Client) ResizeExecTTY(id string, height, width int) error {
 	params.Set("w", strconv.Itoa(width))
 
 	path := fmt.Sprintf("/exec/%s/resize?%s", id, params.Encode())
-	_, _, err := c.do("POST", path, nil, false)
+	_, _, err := c.do("POST", path, doOptions{})
 	return err
 }
 
@@ -152,7 +159,7 @@ func (c *Client) ResizeExecTTY(id string, height, width int) error {
 // See http://goo.gl/ypQULN for more details
 func (c *Client) InspectExec(id string) (*ExecInspect, error) {
 	path := fmt.Sprintf("/exec/%s/json", id)
-	body, status, err := c.do("GET", path, nil, false)
+	body, status, err := c.do("GET", path, doOptions{})
 	if status == http.StatusNotFound {
 		return nil, &NoSuchExec{ID: id}
 	}

--- a/image.go
+++ b/image.go
@@ -106,7 +106,7 @@ var (
 func (c *Client) ListImages(opts ListImagesOptions) ([]APIImages, error) {
 	// TODO(pedge): what happens if we specify the digest parameter when using API Version <1.18?
 	path := "/images/json?" + queryString(opts)
-	body, _, err := c.do("GET", path, nil, false)
+	body, _, err := c.do("GET", path, doOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -122,7 +122,7 @@ func (c *Client) ListImages(opts ListImagesOptions) ([]APIImages, error) {
 //
 // See http://goo.gl/2oJmNs for more details.
 func (c *Client) ImageHistory(name string) ([]ImageHistory, error) {
-	body, status, err := c.do("GET", "/images/"+name+"/history", nil, false)
+	body, status, err := c.do("GET", "/images/"+name+"/history", doOptions{})
 	if status == http.StatusNotFound {
 		return nil, ErrNoSuchImage
 	}
@@ -141,7 +141,7 @@ func (c *Client) ImageHistory(name string) ([]ImageHistory, error) {
 //
 // See http://goo.gl/znj0wM for more details.
 func (c *Client) RemoveImage(name string) error {
-	_, status, err := c.do("DELETE", "/images/"+name, nil, false)
+	_, status, err := c.do("DELETE", "/images/"+name, doOptions{})
 	if status == http.StatusNotFound {
 		return ErrNoSuchImage
 	}
@@ -163,7 +163,7 @@ type RemoveImageOptions struct {
 // See http://goo.gl/znj0wM for more details.
 func (c *Client) RemoveImageExtended(name string, opts RemoveImageOptions) error {
 	uri := fmt.Sprintf("/images/%s?%s", name, queryString(&opts))
-	_, status, err := c.do("DELETE", uri, nil, false)
+	_, status, err := c.do("DELETE", uri, doOptions{})
 	if status == http.StatusNotFound {
 		return ErrNoSuchImage
 	}
@@ -174,7 +174,7 @@ func (c *Client) RemoveImageExtended(name string, opts RemoveImageOptions) error
 //
 // See http://goo.gl/Q112NY for more details.
 func (c *Client) InspectImage(name string) (*Image, error) {
-	body, status, err := c.do("GET", "/images/"+name+"/json", nil, false)
+	body, status, err := c.do("GET", "/images/"+name+"/json", doOptions{})
 	if status == http.StatusNotFound {
 		return nil, ErrNoSuchImage
 	}
@@ -243,8 +243,12 @@ func (c *Client) PushImage(opts PushImageOptions, auth AuthConfiguration) error 
 	name := opts.Name
 	opts.Name = ""
 	path := "/images/" + name + "/push?" + queryString(&opts)
-	headers := headersWithAuth(auth)
-	return c.stream("POST", path, true, opts.RawJSONStream, headers, nil, opts.OutputStream, nil)
+	return c.stream("POST", path, streamOptions{
+		setRawTerminal: true,
+		rawJSONStream:  opts.RawJSONStream,
+		headers:        headersWithAuth(auth),
+		stdout:         opts.OutputStream,
+	})
 }
 
 // PullImageOptions present the set of options available for pulling an image
@@ -273,7 +277,13 @@ func (c *Client) PullImage(opts PullImageOptions, auth AuthConfiguration) error 
 
 func (c *Client) createImage(qs string, headers map[string]string, in io.Reader, w io.Writer, rawJSONStream bool) error {
 	path := "/images/create?" + qs
-	return c.stream("POST", path, true, rawJSONStream, headers, in, w, nil)
+	return c.stream("POST", path, streamOptions{
+		setRawTerminal: true,
+		rawJSONStream:  rawJSONStream,
+		headers:        headers,
+		in:             in,
+		stdout:         w,
+	})
 }
 
 // LoadImageOptions represents the options for LoadImage Docker API Call
@@ -287,7 +297,10 @@ type LoadImageOptions struct {
 //
 // See http://goo.gl/Y8NNCq for more details.
 func (c *Client) LoadImage(opts LoadImageOptions) error {
-	return c.stream("POST", "/images/load", true, false, nil, opts.InputStream, nil, nil)
+	return c.stream("POST", "/images/load", streamOptions{
+		setRawTerminal: true,
+		in:             opts.InputStream,
+	})
 }
 
 // ExportImageOptions represent the options for ExportImage Docker API call
@@ -302,7 +315,10 @@ type ExportImageOptions struct {
 //
 // See http://goo.gl/mi6kvk for more details.
 func (c *Client) ExportImage(opts ExportImageOptions) error {
-	return c.stream("GET", fmt.Sprintf("/images/%s/get", opts.Name), true, false, nil, nil, opts.OutputStream, nil)
+	return c.stream("GET", fmt.Sprintf("/images/%s/get", opts.Name), streamOptions{
+		setRawTerminal: true,
+		stdout:         opts.OutputStream,
+	})
 }
 
 // ExportImagesOptions represent the options for ExportImages Docker API call
@@ -320,7 +336,10 @@ func (c *Client) ExportImages(opts ExportImagesOptions) error {
 	if opts.Names == nil || len(opts.Names) == 0 {
 		return ErrMustSpecifyNames
 	}
-	return c.stream("GET", "/images/get?"+queryString(&opts), true, false, nil, nil, opts.OutputStream, nil)
+	return c.stream("GET", "/images/get?"+queryString(&opts), streamOptions{
+		setRawTerminal: true,
+		stdout:         opts.OutputStream,
+	})
 }
 
 // ImportImageOptions present the set of informations available for importing
@@ -407,8 +426,13 @@ func (c *Client) BuildImage(opts BuildImageOptions) error {
 		}
 	}
 
-	return c.stream("POST", fmt.Sprintf("/build?%s",
-		queryString(&opts)), true, opts.RawJSONStream, headers, opts.InputStream, opts.OutputStream, nil)
+	return c.stream("POST", fmt.Sprintf("/build?%s", queryString(&opts)), streamOptions{
+		setRawTerminal: true,
+		rawJSONStream:  opts.RawJSONStream,
+		headers:        headers,
+		in:             opts.InputStream,
+		stdout:         opts.OutputStream,
+	})
 }
 
 // TagImageOptions present the set of options to tag an image.
@@ -428,7 +452,7 @@ func (c *Client) TagImage(name string, opts TagImageOptions) error {
 		return ErrNoSuchImage
 	}
 	_, status, err := c.do("POST", fmt.Sprintf("/images/"+name+"/tag?%s",
-		queryString(&opts)), nil, false)
+		queryString(&opts)), doOptions{})
 
 	if status == http.StatusNotFound {
 		return ErrNoSuchImage
@@ -479,7 +503,7 @@ type APIImageSearch struct {
 //
 // See http://goo.gl/xI5lLZ for more details.
 func (c *Client) SearchImages(term string) ([]APIImageSearch, error) {
-	body, _, err := c.do("GET", "/images/search?term="+term, nil, false)
+	body, _, err := c.do("GET", "/images/search?term="+term, doOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/misc.go
+++ b/misc.go
@@ -13,7 +13,7 @@ import (
 //
 // See http://goo.gl/BOZrF5 for more details.
 func (c *Client) Version() (*Env, error) {
-	body, _, err := c.do("GET", "/version", nil, false)
+	body, _, err := c.do("GET", "/version", doOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -28,7 +28,7 @@ func (c *Client) Version() (*Env, error) {
 //
 // See http://goo.gl/wmqZsW for more details.
 func (c *Client) Info() (*Env, error) {
-	body, _, err := c.do("GET", "/info", nil, false)
+	body, _, err := c.do("GET", "/info", doOptions{})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When developing in this repository, I am constantly looking back at client.go to figure out which parameters are what for do, stream, and hijack. Most functions are just passing default values for these anyways, so this PR makes it easier to determine what a call to do, stream, or hijack is doing. This also fixes potential easy such as ordering problems for the same parameter types - stdout and stderr were reversed in stream and hijack, for example.