### PR TITLE
Allow DockerServer to force remove a container

### DIFF
--- a/testing/server.go
+++ b/testing/server.go
@@ -566,12 +566,13 @@ func (s *DockerServer) waitContainer(w http.ResponseWriter, r *http.Request) {
 
 func (s *DockerServer) removeContainer(w http.ResponseWriter, r *http.Request) {
 	id := mux.Vars(r)["id"]
+	force := r.URL.Query().Get("force")
 	_, index, err := s.findContainer(id)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusNotFound)
 		return
 	}
-	if s.containers[index].State.Running {
+	if s.containers[index].State.Running && force != "1" {
 		msg := "Error: API error (406): Impossible to remove a running container, please stop it first"
 		http.Error(w, msg, http.StatusInternalServerError)
 		return

--- a/testing/server_test.go
+++ b/testing/server_test.go
@@ -850,6 +850,23 @@ func TestRemoveContainerRunning(t *testing.T) {
 	}
 }
 
+func TestRemoveContainerRunningForce(t *testing.T) {
+	server := DockerServer{}
+	addContainers(&server, 1)
+	server.containers[0].State.Running = true
+	server.buildMuxer()
+	recorder := httptest.NewRecorder()
+	path := fmt.Sprintf("/containers/%s?%s", server.containers[0].ID, "force=1")
+	request, _ := http.NewRequest("DELETE", path, nil)
+	server.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusNoContent {
+		t.Errorf("RemoveContainer: wrong status. Want %d. Got %d.", http.StatusNoContent, recorder.Code)
+	}
+	if len(server.containers) > 0 {
+		t.Error("RemoveContainer: did not remove the container.")
+	}
+}
+
 func TestPullImage(t *testing.T) {
 	server := DockerServer{imgIDs: make(map[string]string)}
 	server.buildMuxer()


### PR DESCRIPTION
Hi @fsouza,

Thanks for this wonderful library. I have been writing some functionality and I've been really digging the testing package.

I noticed a problem though - I wanted to delete a container and when I set the option `force: true`, it still wouldn't delete. I tracked the problem down to the testing server not honoring the query param of `force=1`. 

Here's a PR that fixes the issue!