### PR TITLE
Add NewTLSClientInline, NewTLSVersionedClientInline

### DIFF
--- a/client.go
+++ b/client.go
@@ -153,6 +153,18 @@ func NewTLSClient(endpoint string, cert, key, ca string) (*Client, error) {
 	return client, nil
 }
 
+// NewTLSClientInline returns a Client instance ready for TLS communications with the givens
+// server endpoint, key and certificates (passed inline to the function as opposed to being
+// read from a local file). It will use the latest remote API version available in the server.
+func NewTLSClientInline(endpoint string, certPEMBlock, keyPEMBlock, caPEMCert []byte) (*Client, error) {
+	client, err := NewVersionedTLSClientInline(endpoint, certPEMBlock, keyPEMBlock, caPEMCert, "")
+	if err != nil {
+		return nil, err
+	}
+	client.SkipServerVersionCheck = true
+	return client, nil
+}
+
 // NewVersionedClient returns a Client instance ready for communication with
 // the given server endpoint, using a specific remote API version.
 func NewVersionedClient(endpoint string, apiVersionString string) (*Client, error) {
@@ -184,6 +196,25 @@ func NewVersionnedTLSClient(endpoint string, cert, key, ca, apiVersionString str
 // NewVersionedTLSClient returns a Client instance ready for TLS communications with the givens
 // server endpoint, key and certificates, using a specific remote API version.
 func NewVersionedTLSClient(endpoint string, cert, key, ca, apiVersionString string) (*Client, error) {
+	certPEMBlock, err := ioutil.ReadFile(cert)
+	if err != nil {
+		return nil, err
+	}
+	keyPEMBlock, err := ioutil.ReadFile(key)
+	if err != nil {
+		return nil, err
+	}
+	caPEMCert, err := ioutil.ReadFile(ca)
+	if err != nil {
+		return nil, err
+	}
+	return NewVersionedTLSClientInline(endpoint, certPEMBlock, keyPEMBlock, caPEMCert, apiVersionString)
+}
+
+// NewVersionedTLSClientInline returns a Client instance ready for TLS communications with the givens
+// server endpoint, key and certificates (passed inline to the function as opposed to being
+// read from a local file), using a specific remote API version.
+func NewVersionedTLSClientInline(endpoint string, certPEMBlock, keyPEMBlock, caPEMCert []byte, apiVersionString string) (*Client, error) {
 	u, err := parseEndpoint(endpoint, true)
 	if err != nil {
 		return nil, err
@@ -195,23 +226,19 @@ func NewVersionedTLSClient(endpoint string, cert, key, ca, apiVersionString stri
 			return nil, err
 		}
 	}
-	if cert == "" || key == "" {
-		return nil, errors.New("Both cert and key path are required")
+	if certPEMBlock == nil || keyPEMBlock == nil {
+		return nil, errors.New("Both cert and key are required")
 	}
-	tlsCert, err := tls.LoadX509KeyPair(cert, key)
+	tlsCert, err := tls.X509KeyPair(certPEMBlock, keyPEMBlock)
 	if err != nil {
 		return nil, err
 	}
 	tlsConfig := &tls.Config{Certificates: []tls.Certificate{tlsCert}}
-	if ca == "" {
+	if caPEMCert == nil {
 		tlsConfig.InsecureSkipVerify = true
 	} else {
-		cert, err := ioutil.ReadFile(ca)
-		if err != nil {
-			return nil, err
-		}
 		caPool := x509.NewCertPool()
-		if !caPool.AppendCertsFromPEM(cert) {
+		if !caPool.AppendCertsFromPEM(caPEMCert) {
 			return nil, errors.New("Could not add RootCA pem")
 		}
 		tlsConfig.RootCAs = caPool

--- a/client.go
+++ b/client.go
@@ -153,11 +153,11 @@ func NewTLSClient(endpoint string, cert, key, ca string) (*Client, error) {
 	return client, nil
 }
 
-// NewTLSClientInline returns a Client instance ready for TLS communications with the givens
+// NewTLSClientFromBytes returns a Client instance ready for TLS communications with the givens
 // server endpoint, key and certificates (passed inline to the function as opposed to being
 // read from a local file). It will use the latest remote API version available in the server.
-func NewTLSClientInline(endpoint string, certPEMBlock, keyPEMBlock, caPEMCert []byte) (*Client, error) {
-	client, err := NewVersionedTLSClientInline(endpoint, certPEMBlock, keyPEMBlock, caPEMCert, "")
+func NewTLSClientFromBytes(endpoint string, certPEMBlock, keyPEMBlock, caPEMCert []byte) (*Client, error) {
+	client, err := NewVersionedTLSClientFromBytes(endpoint, certPEMBlock, keyPEMBlock, caPEMCert, "")
 	if err != nil {
 		return nil, err
 	}
@@ -208,13 +208,13 @@ func NewVersionedTLSClient(endpoint string, cert, key, ca, apiVersionString stri
 	if err != nil {
 		return nil, err
 	}
-	return NewVersionedTLSClientInline(endpoint, certPEMBlock, keyPEMBlock, caPEMCert, apiVersionString)
+	return NewVersionedTLSClientFromBytes(endpoint, certPEMBlock, keyPEMBlock, caPEMCert, apiVersionString)
 }
 
-// NewVersionedTLSClientInline returns a Client instance ready for TLS communications with the givens
+// NewVersionedTLSClientFromBytes returns a Client instance ready for TLS communications with the givens
 // server endpoint, key and certificates (passed inline to the function as opposed to being
 // read from a local file), using a specific remote API version.
-func NewVersionedTLSClientInline(endpoint string, certPEMBlock, keyPEMBlock, caPEMCert []byte, apiVersionString string) (*Client, error) {
+func NewVersionedTLSClientFromBytes(endpoint string, certPEMBlock, keyPEMBlock, caPEMCert []byte, apiVersionString string) (*Client, error) {
 	u, err := parseEndpoint(endpoint, true)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This allows certificates and keys to be specified from byte slices instead of local file paths. This is really useful, for example, if go-dockerclient is used within a library that does not necessarily use local file storage - certificates could be stored in a secured database.

I'm not sure on the function name, but this is the best I could come up with. This function really is kind of necessary at least for me :)

This is how it is equivalent: https://golang.org/src/crypto/tls/tls.go?s=4745:4821#L160