### PR TITLE
use net.Dialer instance to establish connections

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -366,6 +366,7 @@ func TestPingErrorWithUnixSocket(t *testing.T) {
 	u, _ := parseEndpoint(endpoint, false)
 	client := Client{
 		HTTPClient:             http.DefaultClient,
+		Dialer:                 &net.Dialer{},
 		endpoint:               endpoint,
 		endpointURL:            u,
 		SkipServerVersionCheck: true,

--- a/container_test.go
+++ b/container_test.go
@@ -1371,6 +1371,7 @@ func TestExportContainerViaUnixSocket(t *testing.T) {
 	u, _ := parseEndpoint(endpoint, false)
 	client := Client{
 		HTTPClient:             http.DefaultClient,
+		Dialer:                 &net.Dialer{},
 		endpoint:               endpoint,
 		endpointURL:            u,
 		SkipServerVersionCheck: true,

--- a/event.go
+++ b/event.go
@@ -5,7 +5,6 @@
 package docker
 
 import (
-	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -260,9 +259,9 @@ func (c *Client) eventHijack(startTime int64, eventChan chan *APIEvents, errChan
 	var dial net.Conn
 	var err error
 	if c.TLSConfig == nil {
-		dial, err = net.Dial(protocol, address)
+		dial, err = c.Dialer.Dial(protocol, address)
 	} else {
-		dial, err = tls.Dial(protocol, address, c.TLSConfig)
+		dial, err = tlsDialWithDialer(c.Dialer, protocol, address, c.TLSConfig)
 	}
 	if err != nil {
 		return err

--- a/image_test.go
+++ b/image_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -24,6 +25,7 @@ func newTestClient(rt *FakeRoundTripper) Client {
 	testAPIVersion, _ := NewAPIVersion("1.17")
 	client := Client{
 		HTTPClient:             &http.Client{Transport: rt},
+		Dialer:                 &net.Dialer{},
 		endpoint:               endpoint,
 		endpointURL:            u,
 		SkipServerVersionCheck: true,

--- a/tls.go
+++ b/tls.go
@@ -94,7 +94,3 @@ func tlsDialWithDialer(dialer *net.Dialer, network, addr string, config *tls.Con
 	// wrapper which holds both the TLS and raw connections.
 	return &tlsClientCon{conn, rawConn}, nil
 }
-
-func tlsDial(network, addr string, config *tls.Config) (net.Conn, error) {
-	return tlsDialWithDialer(new(net.Dialer), network, addr, config)
-}


### PR DESCRIPTION
A pointer to a net.Dialer is stored in the Client struct. This allow clients to override its value the same way it's currently possible with the http.Client.