### PR TITLE
Add Labels in APIContainers

### DIFF
--- a/container.go
+++ b/container.go
@@ -45,15 +45,16 @@ type APIPort struct {
 //
 // See http://goo.gl/QeFH7U for more details.
 type APIContainers struct {
-	ID         string    `json:"Id" yaml:"Id"`
-	Image      string    `json:"Image,omitempty" yaml:"Image,omitempty"`
-	Command    string    `json:"Command,omitempty" yaml:"Command,omitempty"`
-	Created    int64     `json:"Created,omitempty" yaml:"Created,omitempty"`
-	Status     string    `json:"Status,omitempty" yaml:"Status,omitempty"`
-	Ports      []APIPort `json:"Ports,omitempty" yaml:"Ports,omitempty"`
-	SizeRw     int64     `json:"SizeRw,omitempty" yaml:"SizeRw,omitempty"`
-	SizeRootFs int64     `json:"SizeRootFs,omitempty" yaml:"SizeRootFs,omitempty"`
-	Names      []string  `json:"Names,omitempty" yaml:"Names,omitempty"`
+	ID         string            `json:"Id" yaml:"Id"`
+	Image      string            `json:"Image,omitempty" yaml:"Image,omitempty"`
+	Command    string            `json:"Command,omitempty" yaml:"Command,omitempty"`
+	Created    int64             `json:"Created,omitempty" yaml:"Created,omitempty"`
+	Status     string            `json:"Status,omitempty" yaml:"Status,omitempty"`
+	Ports      []APIPort         `json:"Ports,omitempty" yaml:"Ports,omitempty"`
+	SizeRw     int64             `json:"SizeRw,omitempty" yaml:"SizeRw,omitempty"`
+	SizeRootFs int64             `json:"SizeRootFs,omitempty" yaml:"SizeRootFs,omitempty"`
+	Names      []string          `json:"Names,omitempty" yaml:"Names,omitempty"`
+	Labels     map[string]string `json:"Labels,omitempty" yaml:"Labels, omitempty"`
 }
 
 // ListContainers returns a slice of containers matching the given criteria.


### PR DESCRIPTION
Available since API 1.18

https://docs.docker.com/reference/api/docker_remote_api_v1.18/#list-containers