### PR TITLE
Fix for blocked Body.Close()

### DIFF
--- a/image_test.go
+++ b/image_test.go
@@ -23,6 +23,7 @@ func newTestClient(rt *FakeRoundTripper) Client {
 	u, _ := parseEndpoint("http://localhost:4243", false)
 	client := Client{
 		HTTPClient:             &http.Client{Transport: rt},
+		transport:              &http.Transport{},
 		endpoint:               endpoint,
 		endpointURL:            u,
 		SkipServerVersionCheck: true,


### PR DESCRIPTION
This change fixes a bug that was preventing client.stream() from returning properly when the supplied writer closed.

The issue is that you cannont call Body.Close() until the entire body is read. Since this
is a streaming request, the end of the body is never reached unless we
close the connection from the client side.

Addresses #300 