### PR TITLE
Add signal channel to enable stopping periodic stats monitoring

### DIFF
--- a/container.go
+++ b/container.go
@@ -662,6 +662,8 @@ type StatsOptions struct {
 	ID     string
 	Stats  chan<- *Stats
 	Stream bool
+	// A flag that enables stopping the stats operation
+	Done <-chan bool
 }
 
 // Stats sends container statistics for the given container to the given channel.
@@ -669,7 +671,7 @@ type StatsOptions struct {
 // This function is blocking, similar to a streaming call for logs, and should be run
 // on a separate goroutine from the caller. Note that this function will block until
 // the given container is removed, not just exited. When finished, this function
-// will close the given channel.
+// will close the given channel. Alternatively, function can be stopped by signaling on the Done channel
 //
 // See http://goo.gl/DFMiYD for more details.
 func (c *Client) Stats(opts StatsOptions) (retErr error) {
@@ -678,9 +680,16 @@ func (c *Client) Stats(opts StatsOptions) (retErr error) {
 
 	defer func() {
 		close(opts.Stats)
-		if err := <-errC; err != nil && retErr == nil {
-			retErr = err
+
+		select {
+		case err := <-errC:
+			if err != nil && retErr == nil {
+				retErr = err
+			}
+		default:
+			// No errors
 		}
+
 		if err := readCloser.Close(); err != nil && retErr == nil {
 			retErr = err
 		}
@@ -715,6 +724,12 @@ func (c *Client) Stats(opts StatsOptions) (retErr error) {
 		}
 		opts.Stats <- stats
 		stats = new(Stats)
+		select {
+		case <-opts.Done:
+			readCloser.Close()
+		default:
+			// Continue
+		}
 	}
 	return nil
 }

--- a/container_test.go
+++ b/container_test.go
@@ -1810,8 +1810,9 @@ func TestStats(t *testing.T) {
 	client.SkipServerVersionCheck = true
 	errC := make(chan error, 1)
 	statsC := make(chan *Stats)
+	done := make(chan bool)
 	go func() {
-		errC <- client.Stats(StatsOptions{id, statsC, true})
+		errC <- client.Stats(StatsOptions{id, statsC, true, done})
 		close(errC)
 	}()
 	var resultStats []*Stats
@@ -1847,7 +1848,8 @@ func TestStats(t *testing.T) {
 func TestStatsContainerNotFound(t *testing.T) {
 	client := newTestClient(&FakeRoundTripper{message: "no such container", status: http.StatusNotFound})
 	statsC := make(chan *Stats)
-	err := client.Stats(StatsOptions{"abef348", statsC, true})
+	done := make(chan bool)
+	err := client.Stats(StatsOptions{"abef348", statsC, true, done})
 	expected := &NoSuchContainer{ID: "abef348"}
 	if !reflect.DeepEqual(err, expected) {
 		t.Errorf("Stats: Wrong error returned. Want %#v. Got %#v.", expected, err)


### PR DESCRIPTION
As part of our product we need the ability to start and stop stats
monitoring, it will be very helpful if we can use the native docker api.
Let me know if this implementation fits the design principals of this
library.