### PR TITLE
Add support for ulimits during build

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,6 +1,7 @@
 # This is the official list of go-dockerclient authors for copyright purposes.
 
 Adam Bell-Hanssen <adamb@aller.no>
+Adrien Kohlbecker <adrien.kohlbecker@gmail.com>
 Aldrin Leal <aldrin@leal.eng.br>
 Andreas Jaekle <andreas@jaekle.net>
 Andrews Medina <andrewsmedina@gmail.com>

--- a/image_test.go
+++ b/image_test.go
@@ -682,6 +682,7 @@ func TestBuildImageParameters(t *testing.T) {
 		Memswap:             2048,
 		CPUShares:           10,
 		CPUSetCPUs:          "0-3",
+		Ulimits:             []ULimit{ULimit{Name: "nofile", Soft: 100, Hard: 200}},
 		InputStream:         &buf,
 		OutputStream:        &buf,
 	}
@@ -701,6 +702,7 @@ func TestBuildImageParameters(t *testing.T) {
 		"memswap":    {"2048"},
 		"cpushares":  {"10"},
 		"cpusetcpus": {"0-3"},
+		"ulimits":    {"[{\"Name\":\"nofile\",\"Soft\":100,\"Hard\":200}]"},
 	}
 	got := map[string][]string(req.URL.Query())
 	if !reflect.DeepEqual(got, expected) {


### PR DESCRIPTION
Hello,

This adds support for the `ulimits` setting in `BuildImage()`
This parameter, while undocumented in the Remote API, is used by docker itself [here](https://github.com/docker/docker/blob/master/api/client/build.go#L261) to support the `--ulimits` argument to `docker build`.

I was not able to use `queryString()` for this as docker requires a JSON-encoded array and `queryString()` flattens the arrays.

Let me know what you think
Best
