### PR TITLE
Issue http.ReadResponse hanging when running daemon with unix socket

### DIFF
--- a/container.go
+++ b/container.go
@@ -669,6 +669,8 @@ type StatsOptions struct {
 	Stream bool
 	// A flag that enables stopping the stats operation
 	Done <-chan bool
+	// Initial connection timeout
+	Timeout time.Duration
 }
 
 // Stats sends container statistics for the given container to the given channel.
@@ -705,6 +707,7 @@ func (c *Client) Stats(opts StatsOptions) (retErr error) {
 			rawJSONStream:  true,
 			useJSONDecoder: true,
 			stdout:         writeCloser,
+			timeout:        opts.Timeout,
 		})
 		if err != nil {
 			dockerError, ok := err.(*Error)


### PR DESCRIPTION
On several occasions, the stream method hanged for specific container
(the scenario also repro in the docker CLI when running docker stats on
a specific container).
I tracked this error to the http.ReadResponse method but didn't find the
exact root cause in the docker daemon.
Unfortunately, we can't just 'kill' the go-routines that wait for the
stream to arrive, so this code change contains a simple cancellation
mechanism using a timer.
Please let me know if you can think of another way of solving it.