### PR TITLE
Add 'LogPath' property in the 'container' struct

### DIFF
--- a/container.go
+++ b/container.go
@@ -253,6 +253,7 @@ type Container struct {
 	ResolvConfPath string `json:"ResolvConfPath,omitempty" yaml:"ResolvConfPath,omitempty"`
 	HostnamePath   string `json:"HostnamePath,omitempty" yaml:"HostnamePath,omitempty"`
 	HostsPath      string `json:"HostsPath,omitempty" yaml:"HostsPath,omitempty"`
+	LogPath        string `json:"LogPath,omitempty" yaml:"LogPath,omitempty"`
 	Name           string `json:"Name,omitempty" yaml:"Name,omitempty"`
 	Driver         string `json:"Driver,omitempty" yaml:"Driver,omitempty"`
 

--- a/container.go
+++ b/container.go
@@ -949,6 +949,7 @@ type LogsOptions struct {
 	Follow       bool
 	Stdout       bool
 	Stderr       bool
+	Since        int64
 	Timestamps   bool
 	Tail         string
 


### PR DESCRIPTION
The 'LogPath' property was added since v1.18. Please add 'LogPath' property in the 'container' struct