### PR TITLE
Don't keep errChanIn hanging when closing

### DIFF
--- a/client.go
+++ b/client.go
@@ -623,6 +623,7 @@ func (c *Client) hijack(method, path string, hijackOptions hijackOptions) error 
 		defer func() {
 			if hijackOptions.in != nil {
 				if closer, ok := hijackOptions.in.(io.Closer); ok {
+					errChanIn <- nil
 					closer.Close()
 				}
 			}


### PR DESCRIPTION
Exiting an attached container waited for stdin and failed with:
"read dev/stdin: bad file descriptor".

See also issue #374