### PR TITLE
Fix deadlock in disableEventMonitoring():eventState.Wait()

### DIFF
--- a/event.go
+++ b/event.go
@@ -168,6 +168,7 @@ func (eventState *eventMonitoringState) monitorEvents(c *Client) {
 		time.Sleep(10 * time.Millisecond)
 	}
 	if err = eventState.connectWithRetry(c); err != nil {
+		eventState.closeListeners()
 		eventState.terminate()
 	}
 	for eventState.isEnabled() {


### PR DESCRIPTION
Currently the following pseudo-example deadlocks when docker daemon is not running:

     events := make(chan *docker.APIEvents)
     dc, err := docker.NewClient() // no error here
     err = dc.AddEventListener(events) // no error here
     for ev := range events {
              // unreachable
     }
     // unreachable

The client hangs in monitorEvents→connectWithRetry/terminate→disableEventMonitoring→eventState.Wait