### PR TITLE
Switch version call to using map[string]interface{} for API 1.19

### DIFF
--- a/client.go
+++ b/client.go
@@ -299,13 +299,15 @@ func (c *Client) getServerAPIVersionString() (version string, err error) {
 	if status != http.StatusOK {
 		return "", fmt.Errorf("Received unexpected status %d while trying to retrieve the server version", status)
 	}
-	var versionResponse map[string]string
+	var versionResponse map[string]interface{}
 	err = json.Unmarshal(body, &versionResponse)
 	if err != nil {
 		return "", err
 	}
-	version = versionResponse["ApiVersion"]
-	return version, nil
+	if version, ok := (versionResponse["ApiVersion"]).(string); ok {
+		return version, nil
+	}
+	return "", nil
 }
 
 type doOptions struct {


### PR DESCRIPTION
Docker 1.7, API 1.19 introduces a new fields for "Experimental":
false/true.  This means the response is not a map[string]string and
unmarshalling will fail.  We switch to map[string]interface{} to be
compatible with mixed types.

The Version() call in misc.go is not impacted by this as it returns an
Env.