### PR TITLE
Add resource isolation parameters to HostConfig.

### DIFF
--- a/container.go
+++ b/container.go
@@ -426,6 +426,10 @@ type HostConfig struct {
 	ReadonlyRootfs  bool                   `json:"ReadonlyRootfs,omitempty" yaml:"ReadonlyRootfs,omitempty"`
 	SecurityOpt     []string               `json:"SecurityOpt,omitempty" yaml:"SecurityOpt,omitempty"`
 	CgroupParent    string                 `json:"CgroupParent,omitempty" yaml:"CgroupParent,omitempty"`
+	Memory          int64                  `json:"Memory,omitempty" yaml:"Memory,omitempty"`
+	MemorySwap      int64                  `json:"MemorySwap,omitempty" yaml:"MemorySwap,omitempty"`
+	CPUShares       int64                  `json:"CpuShares,omitempty" yaml:"CpuShares,omitempty"`
+	CPUSet          string                 `json:"Cpuset,omitempty" yaml:"Cpuset,omitempty"`
 }
 
 // StartContainer starts a container, returning an error in case of failure.

--- a/container_test.go
+++ b/container_test.go
@@ -232,7 +232,9 @@ func TestInspectContainer(t *testing.T) {
                },
                "Links": null,
                "PublishAllPorts": false,
-               "CgroupParent": "/mesos"
+               "CgroupParent": "/mesos",
+               "Memory": 17179869184,
+               "MemorySwap": 34359738368
              }
 }`
 	var expected Container


### PR DESCRIPTION
This was moved in the v1.18 API. Current implementation is backwards and
forwards compatible, having the fields for older and newer versions of
the API.

Verified fix on new Docker API.

Fixes #285.