### PR TITLE
listening should be in a goroutine

### DIFF
--- a/container.go
+++ b/container.go
@@ -726,11 +726,15 @@ func (c *Client) Stats(opts StatsOptions) (retErr error) {
 		close(errC)
 	}()
 
+	quit := make(chan struct{})
+	defer close(quit)
 	go func() {
 		// block here waiting for the signal to stop function
 		select {
 		case <-opts.Done:
 			readCloser.Close()
+		case <-quit:
+			return
 		}
 	}()
 


### PR DESCRIPTION
When I use function `Stats` I meet one problem. If the container dies(just exited, not removed yet) immediately after it starts, `Stats` will be blocked, now if I want it to stop, I send signal `true` to channel `opts.Done`, however the code never runs into `select`. So I think as a observer this should be running in a separated goroutine.