### PR TITLE
Use the file as a io.Reader

### DIFF
--- a/image.go
+++ b/image.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -379,8 +378,7 @@ func (c *Client) ImportImage(opts ImportImageOptions) error {
 		if err != nil {
 			return err
 		}
-		b, err := ioutil.ReadAll(f)
-		opts.InputStream = bytes.NewBuffer(b)
+		opts.InputStream = f
 		opts.Source = "-"
 	}
 	return c.createImage(queryString(&opts), nil, opts.InputStream, opts.OutputStream, opts.RawJSONStream)


### PR DESCRIPTION
No need to read the whole file in memory and use a buffer, a file is already a
io.Reader