### PR TITLE
Add blkio_stats to Stats struct

### DIFF
--- a/container.go
+++ b/container.go
@@ -596,8 +596,16 @@ type Stats struct {
 		Failcnt  int64 `json:"failcnt,omitempty" yaml:"failcnt,omitempty"`
 		Limit    int64 `json:"limit,omitempty" yaml:"limit,omitempty"`
 	} `json:"memory_stats,omitempty" yaml:"memory_stats,omitempty"`
-	// TODO(pedge): this is in the docker docs, but no data
-	//BlkioStats string `json:"blkio_stats,omitempty" yaml:"blkio_stats,omitempty"`
+	BlkioStats struct {
+		IOServiceBytesRecursive []BlkioStatsEntry `json:"io_service_bytes_recursive,omitempty" yaml:"io_service_bytes_recursive,omitempty"`
+		IOServicedRecursive     []BlkioStatsEntry `json:"io_serviced_recursive,omitempty" yaml:"io_serviced_recursive,omitempty"`
+		IOQueueRecursive        []BlkioStatsEntry `json:"io_queue_recursive,omitempty" yaml:"io_queue_recursive,omitempty"`
+		IOServiceTimeRecursive  []BlkioStatsEntry `json:"io_service_time_recursive,omitempty" yaml:"io_service_time_recursive,omitempty"`
+		IOWaitTimeRecursive     []BlkioStatsEntry `json:"io_wait_time_recursive,omitempty" yaml:"io_wait_time_recursive,omitempty"`
+		IOMergedRecursive       []BlkioStatsEntry `json:"io_merged_recursive,omitempty" yaml:"io_merged_recursive,omitempty"`
+		IOTimeRecursive         []BlkioStatsEntry `json:"io_time_recursive,omitempty" yaml:"io_time_recursive,omitempty"`
+		SectorsRecursive        []BlkioStatsEntry `json:"sectors_recursive,omitempty" yaml:"sectors_recursive,omitempty"`
+	} `json:"blkio_stats,omitempty" yaml:"blkio_stats,omitempty"`
 	CPUStats struct {
 		CPUUsage struct {
 			PercpuUsage       []int64 `json:"percpu_usage,omitempty" yaml:"percpu_usage,omitempty"`
@@ -609,6 +617,14 @@ type Stats struct {
 		// TODO(pedge): this is in the docker docs, but no data
 		//ThrottlingData string `json:"throttling_data,omitempty" yaml:"throttling_data,omitempty"`
 	} `json:"cpu_stats,omitempty" yaml:"cpu_stats,omitempty"`
+}
+
+// BlkioStatsEntry is a stats entry for blkio_stats
+type BlkioStatsEntry struct {
+	Major int    `json:"major,omitempty" yaml:"major,omitempty"`
+	Minor int    `json:"major,omitempty" yaml:"major,omitempty"`
+	Op    string `json:"op,omitempty" yaml:"op,omitempty"`
+	Value int64  `json:"value,omitempty" yaml:"value,omitempty"`
 }
 
 // StatsOptions specify parameters to the Stats function.

--- a/container_test.go
+++ b/container_test.go
@@ -1606,6 +1606,42 @@ func TestStats(t *testing.T) {
           "failcnt" : 0,
           "limit" : 67108864
        },
+       "blkio_stats": {
+          "io_service_bytes_recursive": [
+             {
+                "major": 8,
+                "minor": 0,
+                "op": "Read",
+                "value": 428795731968
+             },
+             {
+                "major": 8,
+                "minor": 0,
+                "op": "Write",
+                "value": 388177920
+             }
+          ],
+          "io_serviced_recursive": [
+             {
+                "major": 8,
+                "minor": 0,
+                "op": "Read",
+                "value": 25994442
+             },
+             {
+                "major": 8,
+                "minor": 0,
+                "op": "Write",
+                "value": 1734
+             }
+          ],
+          "io_queue_recursive": [],
+          "io_service_time_recursive": [],
+          "io_wait_time_recursive": [],
+          "io_merged_recursive": [],
+          "io_time_recursive": [],
+          "sectors_recursive": []
+       },
        "cpu_stats" : {
           "cpu_usage" : {
              "percpu_usage" : [
@@ -1669,6 +1705,42 @@ func TestStats(t *testing.T) {
           "usage" : 6537216,
           "failcnt" : 0,
           "limit" : 67108864
+       },
+       "blkio_stats": {
+          "io_service_bytes_recursive": [
+             {
+                "major": 8,
+                "minor": 0,
+                "op": "Read",
+                "value": 428795731968
+             },
+             {
+                "major": 8,
+                "minor": 0,
+                "op": "Write",
+                "value": 388177920
+             }
+          ],
+          "io_serviced_recursive": [
+             {
+                "major": 8,
+                "minor": 0,
+                "op": "Read",
+                "value": 25994442
+             },
+             {
+                "major": 8,
+                "minor": 0,
+                "op": "Write",
+                "value": 1734
+             }
+          ],
+          "io_queue_recursive": [],
+          "io_service_time_recursive": [],
+          "io_wait_time_recursive": [],
+          "io_merged_recursive": [],
+          "io_time_recursive": [],
+          "sectors_recursive": []
        },
        "cpu_stats" : {
           "cpu_usage" : {


### PR DESCRIPTION
I only have the following stats in 1.6.0:

```
~ λ curl -sN http://127.0.0.1:2375/containers/e2ae202a2a41/stats | head -n1 | jq .blkio_stats
```

```json
{
  "io_service_bytes_recursive": [
    {
      "major": 8,
      "minor": 0,
      "op": "Read",
      "value": 428795731968
    },
    {
      "major": 8,
      "minor": 0,
      "op": "Write",
      "value": 388177920
    },
    {
      "major": 8,
      "minor": 0,
      "op": "Sync",
      "value": 387575808
    },
    {
      "major": 8,
      "minor": 0,
      "op": "Async",
      "value": 428796334080
    },
    {
      "major": 8,
      "minor": 0,
      "op": "Total",
      "value": 429183909888
    }
  ],
  "io_serviced_recursive": [
    {
      "major": 8,
      "minor": 0,
      "op": "Read",
      "value": 25994442
    },
    {
      "major": 8,
      "minor": 0,
      "op": "Write",
      "value": 1734
    },
    {
      "major": 8,
      "minor": 0,
      "op": "Sync",
      "value": 1666
    },
    {
      "major": 8,
      "minor": 0,
      "op": "Async",
      "value": 25994510
    },
    {
      "major": 8,
      "minor": 0,
      "op": "Total",
      "value": 25996176
    }
  ],
  "io_queue_recursive": [],
  "io_service_time_recursive": [],
  "io_wait_time_recursive": [],
  "io_merged_recursive": [],
  "io_time_recursive": [],
  "sectors_recursive": []
}
```

All entries seem to have the [same structure](https://github.com/docker/libcontainer/blob/59eb58b640c4685265e9ff08734a3e8848a8232c/cgroups/fs/blkio.go#L166-L210).

I'm going to use that in [bobrik/collectd-docker](https://github.com/bobrik/collectd-docker).