### PR TITLE
Add /container/ID/logs endpoint to test server

### DIFF
--- a/client.go
+++ b/client.go
@@ -438,7 +438,7 @@ func (c *Client) stream(method, path string, streamOptions streamOptions) error 
 		if streamOptions.setRawTerminal {
 			_, err = io.Copy(streamOptions.stdout, resp.Body)
 		} else {
-			_, err = stdCopy(streamOptions.stdout, streamOptions.stderr, resp.Body)
+			_, err = StdCopy(streamOptions.stdout, streamOptions.stderr, resp.Body)
 		}
 		return err
 	}
@@ -518,7 +518,7 @@ func (c *Client) hijack(method, path string, hijackOptions hijackOptions) error 
 			// When TTY is ON, use regular copy
 			_, err = io.Copy(hijackOptions.stdout, br)
 		} else {
-			_, err = stdCopy(hijackOptions.stdout, hijackOptions.stderr, br)
+			_, err = StdCopy(hijackOptions.stdout, hijackOptions.stderr, br)
 		}
 		errs <- err
 	}()

--- a/stdcopy.go
+++ b/stdcopy.go
@@ -18,6 +18,16 @@ const (
 
 var errInvalidStdHeader = errors.New("Unrecognized input header")
 
+// StdCopy is a modified version of io.Copy.
+//
+// StdCopy will demultiplex `src`, assuming that it contains two streams,
+// previously multiplexed together using a StdWriter instance.
+// As it reads from `src`, StdCopy will write to `dstout` and `dsterr`.
+//
+// StdCopy will read until it hits EOF on `src`. It will then return a nil error.
+// In other words: if `err` is non nil, it indicates a real underlying error.
+//
+// `written` will hold the total number of bytes written to `dstout` and `dsterr`.
 func StdCopy(dstout, dsterr io.Writer, src io.Reader) (written int64, err error) {
 	var (
 		buf       = make([]byte, 32*1024+stdWriterPrefixLen+1)

--- a/stdcopy.go
+++ b/stdcopy.go
@@ -18,7 +18,7 @@ const (
 
 var errInvalidStdHeader = errors.New("Unrecognized input header")
 
-func stdCopy(dstout, dsterr io.Writer, src io.Reader) (written int64, err error) {
+func StdCopy(dstout, dsterr io.Writer, src io.Reader) (written int64, err error) {
 	var (
 		buf       = make([]byte, 32*1024+stdWriterPrefixLen+1)
 		bufLen    = len(buf)

--- a/stdcopy_test.go
+++ b/stdcopy_test.go
@@ -29,7 +29,7 @@ func TestStdCopy(t *testing.T) {
 	input.Write([]byte("just kidding"))
 	input.Write([]byte{0, 0, 0, 0, 0, 0, 0, 6})
 	input.Write([]byte("\nyeah!"))
-	n, err := stdCopy(&stdout, &stderr, &input)
+	n, err := StdCopy(&stdout, &stderr, &input)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -37,10 +37,10 @@ func TestStdCopy(t *testing.T) {
 		t.Errorf("Wrong number of bytes. Want %d. Got %d.", expected, n)
 	}
 	if got := stderr.String(); got != "something happened!" {
-		t.Errorf("stdCopy: wrong stderr. Want %q. Got %q.", "something happened!", got)
+		t.Errorf("StdCopy: wrong stderr. Want %q. Got %q.", "something happened!", got)
 	}
 	if got := stdout.String(); got != "just kidding\nyeah!" {
-		t.Errorf("stdCopy: wrong stdout. Want %q. Got %q.", "just kidding\nyeah!", got)
+		t.Errorf("StdCopy: wrong stdout. Want %q. Got %q.", "just kidding\nyeah!", got)
 	}
 }
 
@@ -49,7 +49,7 @@ func TestStdCopyStress(t *testing.T) {
 	value := strings.Repeat("something ", 4096)
 	writer := newStdWriter(&input, Stdout)
 	writer.Write([]byte(value))
-	n, err := stdCopy(&stdout, &stderr, &input)
+	n, err := StdCopy(&stdout, &stderr, &input)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -57,22 +57,22 @@ func TestStdCopyStress(t *testing.T) {
 		t.Errorf("Wrong number of bytes. Want 40960. Got %d.", n)
 	}
 	if got := stderr.String(); got != "" {
-		t.Errorf("stdCopy: wrong stderr. Want empty string. Got %q", got)
+		t.Errorf("StdCopy: wrong stderr. Want empty string. Got %q", got)
 	}
 	if got := stdout.String(); got != value {
-		t.Errorf("stdCopy: wrong stdout. Want %q. Got %q", value, got)
+		t.Errorf("StdCopy: wrong stdout. Want %q. Got %q", value, got)
 	}
 }
 
 func TestStdCopyInvalidStdHeader(t *testing.T) {
 	var input, stdout, stderr bytes.Buffer
 	input.Write([]byte{3, 0, 0, 0, 0, 0, 0, 19})
-	n, err := stdCopy(&stdout, &stderr, &input)
+	n, err := StdCopy(&stdout, &stderr, &input)
 	if n != 0 {
-		t.Errorf("stdCopy: wrong number of bytes. Want 0. Got %d", n)
+		t.Errorf("StdCopy: wrong number of bytes. Want 0. Got %d", n)
 	}
 	if err != errInvalidStdHeader {
-		t.Errorf("stdCopy: wrong error. Want ErrInvalidStdHeader. Got %#v", err)
+		t.Errorf("StdCopy: wrong error. Want ErrInvalidStdHeader. Got %#v", err)
 	}
 }
 
@@ -80,7 +80,7 @@ func TestStdCopyBigFrame(t *testing.T) {
 	var input, stdout, stderr bytes.Buffer
 	input.Write([]byte{2, 0, 0, 0, 0, 0, 0, 18})
 	input.Write([]byte("something happened!"))
-	n, err := stdCopy(&stdout, &stderr, &input)
+	n, err := StdCopy(&stdout, &stderr, &input)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -88,10 +88,10 @@ func TestStdCopyBigFrame(t *testing.T) {
 		t.Errorf("Wrong number of bytes. Want %d. Got %d.", expected, n)
 	}
 	if got := stderr.String(); got != "something happened" {
-		t.Errorf("stdCopy: wrong stderr. Want %q. Got %q.", "something happened", got)
+		t.Errorf("StdCopy: wrong stderr. Want %q. Got %q.", "something happened", got)
 	}
 	if got := stdout.String(); got != "" {
-		t.Errorf("stdCopy: wrong stdout. Want %q. Got %q.", "", got)
+		t.Errorf("StdCopy: wrong stdout. Want %q. Got %q.", "", got)
 	}
 }
 
@@ -99,41 +99,41 @@ func TestStdCopySmallFrame(t *testing.T) {
 	var input, stdout, stderr bytes.Buffer
 	input.Write([]byte{2, 0, 0, 0, 0, 0, 0, 20})
 	input.Write([]byte("something happened!"))
-	n, err := stdCopy(&stdout, &stderr, &input)
+	n, err := StdCopy(&stdout, &stderr, &input)
 	if err != io.ErrShortWrite {
-		t.Errorf("stdCopy: wrong error. Want ShortWrite. Got %#v", err)
+		t.Errorf("StdCopy: wrong error. Want ShortWrite. Got %#v", err)
 	}
 	if expected := int64(19); n != expected {
 		t.Errorf("Wrong number of bytes. Want %d. Got %d.", expected, n)
 	}
 	if got := stderr.String(); got != "something happened!" {
-		t.Errorf("stdCopy: wrong stderr. Want %q. Got %q.", "something happened", got)
+		t.Errorf("StdCopy: wrong stderr. Want %q. Got %q.", "something happened", got)
 	}
 	if got := stdout.String(); got != "" {
-		t.Errorf("stdCopy: wrong stdout. Want %q. Got %q.", "", got)
+		t.Errorf("StdCopy: wrong stdout. Want %q. Got %q.", "", got)
 	}
 }
 
 func TestStdCopyEmpty(t *testing.T) {
 	var input, stdout, stderr bytes.Buffer
-	n, err := stdCopy(&stdout, &stderr, &input)
+	n, err := StdCopy(&stdout, &stderr, &input)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if n != 0 {
-		t.Errorf("stdCopy: wrong number of bytes. Want 0. Got %d.", n)
+		t.Errorf("StdCopy: wrong number of bytes. Want 0. Got %d.", n)
 	}
 }
 
 func TestStdCopyCorruptedHeader(t *testing.T) {
 	var input, stdout, stderr bytes.Buffer
 	input.Write([]byte{2, 0, 0, 0, 0})
-	n, err := stdCopy(&stdout, &stderr, &input)
+	n, err := StdCopy(&stdout, &stderr, &input)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if n != 0 {
-		t.Errorf("stdCopy: wrong number of bytes. Want 0. Got %d.", n)
+		t.Errorf("StdCopy: wrong number of bytes. Want 0. Got %d.", n)
 	}
 }
 
@@ -141,7 +141,7 @@ func TestStdCopyTruncateWriter(t *testing.T) {
 	var input, stdout, stderr bytes.Buffer
 	input.Write([]byte{2, 0, 0, 0, 0, 0, 0, 19})
 	input.Write([]byte("something happened!"))
-	n, err := stdCopy(&stdout, iotest.TruncateWriter(&stderr, 7), &input)
+	n, err := StdCopy(&stdout, iotest.TruncateWriter(&stderr, 7), &input)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -149,28 +149,28 @@ func TestStdCopyTruncateWriter(t *testing.T) {
 		t.Errorf("Wrong number of bytes. Want %d. Got %d.", expected, n)
 	}
 	if got := stderr.String(); got != "somethi" {
-		t.Errorf("stdCopy: wrong stderr. Want %q. Got %q.", "somethi", got)
+		t.Errorf("StdCopy: wrong stderr. Want %q. Got %q.", "somethi", got)
 	}
 	if got := stdout.String(); got != "" {
-		t.Errorf("stdCopy: wrong stdout. Want %q. Got %q.", "", got)
+		t.Errorf("StdCopy: wrong stdout. Want %q. Got %q.", "", got)
 	}
 }
 
 func TestStdCopyHeaderOnly(t *testing.T) {
 	var input, stdout, stderr bytes.Buffer
 	input.Write([]byte{2, 0, 0, 0, 0, 0, 0, 19})
-	n, err := stdCopy(&stdout, iotest.TruncateWriter(&stderr, 7), &input)
+	n, err := StdCopy(&stdout, iotest.TruncateWriter(&stderr, 7), &input)
 	if err != io.ErrShortWrite {
-		t.Errorf("stdCopy: wrong error. Want ShortWrite. Got %#v", err)
+		t.Errorf("StdCopy: wrong error. Want ShortWrite. Got %#v", err)
 	}
 	if n != 0 {
 		t.Errorf("Wrong number of bytes. Want 0. Got %d.", n)
 	}
 	if got := stderr.String(); got != "" {
-		t.Errorf("stdCopy: wrong stderr. Want %q. Got %q.", "", got)
+		t.Errorf("StdCopy: wrong stderr. Want %q. Got %q.", "", got)
 	}
 	if got := stdout.String(); got != "" {
-		t.Errorf("stdCopy: wrong stdout. Want %q. Got %q.", "", got)
+		t.Errorf("StdCopy: wrong stdout. Want %q. Got %q.", "", got)
 	}
 }
 
@@ -178,7 +178,7 @@ func TestStdCopyDataErrReader(t *testing.T) {
 	var input, stdout, stderr bytes.Buffer
 	input.Write([]byte{2, 0, 0, 0, 0, 0, 0, 19})
 	input.Write([]byte("something happened!"))
-	n, err := stdCopy(&stdout, &stderr, iotest.DataErrReader(&input))
+	n, err := StdCopy(&stdout, &stderr, iotest.DataErrReader(&input))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -186,10 +186,10 @@ func TestStdCopyDataErrReader(t *testing.T) {
 		t.Errorf("Wrong number of bytes. Want %d. Got %d.", expected, n)
 	}
 	if got := stderr.String(); got != "something happened!" {
-		t.Errorf("stdCopy: wrong stderr. Want %q. Got %q.", "something happened!", got)
+		t.Errorf("StdCopy: wrong stderr. Want %q. Got %q.", "something happened!", got)
 	}
 	if got := stdout.String(); got != "" {
-		t.Errorf("stdCopy: wrong stdout. Want %q. Got %q.", "", got)
+		t.Errorf("StdCopy: wrong stdout. Want %q. Got %q.", "", got)
 	}
 }
 
@@ -197,9 +197,9 @@ func TestStdCopyTimeoutReader(t *testing.T) {
 	var input, stdout, stderr bytes.Buffer
 	input.Write([]byte{2, 0, 0, 0, 0, 0, 0, 19})
 	input.Write([]byte("something happened!"))
-	_, err := stdCopy(&stdout, &stderr, iotest.TimeoutReader(&input))
+	_, err := StdCopy(&stdout, &stderr, iotest.TimeoutReader(&input))
 	if err != iotest.ErrTimeout {
-		t.Errorf("stdCopy: wrong error. Want ErrTimeout. Got %#v.", err)
+		t.Errorf("StdCopy: wrong error. Want ErrTimeout. Got %#v.", err)
 	}
 }
 
@@ -208,12 +208,12 @@ func TestStdCopyWriteError(t *testing.T) {
 	input.Write([]byte{2, 0, 0, 0, 0, 0, 0, 19})
 	input.Write([]byte("something happened!"))
 	var stdout, stderr errorWriter
-	n, err := stdCopy(stdout, stderr, &input)
+	n, err := StdCopy(stdout, stderr, &input)
 	if err.Error() != "something went wrong" {
-		t.Errorf("stdCopy: wrong error. Want %q. Got %q", "something went wrong", err)
+		t.Errorf("StdCopy: wrong error. Want %q. Got %q", "something went wrong", err)
 	}
 	if n != 0 {
-		t.Errorf("stdCopy: wrong number of bytes. Want 0. Got %d.", n)
+		t.Errorf("StdCopy: wrong number of bytes. Want 0. Got %d.", n)
 	}
 }
 

--- a/testing/server.go
+++ b/testing/server.go
@@ -97,6 +97,7 @@ func (s *DockerServer) buildMuxer() {
 	s.mux.Path("/containers/{id:.*}/json").Methods("GET").HandlerFunc(s.handlerWrapper(s.inspectContainer))
 	s.mux.Path("/containers/{id:.*}/rename").Methods("POST").HandlerFunc(s.handlerWrapper(s.renameContainer))
 	s.mux.Path("/containers/{id:.*}/top").Methods("GET").HandlerFunc(s.handlerWrapper(s.topContainer))
+	s.mux.Path("/containers/{id:.*}/logs").Methods("GET").HandlerFunc(s.handlerWrapper(s.logsContainer))
 	s.mux.Path("/containers/{id:.*}/start").Methods("POST").HandlerFunc(s.handlerWrapper(s.startContainer))
 	s.mux.Path("/containers/{id:.*}/kill").Methods("POST").HandlerFunc(s.handlerWrapper(s.stopContainer))
 	s.mux.Path("/containers/{id:.*}/stop").Methods("POST").HandlerFunc(s.handlerWrapper(s.stopContainer))
@@ -455,6 +456,19 @@ func (s *DockerServer) topContainer(w http.ResponseWriter, r *http.Request) {
 		},
 	}
 	json.NewEncoder(w).Encode(result)
+}
+
+func (s *DockerServer) logsContainer(w http.ResponseWriter, r *http.Request) {
+	id := mux.Vars(r)["id"]
+	_, _, err := s.findContainer(id)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+	outStream := newStdWriter(w, stdout)
+	w.Header().Add("Content-Type", "application/vnd.docker.raw-stream")
+	fmt.Fprintln(outStream, "log output")
+	fmt.Fprintln(outStream, "more log output")
 }
 
 func (s *DockerServer) startContainer(w http.ResponseWriter, r *http.Request) {

--- a/testing/server_test.go
+++ b/testing/server_test.go
@@ -517,6 +517,17 @@ func TestLogsContainer(t *testing.T) {
 	}
 }
 
+func TestLogsContainerNotFound(t *testing.T) {
+	server := DockerServer{}
+	server.buildMuxer()
+	recorder := httptest.NewRecorder()
+	request, _ := http.NewRequest("GET", "/containers/xyz/logs", nil)
+	server.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusNotFound {
+		t.Errorf("LogsContainer: wrong status. Want %d. Got %d.", http.StatusNotFound, recorder.Code)
+	}
+}
+
 func TestStartContainer(t *testing.T) {
 	server := DockerServer{}
 	addContainers(&server, 1)


### PR DESCRIPTION
Hi @fsouza,

I'd like some feedback on this one:

I wanted to test the logs endpoint on the test docker server, to ensure my code was operating correctly using `client.Logs(opts)`.

If I'm understanding correctly, the test server is writing out data using the code from [writer.go](https://github.com/fsouza/go-dockerclient/blob/master/testing/writer.go). It looks like that in order to read what the writer has written, I'd want to use the `stdCopy` function in stdcopy.go. Unfortunately, the `stdCopy` function is private in this repo.

I'm guessing it might be copied from docker themselves (https://github.com/docker/docker/blob/master/pkg/stdcopy/stdcopy.go) where its public. Perhaps you'd be okay with making `stdCopy` a public function in this repo so the test can strip off the extra docker bytes?

Anyway, besides any feedback you might have, I think there is room for a little more testing here.