### PR TITLE
Use cleanhttp instead of http.Client

### DIFF
--- a/client.go
+++ b/client.go
@@ -32,6 +32,7 @@ import (
 	"github.com/fsouza/go-dockerclient/external/github.com/docker/docker/opts"
 	"github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/homedir"
 	"github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/stdcopy"
+	"github.com/hashicorp/go-cleanhttp"
 )
 
 const userAgent = "go-dockerclient"
@@ -191,7 +192,7 @@ func NewVersionedClient(endpoint string, apiVersionString string) (*Client, erro
 		}
 	}
 	return &Client{
-		HTTPClient:          &http.Client{},
+		HTTPClient:          cleanhttp.DefaultClient(),
 		Dialer:              &net.Dialer{},
 		endpoint:            endpoint,
 		endpointURL:         u,
@@ -294,9 +295,8 @@ func NewVersionedTLSClientFromBytes(endpoint string, certPEMBlock, keyPEMBlock, 
 		}
 		tlsConfig.RootCAs = caPool
 	}
-	tr := &http.Transport{
-		TLSClientConfig: tlsConfig,
-	}
+	tr := cleanhttp.DefaultTransport()
+	tr.TLSClientConfig = tlsConfig
 	if err != nil {
 		return nil, err
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -18,6 +18,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/hashicorp/go-cleanhttp"
 )
 
 func TestNewAPIClient(t *testing.T) {
@@ -445,7 +447,7 @@ func TestPingErrorWithUnixSocket(t *testing.T) {
 	endpoint := "unix:///tmp/echo.sock"
 	u, _ := parseEndpoint(endpoint, false)
 	client := Client{
-		HTTPClient:             &http.Client{},
+		HTTPClient:             cleanhttp.DefaultClient(),
 		Dialer:                 &net.Dialer{},
 		endpoint:               endpoint,
 		endpointURL:            u,

--- a/container_test.go
+++ b/container_test.go
@@ -22,6 +22,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/hashicorp/go-cleanhttp"
 )
 
 func TestStateString(t *testing.T) {
@@ -1371,7 +1373,7 @@ func TestExportContainerViaUnixSocket(t *testing.T) {
 	endpoint := "unix://" + tempSocket
 	u, _ := parseEndpoint(endpoint, false)
 	client := Client{
-		HTTPClient:             &http.Client{},
+		HTTPClient:             cleanhttp.DefaultClient(),
 		Dialer:                 &net.Dialer{},
 		endpoint:               endpoint,
 		endpointURL:            u,


### PR DESCRIPTION
Unfortunately my previous commit overlooked that even in a fresh
http.Client{}, a shared DefaultTransport is used. We made a "cleanhttp"
library that makes it easy to get a clean client and/or transport that
still use the same default values as the Go standard library, so this
commit modifies my earlier changes to use that instead.