### PR TITLE
Fix nil panic when fails to get response from unix socket

### DIFF
--- a/client.go
+++ b/client.go
@@ -345,7 +345,8 @@ func (c *Client) do(method, path string, doOptions doOptions) ([]byte, int, erro
 	protocol := c.endpointURL.Scheme
 	address := c.endpointURL.Path
 	if protocol == "unix" {
-		dial, err := net.Dial(protocol, address)
+		var dial net.Conn
+		dial, err = net.Dial(protocol, address)
 		if err != nil {
 			return nil, -1, err
 		}

--- a/client_test.go
+++ b/client_test.go
@@ -7,12 +7,14 @@ package docker
 import (
 	"fmt"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"net/url"
 	"reflect"
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestNewAPIClient(t *testing.T) {
@@ -321,6 +323,56 @@ func TestPingFailingWrongStatus(t *testing.T) {
 	expectedErrMsg := "API error (202): "
 	if err.Error() != expectedErrMsg {
 		t.Fatalf("Expected error to be %q, got: %q", expectedErrMsg, err.Error())
+	}
+}
+
+func TestPingErrorWithUnixSocket(t *testing.T) {
+	go func() {
+		li, err := net.Listen("unix", "/tmp/echo.sock")
+		defer li.Close()
+		if err != nil {
+			t.Fatalf("Expected to get listner, but failed: %#v", err)
+			return
+		}
+
+		fd, err := li.Accept()
+		if err != nil {
+			t.Fatalf("Expected to accept connection, but failed: %#v", err)
+			return
+		}
+
+		buf := make([]byte, 512)
+		nr, err := fd.Read(buf)
+
+		// Create invalid response message to occur error
+		data := buf[0:nr]
+		for i := 0; i < 10; i++ {
+			data[i] = 63
+		}
+
+		_, err = fd.Write(data)
+		if err != nil {
+			t.Fatalf("Expected to write to socket, but failed: %#v", err)
+		}
+
+		return
+	}()
+
+	// Wait for unix socket to listen
+	time.Sleep(10 * time.Millisecond)
+
+	endpoint := "unix:///tmp/echo.sock"
+	u, _ := parseEndpoint(endpoint, false)
+	client := Client{
+		HTTPClient:             http.DefaultClient,
+		endpoint:               endpoint,
+		endpointURL:            u,
+		SkipServerVersionCheck: true,
+	}
+
+	err := client.Ping()
+	if err == nil {
+		t.Fatal("Expected non nil error, got nil")
 	}
 }
 


### PR DESCRIPTION
From: https://github.com/fsouza/go-dockerclient/blob/master/client.go#L347
```
if protocol == "unix" {
		dial, err := net.Dial(protocol, address)
		if err != nil {
			return nil, -1, err
		}
		defer dial.Close()
		breader := bufio.NewReader(dial)
		err = req.Write(dial)
		if err != nil {
			return nil, -1, err
		}
		resp, err = http.ReadResponse(breader, req)
	} else {
		resp, err = c.HTTPClient.Do(req)
	}
	if err != nil {
		if strings.Contains(err.Error(), "connection refused") {
			return nil, -1, ErrConnectionRefused
		}
		return nil, -1, err
	}
	defer resp.Body.Close()
```

When `http.ReadResponse(breader, req)` return error, since `err` is re-declared on `dial, err := net.Dial(protocol, address)`, `err` is still nil on `if err != nil {`. So it panics on `defer resp.Body.Close()` because `resp` is nil. 

I fixed not to re-declare in `if` block, so it assigns the error to `err` properly.