### PR TITLE
Add function SearchImagesEx to transfer authentication when search.

### DIFF
--- a/client.go
+++ b/client.go
@@ -375,6 +375,7 @@ func (c *Client) getServerAPIVersionString() (version string, err error) {
 type doOptions struct {
 	data      interface{}
 	forceJSON bool
+	headers   map[string]string
 }
 
 func (c *Client) do(method, path string, doOptions doOptions) (*http.Response, error) {
@@ -412,6 +413,10 @@ func (c *Client) do(method, path string, doOptions doOptions) (*http.Response, e
 		req.Header.Set("Content-Type", "application/json")
 	} else if method == "POST" {
 		req.Header.Set("Content-Type", "plain/text")
+	}
+
+	for k, v := range doOptions.headers {
+		req.Header.Set(k, v)
 	}
 
 	resp, err := httpClient.Do(req)

--- a/image.go
+++ b/image.go
@@ -552,3 +552,29 @@ func (c *Client) SearchImages(term string) ([]APIImageSearch, error) {
 	}
 	return searchResult, nil
 }
+
+// SearchImagesEx search the docker hub with a specific given term and authentication.
+//
+// See https://goo.gl/AYjyrF for more details.
+func (c *Client) SearchImagesEx(term string, auth AuthConfiguration) ([]APIImageSearch, error) {
+	headers, err := headersWithAuth(auth)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.do("GET", "/images/search?term="+term, doOptions{
+		headers: headers,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	var searchResult []APIImageSearch
+	if err := json.NewDecoder(resp.Body).Decode(&searchResult); err != nil {
+		return nil, err
+	}
+
+	return searchResult, nil
+}

--- a/image_test.go
+++ b/image_test.go
@@ -969,3 +969,44 @@ func TestSearchImages(t *testing.T) {
 		t.Errorf("SearchImages: Wrong return value. Want %#v. Got %#v.", expected, result)
 	}
 }
+
+func TestSearchImagesEx(t *testing.T) {
+	body := `[
+	{
+		"description":"A container with Cassandra 2.0.3",
+		"is_official":true,
+		"is_automated":true,
+		"name":"poklet/cassandra",
+		"star_count":17
+	},
+	{
+		"description":"A container with Cassandra 2.0.3",
+		"is_official":true,
+		"is_automated":false,
+		"name":"poklet/cassandra",
+		"star_count":17
+	}
+	,
+	{
+		"description":"A container with Cassandra 2.0.3",
+		"is_official":false,
+		"is_automated":true,
+		"name":"poklet/cassandra",
+		"star_count":17
+	}
+]`
+	var expected []APIImageSearch
+	err := json.Unmarshal([]byte(body), &expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := newTestClient(&FakeRoundTripper{message: body, status: http.StatusOK})
+	auth := AuthConfiguration{}
+	result, err := client.SearchImagesEx("cassandra", auth)
+	if err != nil {
+		t.Error(err)
+	}
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("SearchImages: Wrong return value. Want %#v. Got %#v.", expected, result)
+	}
+}


### PR DESCRIPTION
When calling search, there is no authentication information sent to hub.
Like docker client below:
1. docker login -u tester -p tester -e tester@test.com www.hub.com
2. docker search
docker client will send the authentication to hub also. 
But when we use the client which has login info to call SearchImages api, there is no auth header in the  http request. 
So, i add this function to transfer the authentication parameter to hub.