### PR TITLE
return error when attempting to start container with empty id

### DIFF
--- a/container.go
+++ b/container.go
@@ -482,6 +482,9 @@ type HostConfig struct {
 //
 // See http://goo.gl/iM5GYs for more details.
 func (c *Client) StartContainer(id string, hostConfig *HostConfig) error {
+	if id == "" {
+		return &NoSuchContainer{ID: id, Err: fmt.Errorf("empty container id")}
+	}
 	path := "/containers/" + id + "/start"
 	_, status, err := c.do("POST", path, doOptions{data: hostConfig, forceJSON: true})
 	if status == http.StatusNotFound {

--- a/container_test.go
+++ b/container_test.go
@@ -513,6 +513,9 @@ func TestCreateContainerWithHostConfig(t *testing.T) {
 func TestStartContainer(t *testing.T) {
 	fakeRT := &FakeRoundTripper{message: "", status: http.StatusOK}
 	client := newTestClient(fakeRT)
+	if err := client.StartContainer("", &HostConfig{}); err == nil {
+		t.Fatal("expected error on start container with empty id")
+	}
 	id := "4fa6e0f0c6786287e131c3852c58a2e01cc697a68231826813597e4994f1d6e2"
 	err := client.StartContainer(id, &HostConfig{})
 	if err != nil {


### PR DESCRIPTION
When attempting to start a container with "" as the container id, no error is returned. It's not clear that upstream can catch such an error since it is not a valid URL that gets generated.