### PR TITLE
add support for searching private registries fixes #389

### DIFF
--- a/client.go
+++ b/client.go
@@ -375,6 +375,7 @@ func (c *Client) getServerAPIVersionString() (version string, err error) {
 type doOptions struct {
 	data      interface{}
 	forceJSON bool
+	headers   map[string]string
 }
 
 func (c *Client) do(method, path string, doOptions doOptions) (*http.Response, error) {
@@ -412,6 +413,9 @@ func (c *Client) do(method, path string, doOptions doOptions) (*http.Response, e
 		req.Header.Set("Content-Type", "application/json")
 	} else if method == "POST" {
 		req.Header.Set("Content-Type", "plain/text")
+	}
+	for key, val := range doOptions.headers {
+		req.Header.Set(key, val)
 	}
 
 	resp, err := httpClient.Do(req)

--- a/image.go
+++ b/image.go
@@ -540,8 +540,14 @@ type APIImageSearch struct {
 // SearchImages search the docker hub with a specific given term.
 //
 // See https://goo.gl/AYjyrF for more details.
-func (c *Client) SearchImages(term string) ([]APIImageSearch, error) {
-	resp, err := c.do("GET", "/images/search?term="+term, doOptions{})
+func (c *Client) SearchImages(term string, auth AuthConfiguration) ([]APIImageSearch, error) {
+	headers, err := headersWithAuth(auth)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.do("GET", "/images/search?term="+term, doOptions{
+		headers: headers,
+	})
 	defer resp.Body.Close()
 	if err != nil {
 		return nil, err

--- a/image_test.go
+++ b/image_test.go
@@ -961,7 +961,7 @@ func TestSearchImages(t *testing.T) {
 		t.Fatal(err)
 	}
 	client := newTestClient(&FakeRoundTripper{message: body, status: http.StatusOK})
-	result, err := client.SearchImages("cassandra")
+	result, err := client.SearchImages("cassandra", AuthConfiguration{})
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
if found, send headers on GET requests

Change the SearchImages method to require authconfiguration. By passing
empty auth, it will still be able to search public images.

Searching works like this:
/image/search?term=nginx (Look for nginx in index.docker.io)
/image/search?term=quay.io/nginx (look for nginx in quay.io)

It is not possible to search private images on Docker Hub yet, but at
least this will ready the go-dockerclient when that is added!

Signed-off-by: Drew Wells <drew.wells00@gmail.com>