### PR TITLE
Remove use of http.DefaultClient

### DIFF
--- a/client.go
+++ b/client.go
@@ -191,7 +191,7 @@ func NewVersionedClient(endpoint string, apiVersionString string) (*Client, erro
 		}
 	}
 	return &Client{
-		HTTPClient:          http.DefaultClient,
+		HTTPClient:          &http.Client{},
 		Dialer:              &net.Dialer{},
 		endpoint:            endpoint,
 		endpointURL:         u,

--- a/client_test.go
+++ b/client_test.go
@@ -27,9 +27,6 @@ func TestNewAPIClient(t *testing.T) {
 	if client.endpoint != endpoint {
 		t.Errorf("Expected endpoint %s. Got %s.", endpoint, client.endpoint)
 	}
-	if client.HTTPClient != http.DefaultClient {
-		t.Errorf("Expected http.Client %#v. Got %#v.", http.DefaultClient, client.HTTPClient)
-	}
 	// test unix socket endpoints
 	endpoint = "unix:///var/run/docker.sock"
 	client, err = NewClient(endpoint)
@@ -79,9 +76,6 @@ func TestNewVersionedClient(t *testing.T) {
 	}
 	if client.endpoint != endpoint {
 		t.Errorf("Expected endpoint %s. Got %s.", endpoint, client.endpoint)
-	}
-	if client.HTTPClient != http.DefaultClient {
-		t.Errorf("Expected http.Client %#v. Got %#v.", http.DefaultClient, client.HTTPClient)
 	}
 	if reqVersion := client.requestedAPIVersion.String(); reqVersion != "1.12" {
 		t.Errorf("Wrong requestAPIVersion. Want %q. Got %q.", "1.12", reqVersion)
@@ -402,7 +396,7 @@ func TestPingErrorWithUnixSocket(t *testing.T) {
 	endpoint := "unix:///tmp/echo.sock"
 	u, _ := parseEndpoint(endpoint, false)
 	client := Client{
-		HTTPClient:             http.DefaultClient,
+		HTTPClient:             &http.Client{},
 		Dialer:                 &net.Dialer{},
 		endpoint:               endpoint,
 		endpointURL:            u,

--- a/container_test.go
+++ b/container_test.go
@@ -1371,7 +1371,7 @@ func TestExportContainerViaUnixSocket(t *testing.T) {
 	endpoint := "unix://" + tempSocket
 	u, _ := parseEndpoint(endpoint, false)
 	client := Client{
-		HTTPClient:             http.DefaultClient,
+		HTTPClient:             &http.Client{},
 		Dialer:                 &net.Dialer{},
 		endpoint:               endpoint,
 		endpointURL:            u,


### PR DESCRIPTION
http.DefaultClient in libraries can provide dangerous and unexpected
behavior. At HC in our projects we've seen race conditions, strange TLS
behavior, and more caused from various libraries making custom changes
after sourcing http.DefaultClient, affecting all other users in the
process.

Sharing state should be explicit; use an empty client and require
downstream users to explicitly set the client to a shared one if they
need that behavior.