### PR TITLE
Export getDefaultDockerHost

### DIFF
--- a/client.go
+++ b/client.go
@@ -867,12 +867,12 @@ func getDockerEnv() (*dockerEnv, error) {
 
 func getDefaultDockerHost() (string, error) {
 	var defaultHost string
-	if runtime.GOOS != "windows" {
-		// If we do not have a host, default to unix socket
-		defaultHost = fmt.Sprintf("unix://%s", opts.DefaultUnixSocket)
-	} else {
+	if runtime.GOOS == "windows" {
 		// If we do not have a host, default to TCP socket on Windows
 		defaultHost = fmt.Sprintf("tcp://%s:%d", opts.DefaultHTTPHost, opts.DefaultHTTPPort)
+	} else {
+		// If we do not have a host, default to unix socket
+		defaultHost = fmt.Sprintf("unix://%s", opts.DefaultUnixSocket)
 	}
 	return opts.ValidateHost(defaultHost)
 }

--- a/client.go
+++ b/client.go
@@ -865,6 +865,7 @@ func getDockerEnv() (*dockerEnv, error) {
 	}, nil
 }
 
+// GetDefaultDockerHost returns the default docker socket for the current OS
 func GetDefaultDockerHost() (string, error) {
 	var defaultHost string
 	if runtime.GOOS == "windows" {

--- a/client.go
+++ b/client.go
@@ -837,7 +837,7 @@ func getDockerEnv() (*dockerEnv, error) {
 	dockerHost := os.Getenv("DOCKER_HOST")
 	var err error
 	if dockerHost == "" {
-		dockerHost, err = getDefaultDockerHost()
+		dockerHost, err = GetDefaultDockerHost()
 		if err != nil {
 			return nil, err
 		}
@@ -865,7 +865,7 @@ func getDockerEnv() (*dockerEnv, error) {
 	}, nil
 }
 
-func getDefaultDockerHost() (string, error) {
+func GetDefaultDockerHost() (string, error) {
 	var defaultHost string
 	if runtime.GOOS == "windows" {
 		// If we do not have a host, default to TCP socket on Windows

--- a/client.go
+++ b/client.go
@@ -837,7 +837,7 @@ func getDockerEnv() (*dockerEnv, error) {
 	dockerHost := os.Getenv("DOCKER_HOST")
 	var err error
 	if dockerHost == "" {
-		dockerHost, err = GetDefaultDockerHost()
+		dockerHost, err = DefaultDockerHost()
 		if err != nil {
 			return nil, err
 		}
@@ -865,8 +865,8 @@ func getDockerEnv() (*dockerEnv, error) {
 	}, nil
 }
 
-// GetDefaultDockerHost returns the default docker socket for the current OS
-func GetDefaultDockerHost() (string, error) {
+// DefaultDockerHost returns the default docker socket for the current OS
+func DefaultDockerHost() (string, error) {
 	var defaultHost string
 	if runtime.GOOS == "windows" {
 		// If we do not have a host, default to TCP socket on Windows


### PR DESCRIPTION
- Exported `getDefaultDockerHost()` so it can be used outside the library
- Inverted awkward `if` condition