### PR TITLE
Always send the nil signal on errChanIn when out ends

### DIFF
--- a/client.go
+++ b/client.go
@@ -615,9 +615,9 @@ func (c *Client) hijack(method, path string, hijackOptions hijackOptions) error 
 		defer func() {
 			if hijackOptions.in != nil {
 				if closer, ok := hijackOptions.in.(io.Closer); ok {
-					errChanIn <- nil
 					closer.Close()
 				}
+				errChanIn <- nil
 			}
 		}()
 		var err error


### PR DESCRIPTION
If the Docker server closes the out pipe and the hijackOptions.in sent to hijack was not a io.Closer then hijack hangs indefinitely.