### PR TITLE
add error judgement to prevent exception.

### DIFF
--- a/image.go
+++ b/image.go
@@ -486,6 +486,11 @@ func (c *Client) TagImage(name string, opts TagImageOptions) error {
 	}
 	resp, err := c.do("POST", fmt.Sprintf("/images/"+name+"/tag?%s",
 		queryString(&opts)), doOptions{})
+
+	if err != nil {
+		return err
+	}
+
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusNotFound {


### PR DESCRIPTION
In client member function TagImage, add check err != nil before resp.Body.Close() is called, this will prevent the exception when err happens.