### PR TITLE
Add a note about vendoring for go1.5 in the readme

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -9,6 +9,13 @@ support for the extensions in the [Swarm API](https://docs.docker.com/swarm/API/
 
 For more details, check the [remote API documentation](http://docs.docker.com/en/latest/reference/api/docker_remote_api/).
 
+## Vendoring
+
+If you are having issues with Go 1.5 and have GO15VENDOREXPERIMENT set with an application that has go-dockerclient vendored,
+please update your vendoring of go-dockerclient :) We recently moved the `vendor` directory to `external` so that go-dockerclient
+is compatible with this configuration. See [338](https://github.com/fsouza/go-dockerclient/issues/338) and [339](https://github.com/fsouza/go-dockerclient/pull/339)
+for details.
+
 ## Example
 
 ```go

--- a/README.markdown
+++ b/README.markdown
@@ -11,7 +11,7 @@ For more details, check the [remote API documentation](http://docs.docker.com/en
 
 ## Vendoring
 
-If you are having issues with Go 1.5 and have GO15VENDOREXPERIMENT set with an application that has go-dockerclient vendored,
+If you are having issues with Go 1.5 and have `GO15VENDOREXPERIMENT` set with an application that has go-dockerclient vendored,
 please update your vendoring of go-dockerclient :) We recently moved the `vendor` directory to `external` so that go-dockerclient
 is compatible with this configuration. See [338](https://github.com/fsouza/go-dockerclient/issues/338) and [339](https://github.com/fsouza/go-dockerclient/pull/339)
 for details.


### PR DESCRIPTION
We're about to get a barrage of comments about this. Kubernetes is now updated but there's going to be a lot of users that are not yet and they're going to come to the project and wonder what is doing on. Adding this documentation for Now. Also re: https://github.com/fsouza/go-dockerclient/issues/348