### PR TITLE
Update client.go

### DIFF
--- a/client.go
+++ b/client.go
@@ -245,7 +245,7 @@ func NewVersionedTLSClientFromBytes(endpoint string, certPEMBlock, keyPEMBlock, 
 		tlsConfig.RootCAs = caPool
 	}
 	tr := &http.Transport{
-		TLSClientConfig: tlsConfig,
+		TLSClientConfig:   tlsConfig,
 		DisableKeepAlives: true,
 	}
 	if err != nil {

--- a/client.go
+++ b/client.go
@@ -246,6 +246,7 @@ func NewVersionedTLSClientFromBytes(endpoint string, certPEMBlock, keyPEMBlock, 
 	}
 	tr := &http.Transport{
 		TLSClientConfig: tlsConfig,
+		DisableKeepAlives: true,
 	}
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Fixes #328 

I looked at the TLS client code and found the problem. At the bottom of NewVersionedTLSClientFromBytes() you create a Transport with the TLS configuration. Transport uses keep-alive by default and will leave that connection open waiting for another request, but since each call to NewTLSClient() creates another new Transport, the connections are never reused.

The simplest fix is to disable keep-alive in the TLS transport. This has no performance impact over the current implementation because it wasn't using keep-alive anyway. A more performant solution would be to cache the TLS transport based on `endpoint` to be reused on subsequent calls.