### PR TITLE
client: fixing TLS connection using env vars

### DIFF
--- a/client.go
+++ b/client.go
@@ -250,17 +250,17 @@ func NewVersionedClientFromEnv(apiVersionString string) (*Client, error) {
 	}
 	dockerHost := dockerEnv.dockerHost
 	if dockerEnv.dockerTLSVerify {
-		parts := strings.SplitN(dockerHost, "://", 2)
+		parts := strings.SplitN(dockerEnv.dockerHost, "://", 2)
 		if len(parts) != 2 {
 			return nil, fmt.Errorf("could not split %s into two parts by ://", dockerHost)
 		}
-		dockerHost = fmt.Sprintf("https://%s", parts[1])
+
 		cert := filepath.Join(dockerEnv.dockerCertPath, "cert.pem")
 		key := filepath.Join(dockerEnv.dockerCertPath, "key.pem")
 		ca := filepath.Join(dockerEnv.dockerCertPath, "ca.pem")
-		return NewVersionedTLSClient(dockerHost, cert, key, ca, apiVersionString)
+		return NewVersionedTLSClient(dockerEnv.dockerHost, cert, key, ca, apiVersionString)
 	}
-	return NewVersionedClient(dockerHost, apiVersionString)
+	return NewVersionedClient(dockerEnv.dockerHost, apiVersionString)
 }
 
 // NewVersionedTLSClientFromBytes returns a Client instance ready for TLS communications with the givens
@@ -818,7 +818,7 @@ func parseEndpoint(endpoint string, tls bool) (*url.URL, error) {
 		number, err := strconv.ParseInt(port, 10, 64)
 		if err == nil && number > 0 && number < 65536 {
 			if u.Scheme == "tcp" {
-				if number == 2376 {
+				if tls {
 					u.Scheme = "https"
 				} else {
 					u.Scheme = "http"


### PR DESCRIPTION
Using any variant of `NewClientFromEnv` the library has a different behaviour from the original docker client.

On docker if you set `DOCKER_HOST` to `tcp://localhost:2376` and `DOCKER_TLS_VERIFY` empty, try to connect to the `localhost` at port `2376` using HTTP, you must to set `DOCKER_TLS_VERIFY` to `1` to make the connection using TLS.


This is the output of  `docker ps` with the DOCKER_TLS_VERIFY var to empty, to a TLS server
````
docker ps                                                                                                    Fri Oct 16 20:43:05 CEST 2015
Get http://192.168.99.100:2376/v1.20/containers/json: malformed HTTP response "\x15\x03\x01\x00\x02\x02".
* Are you trying to connect to a TLS-enabled daemon without TLS?
```

The  `go-dockerclient` has a [condition](https://github.com/fsouza/go-dockerclient/blob/master/client.go#L821-L825) where checks if the port is `2376` and enforce the use of `https`