### PR TITLE
Fix build authentication header for API version >= 1.19

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -34,6 +34,10 @@ type AuthConfigurations struct {
 	Configs map[string]AuthConfiguration `json:"configs"`
 }
 
+// AuthConfigurations119 is used to serialize a set of AuthConfigurations
+// for Docker API >= 1.19.
+type AuthConfigurations119 map[string]AuthConfiguration
+
 // dockerConfig represents a registry authentation configuration from the
 // .dockercfg file.
 type dockerConfig struct {

--- a/client.go
+++ b/client.go
@@ -45,6 +45,8 @@ var (
 	ErrConnectionRefused = errors.New("cannot connect to Docker endpoint")
 
 	apiVersion112, _ = NewAPIVersion("1.12")
+
+	apiVersion119, _ = NewAPIVersion("1.19")
 )
 
 // APIVersion is an internal representation of a version of the Remote API.

--- a/image_test.go
+++ b/image_test.go
@@ -21,11 +21,13 @@ import (
 func newTestClient(rt *FakeRoundTripper) Client {
 	endpoint := "http://localhost:4243"
 	u, _ := parseEndpoint("http://localhost:4243", false)
+	testAPIVersion, _ := NewAPIVersion("1.17")
 	client := Client{
 		HTTPClient:             &http.Client{Transport: rt},
 		endpoint:               endpoint,
 		endpointURL:            u,
 		SkipServerVersionCheck: true,
+		serverAPIVersion:       testAPIVersion,
 	}
 	return client
 }


### PR DESCRIPTION
The format for the map used by Docker to read auth configs on the BuildImage API call has changed twice since Docker 1.6.x (API version 1.18):

In Docker 1.6.2 (API version 1.18), it uses this format:
```
{ "configs": { auth config map } }
```
Defined here: https://github.com/docker/docker/blob/v1.6.2/registry/auth.go#L37-L40
Decoded here: https://github.com/docker/docker/blob/v1.6.2/api/server/server.go#L1043

In Docker 1.7.0 (API version 1.19), it uses this format:
```
{ "auths": { auth config map } }
```
Defined here: https://github.com/docker/docker/blob/v1.7.0/cliconfig/config.go#L41-L45
Decoded here: https://github.com/docker/docker/blob/v1.7.0/api/server/server.go#L1218

In Docker 1.7.1 and later (still API version 1.19), it uses this format:
```
{ auth config map }
```
Decoded here: https://github.com/docker/docker/blob/v1.7.1/api/server/server.go#L1227

This PR allows go-dockerclient to support the most recent format based on detecting API version 1.19 and above. It ignores the format in Docker 1.7.0 since it was there only for a single version and it was quickly replaced in 1.7.1 (and there wasn't a change in API version)
