### PR TITLE
Fixed port mapping for container inspect API

### DIFF
--- a/container.go
+++ b/container.go
@@ -154,8 +154,8 @@ func (settings *NetworkSettings) PortMappingAPI() []APIPort {
 		p, _ := parsePort(port.Port())
 		if len(bindings) == 0 {
 			mapping = append(mapping, APIPort{
-				PublicPort: int64(p),
-				Type:       port.Proto(),
+				PrivatePort: int64(p),
+				Type:        port.Proto(),
 			})
 			continue
 		}


### PR DESCRIPTION
In container inspect api, if port mapping is private, i.e. not exported to the host system, then the code would mistakenly describe this port as public, and set its private counterpart to 0.