### PR TITLE
Don't read HTTP entire response body unnecessarily

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -127,12 +127,10 @@ func (c *Client) AuthCheck(conf *AuthConfiguration) error {
 	if conf == nil {
 		return fmt.Errorf("conf is nil")
 	}
-	body, statusCode, err := c.do("POST", "/auth", doOptions{data: conf})
+	resp, err := c.do("POST", "/auth", doOptions{data: conf})
 	if err != nil {
 		return err
 	}
-	if statusCode > 400 {
-		return fmt.Errorf("auth error (%d): %s", statusCode, body)
-	}
+	resp.Body.Close()
 	return nil
 }

--- a/client_test.go
+++ b/client_test.go
@@ -5,6 +5,7 @@
 package docker
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -186,7 +187,12 @@ func TestGetURL(t *testing.T) {
 }
 
 func TestError(t *testing.T) {
-	err := newError(400, []byte("bad parameter"))
+	fakeBody := ioutil.NopCloser(bytes.NewBufferString("bad parameter"))
+	resp := &http.Response{
+		StatusCode: 400,
+		Body:       fakeBody,
+	}
+	err := newError(resp)
 	expected := Error{Status: 400, Message: "bad parameter"}
 	if !reflect.DeepEqual(expected, *err) {
 		t.Errorf("Wrong error type. Want %#v. Got %#v.", expected, *err)

--- a/container.go
+++ b/container.go
@@ -5,7 +5,6 @@
 package docker
 
 import (
-	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -61,13 +60,13 @@ type APIContainers struct {
 // See https://goo.gl/47a6tO for more details.
 func (c *Client) ListContainers(opts ListContainersOptions) ([]APIContainers, error) {
 	path := "/containers/json?" + queryString(opts)
-	body, _, err := c.do("GET", path, doOptions{})
+	resp, err := c.do("GET", path, doOptions{})
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 	var containers []APIContainers
-	err = json.Unmarshal(body, &containers)
-	if err != nil {
+	if err := json.NewDecoder(resp.Body).Decode(&containers); err != nil {
 		return nil, err
 	}
 	return containers, nil
@@ -306,8 +305,12 @@ type RenameContainerOptions struct {
 //
 // See https://goo.gl/laSOIy for more details.
 func (c *Client) RenameContainer(opts RenameContainerOptions) error {
-	_, _, err := c.do("POST", fmt.Sprintf("/containers/"+opts.ID+"/rename?%s", queryString(opts)), doOptions{})
-	return err
+	resp, err := c.do("POST", fmt.Sprintf("/containers/"+opts.ID+"/rename?%s", queryString(opts)), doOptions{})
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+	return nil
 }
 
 // InspectContainer returns information about a container by its ID.
@@ -315,16 +318,16 @@ func (c *Client) RenameContainer(opts RenameContainerOptions) error {
 // See https://goo.gl/RdIq0b for more details.
 func (c *Client) InspectContainer(id string) (*Container, error) {
 	path := "/containers/" + id + "/json"
-	body, status, err := c.do("GET", path, doOptions{})
-	if status == http.StatusNotFound {
-		return nil, &NoSuchContainer{ID: id}
-	}
+	resp, err := c.do("GET", path, doOptions{})
 	if err != nil {
+		if e, ok := err.(*Error); ok && e.Status == http.StatusNotFound {
+			return nil, &NoSuchContainer{ID: id}
+		}
 		return nil, err
 	}
+	defer resp.Body.Close()
 	var container Container
-	err = json.Unmarshal(body, &container)
-	if err != nil {
+	if err := json.NewDecoder(resp.Body).Decode(&container); err != nil {
 		return nil, err
 	}
 	return &container, nil
@@ -335,16 +338,16 @@ func (c *Client) InspectContainer(id string) (*Container, error) {
 // See https://goo.gl/9GsTIF for more details.
 func (c *Client) ContainerChanges(id string) ([]Change, error) {
 	path := "/containers/" + id + "/changes"
-	body, status, err := c.do("GET", path, doOptions{})
-	if status == http.StatusNotFound {
-		return nil, &NoSuchContainer{ID: id}
-	}
+	resp, err := c.do("GET", path, doOptions{})
 	if err != nil {
+		if e, ok := err.(*Error); ok && e.Status == http.StatusNotFound {
+			return nil, &NoSuchContainer{ID: id}
+		}
 		return nil, err
 	}
+	defer resp.Body.Close()
 	var changes []Change
-	err = json.Unmarshal(body, &changes)
-	if err != nil {
+	if err := json.NewDecoder(resp.Body).Decode(&changes); err != nil {
 		return nil, err
 	}
 	return changes, nil
@@ -365,7 +368,7 @@ type CreateContainerOptions struct {
 // See https://goo.gl/WxQzrr for more details.
 func (c *Client) CreateContainer(opts CreateContainerOptions) (*Container, error) {
 	path := "/containers/create?" + queryString(opts)
-	body, status, err := c.do(
+	resp, err := c.do(
 		"POST",
 		path,
 		doOptions{
@@ -379,18 +382,21 @@ func (c *Client) CreateContainer(opts CreateContainerOptions) (*Container, error
 		},
 	)
 
-	if status == http.StatusNotFound {
-		return nil, ErrNoSuchImage
+	if e, ok := err.(*Error); ok {
+		if e.Status == http.StatusNotFound {
+			return nil, ErrNoSuchImage
+		}
+		if e.Status == http.StatusConflict {
+			return nil, ErrContainerAlreadyExists
+		}
 	}
-	if status == http.StatusConflict {
-		return nil, ErrContainerAlreadyExists
-	}
+
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 	var container Container
-	err = json.Unmarshal(body, &container)
-	if err != nil {
+	if err := json.NewDecoder(resp.Body).Decode(&container); err != nil {
 		return nil, err
 	}
 
@@ -490,16 +496,17 @@ type HostConfig struct {
 // See https://goo.gl/MrBAJv for more details.
 func (c *Client) StartContainer(id string, hostConfig *HostConfig) error {
 	path := "/containers/" + id + "/start"
-	_, status, err := c.do("POST", path, doOptions{data: hostConfig, forceJSON: true})
-	if status == http.StatusNotFound {
-		return &NoSuchContainer{ID: id, Err: err}
-	}
-	if status == http.StatusNotModified {
-		return &ContainerAlreadyRunning{ID: id}
-	}
+	resp, err := c.do("POST", path, doOptions{data: hostConfig, forceJSON: true})
 	if err != nil {
+		if e, ok := err.(*Error); ok && e.Status == http.StatusNotFound {
+			return &NoSuchContainer{ID: id, Err: err}
+		}
 		return err
 	}
+	if resp.StatusCode == http.StatusNotModified {
+		return &ContainerAlreadyRunning{ID: id}
+	}
+	resp.Body.Close()
 	return nil
 }
 
@@ -509,16 +516,17 @@ func (c *Client) StartContainer(id string, hostConfig *HostConfig) error {
 // See https://goo.gl/USqsFt for more details.
 func (c *Client) StopContainer(id string, timeout uint) error {
 	path := fmt.Sprintf("/containers/%s/stop?t=%d", id, timeout)
-	_, status, err := c.do("POST", path, doOptions{})
-	if status == http.StatusNotFound {
-		return &NoSuchContainer{ID: id}
-	}
-	if status == http.StatusNotModified {
-		return &ContainerNotRunning{ID: id}
-	}
+	resp, err := c.do("POST", path, doOptions{})
 	if err != nil {
+		if e, ok := err.(*Error); ok && e.Status == http.StatusNotFound {
+			return &NoSuchContainer{ID: id}
+		}
 		return err
 	}
+	if resp.StatusCode == http.StatusNotModified {
+		return &ContainerNotRunning{ID: id}
+	}
+	resp.Body.Close()
 	return nil
 }
 
@@ -528,13 +536,14 @@ func (c *Client) StopContainer(id string, timeout uint) error {
 // See https://goo.gl/QzsDnz for more details.
 func (c *Client) RestartContainer(id string, timeout uint) error {
 	path := fmt.Sprintf("/containers/%s/restart?t=%d", id, timeout)
-	_, status, err := c.do("POST", path, doOptions{})
-	if status == http.StatusNotFound {
-		return &NoSuchContainer{ID: id}
-	}
+	resp, err := c.do("POST", path, doOptions{})
 	if err != nil {
+		if e, ok := err.(*Error); ok && e.Status == http.StatusNotFound {
+			return &NoSuchContainer{ID: id}
+		}
 		return err
 	}
+	resp.Body.Close()
 	return nil
 }
 
@@ -543,13 +552,14 @@ func (c *Client) RestartContainer(id string, timeout uint) error {
 // See https://goo.gl/OF7W9X for more details.
 func (c *Client) PauseContainer(id string) error {
 	path := fmt.Sprintf("/containers/%s/pause", id)
-	_, status, err := c.do("POST", path, doOptions{})
-	if status == http.StatusNotFound {
-		return &NoSuchContainer{ID: id}
-	}
+	resp, err := c.do("POST", path, doOptions{})
 	if err != nil {
+		if e, ok := err.(*Error); ok && e.Status == http.StatusNotFound {
+			return &NoSuchContainer{ID: id}
+		}
 		return err
 	}
+	resp.Body.Close()
 	return nil
 }
 
@@ -558,13 +568,14 @@ func (c *Client) PauseContainer(id string) error {
 // See https://goo.gl/7dwyPA for more details.
 func (c *Client) UnpauseContainer(id string) error {
 	path := fmt.Sprintf("/containers/%s/unpause", id)
-	_, status, err := c.do("POST", path, doOptions{})
-	if status == http.StatusNotFound {
-		return &NoSuchContainer{ID: id}
-	}
+	resp, err := c.do("POST", path, doOptions{})
 	if err != nil {
+		if e, ok := err.(*Error); ok && e.Status == http.StatusNotFound {
+			return &NoSuchContainer{ID: id}
+		}
 		return err
 	}
+	resp.Body.Close()
 	return nil
 }
 
@@ -587,15 +598,15 @@ func (c *Client) TopContainer(id string, psArgs string) (TopResult, error) {
 		args = fmt.Sprintf("?ps_args=%s", psArgs)
 	}
 	path := fmt.Sprintf("/containers/%s/top%s", id, args)
-	body, status, err := c.do("GET", path, doOptions{})
-	if status == http.StatusNotFound {
-		return result, &NoSuchContainer{ID: id}
-	}
+	resp, err := c.do("GET", path, doOptions{})
 	if err != nil {
+		if e, ok := err.(*Error); ok && e.Status == http.StatusNotFound {
+			return result, &NoSuchContainer{ID: id}
+		}
 		return result, err
 	}
-	err = json.Unmarshal(body, &result)
-	if err != nil {
+	defer resp.Body.Close()
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -799,13 +810,14 @@ type KillContainerOptions struct {
 // See https://goo.gl/hkS9i8 for more details.
 func (c *Client) KillContainer(opts KillContainerOptions) error {
 	path := "/containers/" + opts.ID + "/kill" + "?" + queryString(opts)
-	_, status, err := c.do("POST", path, doOptions{})
-	if status == http.StatusNotFound {
-		return &NoSuchContainer{ID: opts.ID}
-	}
+	resp, err := c.do("POST", path, doOptions{})
 	if err != nil {
+		if e, ok := err.(*Error); ok && e.Status == http.StatusNotFound {
+			return &NoSuchContainer{ID: opts.ID}
+		}
 		return err
 	}
+	resp.Body.Close()
 	return nil
 }
 
@@ -830,13 +842,14 @@ type RemoveContainerOptions struct {
 // See https://goo.gl/RQyX62 for more details.
 func (c *Client) RemoveContainer(opts RemoveContainerOptions) error {
 	path := "/containers/" + opts.ID + "?" + queryString(opts)
-	_, status, err := c.do("DELETE", path, doOptions{})
-	if status == http.StatusNotFound {
-		return &NoSuchContainer{ID: opts.ID}
-	}
+	resp, err := c.do("DELETE", path, doOptions{})
 	if err != nil {
+		if e, ok := err.(*Error); ok && e.Status == http.StatusNotFound {
+			return &NoSuchContainer{ID: opts.ID}
+		}
 		return err
 	}
+	resp.Body.Close()
 	return nil
 }
 
@@ -880,14 +893,15 @@ func (c *Client) CopyFromContainer(opts CopyFromContainerOptions) error {
 		return &NoSuchContainer{ID: opts.Container}
 	}
 	url := fmt.Sprintf("/containers/%s/copy", opts.Container)
-	body, status, err := c.do("POST", url, doOptions{data: opts})
-	if status == http.StatusNotFound {
-		return &NoSuchContainer{ID: opts.Container}
-	}
+	resp, err := c.do("POST", url, doOptions{data: opts})
 	if err != nil {
+		if e, ok := err.(*Error); ok && e.Status == http.StatusNotFound {
+			return &NoSuchContainer{ID: opts.Container}
+		}
 		return err
 	}
-	_, err = io.Copy(opts.OutputStream, bytes.NewBuffer(body))
+	defer resp.Body.Close()
+	_, err = io.Copy(opts.OutputStream, resp.Body)
 	return err
 }
 
@@ -896,16 +910,16 @@ func (c *Client) CopyFromContainer(opts CopyFromContainerOptions) error {
 //
 // See https://goo.gl/Gc1rge for more details.
 func (c *Client) WaitContainer(id string) (int, error) {
-	body, status, err := c.do("POST", "/containers/"+id+"/wait", doOptions{})
-	if status == http.StatusNotFound {
-		return 0, &NoSuchContainer{ID: id}
-	}
+	resp, err := c.do("POST", "/containers/"+id+"/wait", doOptions{})
 	if err != nil {
+		if e, ok := err.(*Error); ok && e.Status == http.StatusNotFound {
+			return 0, &NoSuchContainer{ID: id}
+		}
 		return 0, err
 	}
+	defer resp.Body.Close()
 	var r struct{ StatusCode int }
-	err = json.Unmarshal(body, &r)
-	if err != nil {
+	if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
 		return 0, err
 	}
 	return r.StatusCode, nil
@@ -928,16 +942,16 @@ type CommitContainerOptions struct {
 // See https://goo.gl/mqfoCw for more details.
 func (c *Client) CommitContainer(opts CommitContainerOptions) (*Image, error) {
 	path := "/commit?" + queryString(opts)
-	body, status, err := c.do("POST", path, doOptions{data: opts.Run})
-	if status == http.StatusNotFound {
-		return nil, &NoSuchContainer{ID: opts.Container}
-	}
+	resp, err := c.do("POST", path, doOptions{data: opts.Run})
 	if err != nil {
+		if e, ok := err.(*Error); ok && e.Status == http.StatusNotFound {
+			return nil, &NoSuchContainer{ID: opts.Container}
+		}
 		return nil, err
 	}
+	defer resp.Body.Close()
 	var image Image
-	err = json.Unmarshal(body, &image)
-	if err != nil {
+	if err := json.NewDecoder(resp.Body).Decode(&image); err != nil {
 		return nil, err
 	}
 	return &image, nil
@@ -1040,8 +1054,12 @@ func (c *Client) ResizeContainerTTY(id string, height, width int) error {
 	params := make(url.Values)
 	params.Set("h", strconv.Itoa(height))
 	params.Set("w", strconv.Itoa(width))
-	_, _, err := c.do("POST", "/containers/"+id+"/resize?"+params.Encode(), doOptions{})
-	return err
+	resp, err := c.do("POST", "/containers/"+id+"/resize?"+params.Encode(), doOptions{})
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+	return nil
 }
 
 // ExportContainerOptions is the set of parameters to the ExportContainer

--- a/container_test.go
+++ b/container_test.go
@@ -1437,9 +1437,8 @@ func TestPutContainerArchive(t *testing.T) {
 		InputStream: in,
 	}
 	err := client.PutContainerArchive("a123456", opts)
-
 	if err != nil {
-		t.Errorf("PutContainerArchive: caugh error %#v while copying to container, expected nil", err)
+		t.Errorf("PutContainerArchive: caught error %#v while uploading archive to container, expected nil", err)
 	}
 
 	req := fakeRT.requests[0]
@@ -1455,19 +1454,20 @@ func TestPutContainerArchive(t *testing.T) {
 }
 
 func TestCopyFromContainer(t *testing.T) {
-	content := "File content"
-	out := stdoutMock{bytes.NewBufferString(content)}
-	client := newTestClient(&FakeRoundTripper{status: http.StatusOK})
+	filecontent := "File content"
+	client := newTestClient(&FakeRoundTripper{message: filecontent, status: http.StatusOK})
+
+	var out bytes.Buffer
 	opts := CopyFromContainerOptions{
 		Container:    "a123456",
-		OutputStream: out,
+		OutputStream: &out,
 	}
 	err := client.CopyFromContainer(opts)
 	if err != nil {
-		t.Errorf("CopyFromContainer: caugh error %#v while copying from container, expected nil", err.Error())
+		t.Errorf("CopyFromContainer: caught error %#v while copying from container, expected nil", err.Error())
 	}
-	if out.String() != content {
-		t.Errorf("CopyFromContainer: wrong stdout. Want %#v. Got %#v.", content, out.String())
+	if out.String() != filecontent {
+		t.Errorf("CopyFromContainer: wrong stdout. Want %#v. Got %#v.", filecontent, out.String())
 	}
 }
 

--- a/exec.go
+++ b/exec.go
@@ -38,16 +38,16 @@ type CreateExecOptions struct {
 // See https://goo.gl/1KSIb7 for more details
 func (c *Client) CreateExec(opts CreateExecOptions) (*Exec, error) {
 	path := fmt.Sprintf("/containers/%s/exec", opts.Container)
-	body, status, err := c.do("POST", path, doOptions{data: opts})
-	if status == http.StatusNotFound {
-		return nil, &NoSuchContainer{ID: opts.Container}
-	}
+	resp, err := c.do("POST", path, doOptions{data: opts})
 	if err != nil {
+		if e, ok := err.(*Error); ok && e.Status == http.StatusNotFound {
+			return nil, &NoSuchContainer{ID: opts.Container}
+		}
 		return nil, err
 	}
+	defer resp.Body.Close()
 	var exec Exec
-	err = json.Unmarshal(body, &exec)
-	if err != nil {
+	if err := json.NewDecoder(resp.Body).Decode(&exec); err != nil {
 		return nil, err
 	}
 
@@ -90,13 +90,14 @@ func (c *Client) StartExec(id string, opts StartExecOptions) error {
 	path := fmt.Sprintf("/exec/%s/start", id)
 
 	if opts.Detach {
-		_, status, err := c.do("POST", path, doOptions{data: opts})
-		if status == http.StatusNotFound {
-			return &NoSuchExec{ID: id}
-		}
+		resp, err := c.do("POST", path, doOptions{data: opts})
 		if err != nil {
+			if e, ok := err.(*Error); ok && e.Status == http.StatusNotFound {
+				return &NoSuchExec{ID: id}
+			}
 			return err
 		}
+		defer resp.Body.Close()
 		return nil
 	}
 
@@ -121,8 +122,12 @@ func (c *Client) ResizeExecTTY(id string, height, width int) error {
 	params.Set("w", strconv.Itoa(width))
 
 	path := fmt.Sprintf("/exec/%s/resize?%s", id, params.Encode())
-	_, _, err := c.do("POST", path, doOptions{})
-	return err
+	resp, err := c.do("POST", path, doOptions{})
+	if err != nil {
+		resp.Body.Close()
+		return err
+	}
+	return nil
 }
 
 // ExecProcessConfig is a type describing the command associated to a Exec
@@ -156,16 +161,16 @@ type ExecInspect struct {
 // See https://goo.gl/gPtX9R for more details
 func (c *Client) InspectExec(id string) (*ExecInspect, error) {
 	path := fmt.Sprintf("/exec/%s/json", id)
-	body, status, err := c.do("GET", path, doOptions{})
-	if status == http.StatusNotFound {
-		return nil, &NoSuchExec{ID: id}
-	}
+	resp, err := c.do("GET", path, doOptions{})
 	if err != nil {
+		if e, ok := err.(*Error); ok && e.Status == http.StatusNotFound {
+			return nil, &NoSuchExec{ID: id}
+		}
 		return nil, err
 	}
+	defer resp.Body.Close()
 	var exec ExecInspect
-	err = json.Unmarshal(body, &exec)
-	if err != nil {
+	if err := json.NewDecoder(resp.Body).Decode(&exec); err != nil {
 		return nil, err
 	}
 	return &exec, nil

--- a/image.go
+++ b/image.go
@@ -96,13 +96,13 @@ type ListImagesOptions struct {
 // See https://goo.gl/xBe1u3 for more details.
 func (c *Client) ListImages(opts ListImagesOptions) ([]APIImages, error) {
 	path := "/images/json?" + queryString(opts)
-	body, _, err := c.do("GET", path, doOptions{})
+	resp, err := c.do("GET", path, doOptions{})
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 	var images []APIImages
-	err = json.Unmarshal(body, &images)
-	if err != nil {
+	if err := json.NewDecoder(resp.Body).Decode(&images); err != nil {
 		return nil, err
 	}
 	return images, nil
@@ -122,16 +122,16 @@ type ImageHistory struct {
 //
 // See https://goo.gl/8bnTId for more details.
 func (c *Client) ImageHistory(name string) ([]ImageHistory, error) {
-	body, status, err := c.do("GET", "/images/"+name+"/history", doOptions{})
-	if status == http.StatusNotFound {
-		return nil, ErrNoSuchImage
-	}
+	resp, err := c.do("GET", "/images/"+name+"/history", doOptions{})
 	if err != nil {
+		if e, ok := err.(*Error); ok && e.Status == http.StatusNotFound {
+			return nil, ErrNoSuchImage
+		}
 		return nil, err
 	}
+	defer resp.Body.Close()
 	var history []ImageHistory
-	err = json.Unmarshal(body, &history)
-	if err != nil {
+	if err := json.NewDecoder(resp.Body).Decode(&history); err != nil {
 		return nil, err
 	}
 	return history, nil
@@ -141,11 +141,15 @@ func (c *Client) ImageHistory(name string) ([]ImageHistory, error) {
 //
 // See https://goo.gl/V3ZWnK for more details.
 func (c *Client) RemoveImage(name string) error {
-	_, status, err := c.do("DELETE", "/images/"+name, doOptions{})
-	if status == http.StatusNotFound {
-		return ErrNoSuchImage
+	resp, err := c.do("DELETE", "/images/"+name, doOptions{})
+	if err != nil {
+		if e, ok := err.(*Error); ok && e.Status == http.StatusNotFound {
+			return ErrNoSuchImage
+		}
+		return err
 	}
-	return err
+	resp.Body.Close()
+	return nil
 }
 
 // RemoveImageOptions present the set of options available for removing an image
@@ -163,37 +167,40 @@ type RemoveImageOptions struct {
 // See https://goo.gl/V3ZWnK for more details.
 func (c *Client) RemoveImageExtended(name string, opts RemoveImageOptions) error {
 	uri := fmt.Sprintf("/images/%s?%s", name, queryString(&opts))
-	_, status, err := c.do("DELETE", uri, doOptions{})
-	if status == http.StatusNotFound {
-		return ErrNoSuchImage
+	resp, err := c.do("DELETE", uri, doOptions{})
+	if err != nil {
+		if e, ok := err.(*Error); ok && e.Status == http.StatusNotFound {
+			return ErrNoSuchImage
+		}
+		return err
 	}
-	return err
+	resp.Body.Close()
+	return nil
 }
 
 // InspectImage returns an image by its name or ID.
 //
 // See https://goo.gl/jHPcg6 for more details.
 func (c *Client) InspectImage(name string) (*Image, error) {
-	body, status, err := c.do("GET", "/images/"+name+"/json", doOptions{})
-	if status == http.StatusNotFound {
-		return nil, ErrNoSuchImage
-	}
+	resp, err := c.do("GET", "/images/"+name+"/json", doOptions{})
 	if err != nil {
+		if e, ok := err.(*Error); ok && e.Status == http.StatusNotFound {
+			return nil, ErrNoSuchImage
+		}
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var image Image
 
 	// if the caller elected to skip checking the server's version, assume it's the latest
 	if c.SkipServerVersionCheck || c.expectedAPIVersion.GreaterThanOrEqualTo(apiVersion112) {
-		err = json.Unmarshal(body, &image)
-		if err != nil {
+		if err := json.NewDecoder(resp.Body).Decode(&image); err != nil {
 			return nil, err
 		}
 	} else {
 		var imagePre012 ImagePre012
-		err = json.Unmarshal(body, &imagePre012)
-		if err != nil {
+		if err := json.NewDecoder(resp.Body).Decode(&imagePre012); err != nil {
 			return nil, err
 		}
 
@@ -477,10 +484,11 @@ func (c *Client) TagImage(name string, opts TagImageOptions) error {
 	if name == "" {
 		return ErrNoSuchImage
 	}
-	_, status, err := c.do("POST", fmt.Sprintf("/images/"+name+"/tag?%s",
+	resp, err := c.do("POST", fmt.Sprintf("/images/"+name+"/tag?%s",
 		queryString(&opts)), doOptions{})
+	defer resp.Body.Close()
 
-	if status == http.StatusNotFound {
+	if resp.StatusCode == http.StatusNotFound {
 		return ErrNoSuchImage
 	}
 
@@ -533,13 +541,13 @@ type APIImageSearch struct {
 //
 // See https://goo.gl/AYjyrF for more details.
 func (c *Client) SearchImages(term string) ([]APIImageSearch, error) {
-	body, _, err := c.do("GET", "/images/search?term="+term, doOptions{})
+	resp, err := c.do("GET", "/images/search?term="+term, doOptions{})
+	defer resp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
 	var searchResult []APIImageSearch
-	err = json.Unmarshal(body, &searchResult)
-	if err != nil {
+	if err := json.NewDecoder(resp.Body).Decode(&searchResult); err != nil {
 		return nil, err
 	}
 	return searchResult, nil

--- a/misc.go
+++ b/misc.go
@@ -4,21 +4,19 @@
 
 package docker
 
-import (
-	"bytes"
-	"strings"
-)
+import "strings"
 
 // Version returns version information about the docker server.
 //
 // See https://goo.gl/ND9R8L for more details.
 func (c *Client) Version() (*Env, error) {
-	body, _, err := c.do("GET", "/version", doOptions{})
+	resp, err := c.do("GET", "/version", doOptions{})
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 	var env Env
-	if err := env.Decode(bytes.NewReader(body)); err != nil {
+	if err := env.Decode(resp.Body); err != nil {
 		return nil, err
 	}
 	return &env, nil
@@ -28,13 +26,13 @@ func (c *Client) Version() (*Env, error) {
 //
 // See https://goo.gl/ElTHi2 for more details.
 func (c *Client) Info() (*Env, error) {
-	body, _, err := c.do("GET", "/info", doOptions{})
+	resp, err := c.do("GET", "/info", doOptions{})
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 	var info Env
-	err = info.Decode(bytes.NewReader(body))
-	if err != nil {
+	if err := info.Decode(resp.Body); err != nil {
 		return nil, err
 	}
 	return &info, nil


### PR DESCRIPTION
We ran into this problem where copying a large file from the container consumed a lot of memory.

I realize that the problem is because [`Client.do()` reads the entire HTTP response from the remote API](https://github.com/fsouza/go-dockerclient/blob/49c1b8c3ae297cdbddb0aad022b82c0480f92877/client.go#L422).

This is an unnecessary memory / allocation burden, so I've changed it to return the `*http.Response` and rely on callers to read / copy from / close the body as necessary.

Since I was trying to fix `CopyFromContainer`, I noticed that its test wasn't actually testing the contents of its output stream - I've fixed that too.