### PR TITLE
Volume API Methods

### DIFF
--- a/volume.go
+++ b/volume.go
@@ -4,12 +4,21 @@
 
 package docker
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+)
 
-// APIVolumes represents a volume.
+var (
+	ErrNoSuchVolume = errors.New("no such volume")
+	ErrVolumeInUse  = errors.New("volume in use and cannot be removed")
+)
+
+// Volume represents a volume.
 //
 // See https://goo.gl/FZA4BK for more details.
-type APIVolumes struct {
+type Volume struct {
 	Name       string `json:"Name" yaml:"Name"`
 	Driver     string `json:"Driver,omitempty" yaml:"Driver,omitempty"`
 	Mountpoint string `json:"Mountpoint,omitempty" yaml:"Mountpoint,omitempty"`
@@ -25,7 +34,7 @@ type ListVolumesOptions struct {
 // ListVolumes returns a list of available volumes in the server.
 //
 // See https://goo.gl/FZA4BK for more details.
-func (c *Client) ListVolumes(opts ListVolumesOptions) ([]APIVolumes, error) {
+func (c *Client) ListVolumes(opts ListVolumesOptions) ([]Volume, error) {
 	body, _, err := c.do("GET", "/volumes?"+queryString(opts), doOptions{})
 	if err != nil {
 		return nil, err
@@ -34,7 +43,7 @@ func (c *Client) ListVolumes(opts ListVolumesOptions) ([]APIVolumes, error) {
 	if err := json.Unmarshal(body, &m); err != nil {
 		return nil, err
 	}
-	var volumes []APIVolumes
+	var volumes []Volume
 	volumesJSON, ok := m["Volumes"]
 	if !ok {
 		return volumes, nil
@@ -47,4 +56,48 @@ func (c *Client) ListVolumes(opts ListVolumesOptions) ([]APIVolumes, error) {
 		return nil, err
 	}
 	return volumes, nil
+}
+
+type CreateVolumeOptions struct {
+	Name       string
+	Driver     string
+	DriverOpts map[string]string
+}
+
+func (c *Client) CreateVolume(opts CreateVolumeOptions) (*Volume, error) {
+	body, _, err := c.do("POST", "/volumes", doOptions{data: opts})
+	if err != nil {
+		return nil, err
+	}
+	var volume Volume
+	if err := json.Unmarshal(body, &volume); err != nil {
+		return nil, err
+	}
+	return &volume, nil
+}
+
+func (c *Client) InspectVolume(name string) (*Volume, error) {
+	body, status, err := c.do("GET", "/volumes/"+name, doOptions{})
+	if status == http.StatusNotFound {
+		return nil, ErrNoSuchVolume
+	}
+	if err != nil {
+		return nil, err
+	}
+	var volume Volume
+	if err := json.Unmarshal(body, &volume); err != nil {
+		return nil, err
+	}
+	return &volume, nil
+}
+
+func (c *Client) RemoveVolume(name string) error {
+	_, status, err := c.do("DELETE", "/volumes/"+name, doOptions{})
+	if status == http.StatusNotFound {
+		return ErrNoSuchVolume
+	}
+	if status == http.StatusConflict {
+		return ErrVolumeInUse
+	}
+	retur err
 }

--- a/volume.go
+++ b/volume.go
@@ -99,5 +99,5 @@ func (c *Client) RemoveVolume(name string) error {
 	if status == http.StatusConflict {
 		return ErrVolumeInUse
 	}
-	retur err
+	return err
 }

--- a/volume.go
+++ b/volume.go
@@ -22,6 +22,9 @@ type ListVolumesOptions struct {
 	Filters map[string][]string
 }
 
+// ListVolumes returns a list of available volumes in the server.
+//
+// See https://goo.gl/FZA4BK for more details.
 func (c *Client) ListVolumes(opts ListVolumesOptions) ([]APIVolumes, error) {
 	body, _, err := c.do("GET", "/volumes?"+queryString(opts), doOptions{})
 	if err != nil {

--- a/volume.go
+++ b/volume.go
@@ -11,8 +11,11 @@ import (
 )
 
 var (
+	// ErrNoSuchVolume is the error returned when the volume does not exist.
 	ErrNoSuchVolume = errors.New("no such volume")
-	ErrVolumeInUse  = errors.New("volume in use and cannot be removed")
+
+	// ErrVolumeInUse is the error returned when the volume requested to be removed is still in use.
+	ErrVolumeInUse = errors.New("volume in use and cannot be removed")
 )
 
 // Volume represents a volume.
@@ -58,12 +61,18 @@ func (c *Client) ListVolumes(opts ListVolumesOptions) ([]Volume, error) {
 	return volumes, nil
 }
 
+// CreateVolumeOptions specify parameters to the CreateVolume function.
+//
+// See https://goo.gl/pBUbZ9 for more details.
 type CreateVolumeOptions struct {
 	Name       string
 	Driver     string
 	DriverOpts map[string]string
 }
 
+// CreateVolume creates a volume on the server.
+//
+// See https://goo.gl/pBUbZ9 for more details.
 func (c *Client) CreateVolume(opts CreateVolumeOptions) (*Volume, error) {
 	body, _, err := c.do("POST", "/volumes", doOptions{data: opts})
 	if err != nil {
@@ -76,6 +85,9 @@ func (c *Client) CreateVolume(opts CreateVolumeOptions) (*Volume, error) {
 	return &volume, nil
 }
 
+// InspectVolume returns a volume by its name.
+//
+// See https://goo.gl/0g9A6i for more details.
 func (c *Client) InspectVolume(name string) (*Volume, error) {
 	body, status, err := c.do("GET", "/volumes/"+name, doOptions{})
 	if status == http.StatusNotFound {
@@ -91,6 +103,9 @@ func (c *Client) InspectVolume(name string) (*Volume, error) {
 	return &volume, nil
 }
 
+// RemoveVolume removes a volume by its name.
+//
+// See https://goo.gl/79GNQz for more details.
 func (c *Client) RemoveVolume(name string) error {
 	_, status, err := c.do("DELETE", "/volumes/"+name, doOptions{})
 	if status == http.StatusNotFound {

--- a/volume.go
+++ b/volume.go
@@ -1,0 +1,47 @@
+// Copyright 2015 go-dockerclient authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package docker
+
+import "encoding/json"
+
+// APIVolumes represents a volume.
+//
+// See https://goo.gl/FZA4BK for more details.
+type APIVolumes struct {
+	Name       string `json:"Name" yaml:"Name"`
+	Driver     string `json:"Driver,omitempty" yaml:"Driver,omitempty"`
+	Mountpoint string `json:"Mountpoint,omitempty" yaml:"Mountpoint,omitempty"`
+}
+
+// ListVolumesOptions specify parameters to the ListVolumes function.
+//
+// See https://goo.gl/FZA4BK for more details.
+type ListVolumesOptions struct {
+	Filters map[string][]string
+}
+
+func (c *Client) ListVolumes(opts ListVolumesOptions) ([]APIVolumes, error) {
+	body, _, err := c.do("GET", "/volumes?"+queryString(opts), doOptions{})
+	if err != nil {
+		return nil, err
+	}
+	m := make(map[string]interface{})
+	if err := json.Unmarshal(body, &m); err != nil {
+		return nil, err
+	}
+	var volumes []APIVolumes
+	volumesJSON, ok := m["Volumes"]
+	if !ok {
+		return volumes, nil
+	}
+	data, err := json.Marshal(volumesJSON)
+	if err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(data, &volumes); err != nil {
+		return nil, err
+	}
+	return volumes, nil
+}

--- a/volume_test.go
+++ b/volume_test.go
@@ -7,6 +7,7 @@ package docker
 import (
 	"encoding/json"
 	"net/http"
+	"net/url"
 	"reflect"
 	"testing"
 )
@@ -37,5 +38,40 @@ func TestListVolumes(t *testing.T) {
 	}
 	if !reflect.DeepEqual(images, expected) {
 		t.Errorf("ListVolumes: Wrong return value. Want %#v. Got %#v.", expected, images)
+	}
+}
+
+func TestRemoveVolume(t *testing.T) {
+	name := "test"
+	fakeRT := &FakeRoundTripper{message: "", status: http.StatusNoContent}
+	client := newTestClient(fakeRT)
+	err := client.RemoveVolume(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := fakeRT.requests[0]
+	expectedMethod := "DELETE"
+	if req.Method != expectedMethod {
+		t.Errorf("RemoveVolume(%q): Wrong HTTP method. Want %s. Got %s.", name, expectedMethod, req.Method)
+	}
+	u, _ := url.Parse(client.getURL("/volumes/" + name))
+	if req.URL.Path != u.Path {
+		t.Errorf("RemoveVolume(%q): Wrong request path. Want %q. Got %q.", name, u.Path, req.URL.Path)
+	}
+}
+
+func TestRemoveVolumeNotFound(t *testing.T) {
+	client := newTestClient(&FakeRoundTripper{message: "no such volume", status: http.StatusNotFound})
+	err := client.RemoveVolume("test:")
+	if err != ErrNoSuchVolume {
+		t.Errorf("RemoveVolume: wrong error. Want %#v. Got %#v.", ErrNoSuchVolume, err)
+	}
+}
+
+func TestRemoveVolumeInUse(t *testing.T) {
+	client := newTestClient(&FakeRoundTripper{message: "volume in use and cannot be removed", status: http.StatusConflict})
+	err := client.RemoveVolume("test:")
+	if err != ErrVolumeInUse {
+		t.Errorf("RemoveVolume: wrong error. Want %#v. Got %#v.", ErrVolumeInUse, err)
 	}
 }

--- a/volume_test.go
+++ b/volume_test.go
@@ -24,7 +24,7 @@ func TestListVolumes(t *testing.T) {
 		"Mountpoint": "/var/lib/docker/volumes/bar"
 	}
 ]`
-	body := `{ "Volumes":` + volumesData + ` }`
+	body := `{ "Volumes": ` + volumesData + ` }`
 	var expected []APIVolumes
 	err := json.Unmarshal([]byte(volumesData), &expected)
 	if err != nil {

--- a/volume_test.go
+++ b/volume_test.go
@@ -25,7 +25,7 @@ func TestListVolumes(t *testing.T) {
 	}
 ]`
 	body := `{ "Volumes": ` + volumesData + ` }`
-	var expected []APIVolumes
+	var expected []Volume
 	err := json.Unmarshal([]byte(volumesData), &expected)
 	if err != nil {
 		t.Fatal(err)

--- a/volume_test.go
+++ b/volume_test.go
@@ -1,0 +1,41 @@
+// Copyright 2015 go-dockerclient authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package docker
+
+import (
+	"encoding/json"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestListVolumes(t *testing.T) {
+	volumesData := `[
+	{
+		"Name": "tardis",
+		"Driver": "local",
+		"Mountpoint": "/var/lib/docker/volumes/tardis"
+	},
+	{
+		"Name": "foo",
+		"Driver": "bar",
+		"Mountpoint": "/var/lib/docker/volumes/bar"
+	}
+]`
+	body := `{ "Volumes":` + volumesData + ` }`
+	var expected []APIVolumes
+	err := json.Unmarshal([]byte(volumesData), &expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := newTestClient(&FakeRoundTripper{message: body, status: http.StatusOK})
+	images, err := client.ListVolumes(ListVolumesOptions{})
+	if err != nil {
+		t.Error(err)
+	}
+	if !reflect.DeepEqual(images, expected) {
+		t.Errorf("ListVolumes: Wrong return value. Want %#v. Got %#v.", expected, images)
+	}
+}


### PR DESCRIPTION
This is for https://github.com/docker/docker/pull/14242. @fsouza this is blazing new, and not even on the experimental.docker.com install yet (although probably will be in the next few days, when the date on https://apt.dockerproject.org/repo/ changes from August 26th to something newer, this will be there), but I need it for something I'm doing on the Pachyderm codebase - the goo.gl short links are directly to the documentation within https://github.com/docker/docker/blob/master/docs/reference/api/docker_remote_api_v1.21.md#24-volumes, but I will update those links without bothering you (ie without a PR :) ) when the documentation is up on docker's website, assumedly when 1.9.0 is released.