### PR TITLE
Don't read HTTP entire response body unnecessarily, take 2

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -127,12 +127,10 @@ func (c *Client) AuthCheck(conf *AuthConfiguration) error {
 	if conf == nil {
 		return fmt.Errorf("conf is nil")
 	}
-	body, statusCode, err := c.do("POST", "/auth", doOptions{data: conf})
+	resp, err := c.do("POST", "/auth", doOptions{data: conf})
 	if err != nil {
 		return err
 	}
-	if statusCode > 400 {
-		return fmt.Errorf("auth error (%d): %s", statusCode, body)
-	}
+	resp.Body.Close()
 	return nil
 }

--- a/client_test.go
+++ b/client_test.go
@@ -5,6 +5,7 @@
 package docker
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -186,7 +187,12 @@ func TestGetURL(t *testing.T) {
 }
 
 func TestError(t *testing.T) {
-	err := newError(400, []byte("bad parameter"))
+	fakeBody := ioutil.NopCloser(bytes.NewBufferString("bad parameter"))
+	resp := &http.Response{
+		StatusCode: 400,
+		Body:       fakeBody,
+	}
+	err := newError(resp)
 	expected := Error{Status: 400, Message: "bad parameter"}
 	if !reflect.DeepEqual(expected, *err) {
 		t.Errorf("Wrong error type. Want %#v. Got %#v.", expected, *err)

--- a/exec.go
+++ b/exec.go
@@ -38,16 +38,16 @@ type CreateExecOptions struct {
 // See https://goo.gl/1KSIb7 for more details
 func (c *Client) CreateExec(opts CreateExecOptions) (*Exec, error) {
 	path := fmt.Sprintf("/containers/%s/exec", opts.Container)
-	body, status, err := c.do("POST", path, doOptions{data: opts})
-	if status == http.StatusNotFound {
-		return nil, &NoSuchContainer{ID: opts.Container}
-	}
+	resp, err := c.do("POST", path, doOptions{data: opts})
 	if err != nil {
+		if e, ok := err.(*Error); ok && e.Status == http.StatusNotFound {
+			return nil, &NoSuchContainer{ID: opts.Container}
+		}
 		return nil, err
 	}
+	defer resp.Body.Close()
 	var exec Exec
-	err = json.Unmarshal(body, &exec)
-	if err != nil {
+	if err := json.NewDecoder(resp.Body).Decode(&exec); err != nil {
 		return nil, err
 	}
 
@@ -90,13 +90,14 @@ func (c *Client) StartExec(id string, opts StartExecOptions) error {
 	path := fmt.Sprintf("/exec/%s/start", id)
 
 	if opts.Detach {
-		_, status, err := c.do("POST", path, doOptions{data: opts})
-		if status == http.StatusNotFound {
-			return &NoSuchExec{ID: id}
-		}
+		resp, err := c.do("POST", path, doOptions{data: opts})
 		if err != nil {
+			if e, ok := err.(*Error); ok && e.Status == http.StatusNotFound {
+				return &NoSuchExec{ID: id}
+			}
 			return err
 		}
+		defer resp.Body.Close()
 		return nil
 	}
 
@@ -121,8 +122,12 @@ func (c *Client) ResizeExecTTY(id string, height, width int) error {
 	params.Set("w", strconv.Itoa(width))
 
 	path := fmt.Sprintf("/exec/%s/resize?%s", id, params.Encode())
-	_, _, err := c.do("POST", path, doOptions{})
-	return err
+	resp, err := c.do("POST", path, doOptions{})
+	if err != nil {
+		resp.Body.Close()
+		return err
+	}
+	return nil
 }
 
 // ExecProcessConfig is a type describing the command associated to a Exec
@@ -156,16 +161,16 @@ type ExecInspect struct {
 // See https://goo.gl/gPtX9R for more details
 func (c *Client) InspectExec(id string) (*ExecInspect, error) {
 	path := fmt.Sprintf("/exec/%s/json", id)
-	body, status, err := c.do("GET", path, doOptions{})
-	if status == http.StatusNotFound {
-		return nil, &NoSuchExec{ID: id}
-	}
+	resp, err := c.do("GET", path, doOptions{})
 	if err != nil {
+		if e, ok := err.(*Error); ok && e.Status == http.StatusNotFound {
+			return nil, &NoSuchExec{ID: id}
+		}
 		return nil, err
 	}
+	defer resp.Body.Close()
 	var exec ExecInspect
-	err = json.Unmarshal(body, &exec)
-	if err != nil {
+	if err := json.NewDecoder(resp.Body).Decode(&exec); err != nil {
 		return nil, err
 	}
 	return &exec, nil

--- a/exec.go
+++ b/exec.go
@@ -124,9 +124,9 @@ func (c *Client) ResizeExecTTY(id string, height, width int) error {
 	path := fmt.Sprintf("/exec/%s/resize?%s", id, params.Encode())
 	resp, err := c.do("POST", path, doOptions{})
 	if err != nil {
-		resp.Body.Close()
 		return err
 	}
+	resp.Body.Close()
 	return nil
 }
 

--- a/image.go
+++ b/image.go
@@ -96,13 +96,13 @@ type ListImagesOptions struct {
 // See https://goo.gl/xBe1u3 for more details.
 func (c *Client) ListImages(opts ListImagesOptions) ([]APIImages, error) {
 	path := "/images/json?" + queryString(opts)
-	body, _, err := c.do("GET", path, doOptions{})
+	resp, err := c.do("GET", path, doOptions{})
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 	var images []APIImages
-	err = json.Unmarshal(body, &images)
-	if err != nil {
+	if err := json.NewDecoder(resp.Body).Decode(&images); err != nil {
 		return nil, err
 	}
 	return images, nil
@@ -122,16 +122,16 @@ type ImageHistory struct {
 //
 // See https://goo.gl/8bnTId for more details.
 func (c *Client) ImageHistory(name string) ([]ImageHistory, error) {
-	body, status, err := c.do("GET", "/images/"+name+"/history", doOptions{})
-	if status == http.StatusNotFound {
-		return nil, ErrNoSuchImage
-	}
+	resp, err := c.do("GET", "/images/"+name+"/history", doOptions{})
 	if err != nil {
+		if e, ok := err.(*Error); ok && e.Status == http.StatusNotFound {
+			return nil, ErrNoSuchImage
+		}
 		return nil, err
 	}
+	defer resp.Body.Close()
 	var history []ImageHistory
-	err = json.Unmarshal(body, &history)
-	if err != nil {
+	if err := json.NewDecoder(resp.Body).Decode(&history); err != nil {
 		return nil, err
 	}
 	return history, nil
@@ -141,11 +141,15 @@ func (c *Client) ImageHistory(name string) ([]ImageHistory, error) {
 //
 // See https://goo.gl/V3ZWnK for more details.
 func (c *Client) RemoveImage(name string) error {
-	_, status, err := c.do("DELETE", "/images/"+name, doOptions{})
-	if status == http.StatusNotFound {
-		return ErrNoSuchImage
+	resp, err := c.do("DELETE", "/images/"+name, doOptions{})
+	if err != nil {
+		if e, ok := err.(*Error); ok && e.Status == http.StatusNotFound {
+			return ErrNoSuchImage
+		}
+		return err
 	}
-	return err
+	resp.Body.Close()
+	return nil
 }
 
 // RemoveImageOptions present the set of options available for removing an image
@@ -163,37 +167,40 @@ type RemoveImageOptions struct {
 // See https://goo.gl/V3ZWnK for more details.
 func (c *Client) RemoveImageExtended(name string, opts RemoveImageOptions) error {
 	uri := fmt.Sprintf("/images/%s?%s", name, queryString(&opts))
-	_, status, err := c.do("DELETE", uri, doOptions{})
-	if status == http.StatusNotFound {
-		return ErrNoSuchImage
+	resp, err := c.do("DELETE", uri, doOptions{})
+	if err != nil {
+		if e, ok := err.(*Error); ok && e.Status == http.StatusNotFound {
+			return ErrNoSuchImage
+		}
+		return err
 	}
-	return err
+	resp.Body.Close()
+	return nil
 }
 
 // InspectImage returns an image by its name or ID.
 //
 // See https://goo.gl/jHPcg6 for more details.
 func (c *Client) InspectImage(name string) (*Image, error) {
-	body, status, err := c.do("GET", "/images/"+name+"/json", doOptions{})
-	if status == http.StatusNotFound {
-		return nil, ErrNoSuchImage
-	}
+	resp, err := c.do("GET", "/images/"+name+"/json", doOptions{})
 	if err != nil {
+		if e, ok := err.(*Error); ok && e.Status == http.StatusNotFound {
+			return nil, ErrNoSuchImage
+		}
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var image Image
 
 	// if the caller elected to skip checking the server's version, assume it's the latest
 	if c.SkipServerVersionCheck || c.expectedAPIVersion.GreaterThanOrEqualTo(apiVersion112) {
-		err = json.Unmarshal(body, &image)
-		if err != nil {
+		if err := json.NewDecoder(resp.Body).Decode(&image); err != nil {
 			return nil, err
 		}
 	} else {
 		var imagePre012 ImagePre012
-		err = json.Unmarshal(body, &imagePre012)
-		if err != nil {
+		if err := json.NewDecoder(resp.Body).Decode(&imagePre012); err != nil {
 			return nil, err
 		}
 
@@ -477,10 +484,11 @@ func (c *Client) TagImage(name string, opts TagImageOptions) error {
 	if name == "" {
 		return ErrNoSuchImage
 	}
-	_, status, err := c.do("POST", fmt.Sprintf("/images/"+name+"/tag?%s",
+	resp, err := c.do("POST", fmt.Sprintf("/images/"+name+"/tag?%s",
 		queryString(&opts)), doOptions{})
+	defer resp.Body.Close()
 
-	if status == http.StatusNotFound {
+	if resp.StatusCode == http.StatusNotFound {
 		return ErrNoSuchImage
 	}
 
@@ -533,13 +541,13 @@ type APIImageSearch struct {
 //
 // See https://goo.gl/AYjyrF for more details.
 func (c *Client) SearchImages(term string) ([]APIImageSearch, error) {
-	body, _, err := c.do("GET", "/images/search?term="+term, doOptions{})
+	resp, err := c.do("GET", "/images/search?term="+term, doOptions{})
+	defer resp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
 	var searchResult []APIImageSearch
-	err = json.Unmarshal(body, &searchResult)
-	if err != nil {
+	if err := json.NewDecoder(resp.Body).Decode(&searchResult); err != nil {
 		return nil, err
 	}
 	return searchResult, nil

--- a/misc.go
+++ b/misc.go
@@ -4,21 +4,19 @@
 
 package docker
 
-import (
-	"bytes"
-	"strings"
-)
+import "strings"
 
 // Version returns version information about the docker server.
 //
 // See https://goo.gl/ND9R8L for more details.
 func (c *Client) Version() (*Env, error) {
-	body, _, err := c.do("GET", "/version", doOptions{})
+	resp, err := c.do("GET", "/version", doOptions{})
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 	var env Env
-	if err := env.Decode(bytes.NewReader(body)); err != nil {
+	if err := env.Decode(resp.Body); err != nil {
 		return nil, err
 	}
 	return &env, nil
@@ -28,13 +26,13 @@ func (c *Client) Version() (*Env, error) {
 //
 // See https://goo.gl/ElTHi2 for more details.
 func (c *Client) Info() (*Env, error) {
-	body, _, err := c.do("GET", "/info", doOptions{})
+	resp, err := c.do("GET", "/info", doOptions{})
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 	var info Env
-	err = info.Decode(bytes.NewReader(body))
-	if err != nil {
+	if err := info.Decode(resp.Body); err != nil {
 		return nil, err
 	}
 	return &info, nil


### PR DESCRIPTION
Fixes #379, follow up to the reverted #375.

`Client.do()` now does not read the entire HTTP response from the Docker remote API, since that is an unnecessary memory / allocation burden. Instead, it returns the `*http.Response` and relies on callers to read / copy from / close the body as necessary.

When connecting to Docker via UNIX domain socket, we use a fake `http.Client` that dials to the socket, thus fixing the issue reported in #378 where the underlying network connection was prematurely closed when the HTTP response (+headers) does not fit into the default 4096-byte buffer.