### PR TITLE
Extend NetworkSettings to include Networks introduced in Docker 1.9

### DIFF
--- a/container.go
+++ b/container.go
@@ -125,25 +125,38 @@ type PortBinding struct {
 // and its value as found in NetworkSettings should always be nil
 type PortMapping map[string]string
 
+// ContainerNetwork represents the networking settings of a container per network.
+type ContainerNetwork struct {
+	MacAddress          string `json:"MacAddress,omitempty" yaml:"MacAddress,omitempty"`
+	GlobalIPv6PrefixLen int    `json:"GlobalIPv6PrefixLen,omitempty" yaml:"GlobalIPv6PrefixLen,omitempty"`
+	GlobalIPv6Address   string `json:"GlobalIPv6Address,omitempty" yaml:"GlobalIPv6Address,omitempty"`
+	IPv6Gateway         string `json:"IPv6Gateway,omitempty" yaml:"IPv6Gateway,omitempty"`
+	IPPrefixLen         int    `json:"IPPrefixLen,omitempty" yaml:"IPPrefixLen,omitempty"`
+	IPAddress           string `json:"IPAddress,omitempty" yaml:"IPAddress,omitempty"`
+	Gateway             string `json:"Gateway,omitempty" yaml:"Gateway,omitempty"`
+	EndpointID          string `json:"EndpointID,omitempty" yaml:"EndpointID,omitempty"`
+}
+
 // NetworkSettings contains network-related information about a container
 type NetworkSettings struct {
-	IPAddress              string                 `json:"IPAddress,omitempty" yaml:"IPAddress,omitempty"`
-	IPPrefixLen            int                    `json:"IPPrefixLen,omitempty" yaml:"IPPrefixLen,omitempty"`
-	MacAddress             string                 `json:"MacAddress,omitempty" yaml:"MacAddress,omitempty"`
-	Gateway                string                 `json:"Gateway,omitempty" yaml:"Gateway,omitempty"`
-	Bridge                 string                 `json:"Bridge,omitempty" yaml:"Bridge,omitempty"`
-	PortMapping            map[string]PortMapping `json:"PortMapping,omitempty" yaml:"PortMapping,omitempty"`
-	Ports                  map[Port][]PortBinding `json:"Ports,omitempty" yaml:"Ports,omitempty"`
-	NetworkID              string                 `json:"NetworkID,omitempty" yaml:"NetworkID,omitempty"`
-	EndpointID             string                 `json:"EndpointID,omitempty" yaml:"EndpointID,omitempty"`
-	SandboxKey             string                 `json:"SandboxKey,omitempty" yaml:"SandboxKey,omitempty"`
-	GlobalIPv6Address      string                 `json:"GlobalIPv6Address,omitempty" yaml:"GlobalIPv6Address,omitempty"`
-	GlobalIPv6PrefixLen    int                    `json:"GlobalIPv6PrefixLen,omitempty" yaml:"GlobalIPv6PrefixLen,omitempty"`
-	IPv6Gateway            string                 `json:"IPv6Gateway,omitempty" yaml:"IPv6Gateway,omitempty"`
-	LinkLocalIPv6Address   string                 `json:"LinkLocalIPv6Address,omitempty" yaml:"LinkLocalIPv6Address,omitempty"`
-	LinkLocalIPv6PrefixLen int                    `json:"LinkLocalIPv6PrefixLen,omitempty" yaml:"LinkLocalIPv6PrefixLen,omitempty"`
-	SecondaryIPAddresses   []string               `json:"SecondaryIPAddresses,omitempty" yaml:"SecondaryIPAddresses,omitempty"`
-	SecondaryIPv6Addresses []string               `json:"SecondaryIPv6Addresses,omitempty" yaml:"SecondaryIPv6Addresses,omitempty"`
+	Networks               map[string]ContainerNetwork `json:"Networks,omitempty" yaml:"Networks,omitempty"`
+	IPAddress              string                      `json:"IPAddress,omitempty" yaml:"IPAddress,omitempty"`
+	IPPrefixLen            int                         `json:"IPPrefixLen,omitempty" yaml:"IPPrefixLen,omitempty"`
+	MacAddress             string                      `json:"MacAddress,omitempty" yaml:"MacAddress,omitempty"`
+	Gateway                string                      `json:"Gateway,omitempty" yaml:"Gateway,omitempty"`
+	Bridge                 string                      `json:"Bridge,omitempty" yaml:"Bridge,omitempty"`
+	PortMapping            map[string]PortMapping      `json:"PortMapping,omitempty" yaml:"PortMapping,omitempty"`
+	Ports                  map[Port][]PortBinding      `json:"Ports,omitempty" yaml:"Ports,omitempty"`
+	NetworkID              string                      `json:"NetworkID,omitempty" yaml:"NetworkID,omitempty"`
+	EndpointID             string                      `json:"EndpointID,omitempty" yaml:"EndpointID,omitempty"`
+	SandboxKey             string                      `json:"SandboxKey,omitempty" yaml:"SandboxKey,omitempty"`
+	GlobalIPv6Address      string                      `json:"GlobalIPv6Address,omitempty" yaml:"GlobalIPv6Address,omitempty"`
+	GlobalIPv6PrefixLen    int                         `json:"GlobalIPv6PrefixLen,omitempty" yaml:"GlobalIPv6PrefixLen,omitempty"`
+	IPv6Gateway            string                      `json:"IPv6Gateway,omitempty" yaml:"IPv6Gateway,omitempty"`
+	LinkLocalIPv6Address   string                      `json:"LinkLocalIPv6Address,omitempty" yaml:"LinkLocalIPv6Address,omitempty"`
+	LinkLocalIPv6PrefixLen int                         `json:"LinkLocalIPv6PrefixLen,omitempty" yaml:"LinkLocalIPv6PrefixLen,omitempty"`
+	SecondaryIPAddresses   []string                    `json:"SecondaryIPAddresses,omitempty" yaml:"SecondaryIPAddresses,omitempty"`
+	SecondaryIPv6Addresses []string                    `json:"SecondaryIPv6Addresses,omitempty" yaml:"SecondaryIPv6Addresses,omitempty"`
 }
 
 // PortMappingAPI translates the port mappings as contained in NetworkSettings

--- a/container_test.go
+++ b/container_test.go
@@ -265,6 +265,220 @@ func TestInspectContainer(t *testing.T) {
 	}
 }
 
+func TestInspectContainerNetwork(t *testing.T) {
+	jsonContainer := `{
+            "Id": "81e1bbe20b5508349e1c804eb08b7b6ca8366751dbea9f578b3ea0773fa66c1c",
+            "Created": "2015-11-12T14:54:04.791485659Z",
+            "Path": "consul-template",
+            "Args": [
+                "-config=/tmp/haproxy.json",
+                "-consul=192.168.99.120:8500"
+            ],
+            "State": {
+                "Status": "running",
+                "Running": true,
+                "Paused": false,
+                "Restarting": false,
+                "OOMKilled": false,
+                "Dead": false,
+                "Pid": 3196,
+                "ExitCode": 0,
+                "Error": "",
+                "StartedAt": "2015-11-12T14:54:05.026747471Z",
+                "FinishedAt": "0001-01-01T00:00:00Z"
+            },
+            "Image": "4921c5917fc117df3dec32f4c1976635dc6c56ccd3336fe1db3477f950e78bf7",
+            "ResolvConfPath": "/mnt/sda1/var/lib/docker/containers/81e1bbe20b5508349e1c804eb08b7b6ca8366751dbea9f578b3ea0773fa66c1c/resolv.conf",
+            "HostnamePath": "/mnt/sda1/var/lib/docker/containers/81e1bbe20b5508349e1c804eb08b7b6ca8366751dbea9f578b3ea0773fa66c1c/hostname",
+            "HostsPath": "/mnt/sda1/var/lib/docker/containers/81e1bbe20b5508349e1c804eb08b7b6ca8366751dbea9f578b3ea0773fa66c1c/hosts",
+            "LogPath": "/mnt/sda1/var/lib/docker/containers/81e1bbe20b5508349e1c804eb08b7b6ca8366751dbea9f578b3ea0773fa66c1c/81e1bbe20b5508349e1c804eb08b7b6ca8366751dbea9f578b3ea0773fa66c1c-json.log",
+            "Node": {
+                "ID": "AUIB:LFOT:3LSF:SCFS:OYDQ:NLXD:JZNE:4INI:3DRC:ZFBB:GWCY:DWJK",
+                "IP": "192.168.99.121",
+                "Addr": "192.168.99.121:2376",
+                "Name": "swl-demo1",
+                "Cpus": 1,
+                "Memory": 2099945472,
+                "Labels": {
+                    "executiondriver": "native-0.2",
+                    "kernelversion": "4.1.12-boot2docker",
+                    "operatingsystem": "Boot2Docker 1.9.0 (TCL 6.4); master : 16e4a2a - Tue Nov  3 19:49:22 UTC 2015",
+                    "provider": "virtualbox",
+                    "storagedriver": "aufs"
+                }
+            },
+            "Name": "/docker-proxy.swl-demo1",
+            "RestartCount": 0,
+            "Driver": "aufs",
+            "ExecDriver": "native-0.2",
+            "MountLabel": "",
+            "ProcessLabel": "",
+            "AppArmorProfile": "",
+            "ExecIDs": null,
+            "HostConfig": {
+                "Binds": null,
+                "ContainerIDFile": "",
+                "LxcConf": [],
+                "Memory": 0,
+                "MemoryReservation": 0,
+                "MemorySwap": 0,
+                "KernelMemory": 0,
+                "CpuShares": 0,
+                "CpuPeriod": 0,
+                "CpusetCpus": "",
+                "CpusetMems": "",
+                "CpuQuota": 0,
+                "BlkioWeight": 0,
+                "OomKillDisable": false,
+                "MemorySwappiness": -1,
+                "Privileged": false,
+                "PortBindings": {
+                    "443/tcp": [
+                        {
+                            "HostIp": "",
+                            "HostPort": "443"
+                        }
+                    ]
+                },
+                "Links": null,
+                "PublishAllPorts": false,
+                "Dns": null,
+                "DnsOptions": null,
+                "DnsSearch": null,
+                "ExtraHosts": null,
+                "VolumesFrom": null,
+                "Devices": [],
+                "NetworkMode": "swl-net",
+                "IpcMode": "",
+                "PidMode": "",
+                "UTSMode": "",
+                "CapAdd": null,
+                "CapDrop": null,
+                "GroupAdd": null,
+                "RestartPolicy": {
+                    "Name": "no",
+                    "MaximumRetryCount": 0
+                },
+                "SecurityOpt": null,
+                "ReadonlyRootfs": false,
+                "Ulimits": null,
+                "LogConfig": {
+                    "Type": "json-file",
+                    "Config": {}
+                },
+                "CgroupParent": "",
+                "ConsoleSize": [
+                    0,
+                    0
+                ],
+                "VolumeDriver": ""
+            },
+            "GraphDriver": {
+                "Name": "aufs",
+                "Data": null
+            },
+            "Mounts": [],
+            "Config": {
+                "Hostname": "81e1bbe20b55",
+                "Domainname": "",
+                "User": "",
+                "AttachStdin": false,
+                "AttachStdout": false,
+                "AttachStderr": false,
+                "ExposedPorts": {
+                    "443/tcp": {}
+                },
+                "Tty": false,
+                "OpenStdin": false,
+                "StdinOnce": false,
+                "Env": [
+                    "DOMAIN=local.auto",
+                    "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+                    "CONSUL_TEMPLATE_VERSION=0.11.1"
+                ],
+                "Cmd": [
+                    "-consul=192.168.99.120:8500"
+                ],
+                "Image": "docker-proxy:latest",
+                "Volumes": null,
+                "WorkingDir": "",
+                "Entrypoint": [
+                    "consul-template",
+                    "-config=/tmp/haproxy.json"
+                ],
+                "OnBuild": null,
+                "Labels": {},
+                "StopSignal": "SIGTERM"
+            },
+            "NetworkSettings": {
+                "Bridge": "",
+                "SandboxID": "c6b903dc5c1a96113a22dbc44709e30194079bd2d262eea1eb4f38d85821f6e1",
+                "HairpinMode": false,
+                "LinkLocalIPv6Address": "",
+                "LinkLocalIPv6PrefixLen": 0,
+                "Ports": {
+                    "443/tcp": [
+                        {
+                            "HostIp": "192.168.99.121",
+                            "HostPort": "443"
+                        }
+                    ]
+                },
+                "SandboxKey": "/var/run/docker/netns/c6b903dc5c1a",
+                "SecondaryIPAddresses": null,
+                "SecondaryIPv6Addresses": null,
+                "EndpointID": "",
+                "Gateway": "",
+                "GlobalIPv6Address": "",
+                "GlobalIPv6PrefixLen": 0,
+                "IPAddress": "",
+                "IPPrefixLen": 0,
+                "IPv6Gateway": "",
+                "MacAddress": "",
+                "Networks": {
+                    "swl-net": {
+                        "EndpointID": "683e3092275782a53c3b0968cc7e3a10f23264022ded9cb20490902f96fc5981",
+                        "Gateway": "",
+                        "IPAddress": "10.0.0.3",
+                        "IPPrefixLen": 24,
+                        "IPv6Gateway": "",
+                        "GlobalIPv6Address": "",
+                        "GlobalIPv6PrefixLen": 0,
+                        "MacAddress": "02:42:0a:00:00:03"
+                    }
+                }
+            }
+}`
+
+	fakeRT := &FakeRoundTripper{message: jsonContainer, status: http.StatusOK}
+	client := newTestClient(fakeRT)
+	id := "81e1bbe20b55"
+	exp := "10.0.0.3"
+
+	container, err := client.InspectContainer(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s := reflect.Indirect(reflect.ValueOf(container.NetworkSettings))
+	networks := s.FieldByName("Networks")
+	if networks.IsValid() {
+		var ip string
+		for _, net := range networks.MapKeys() {
+			if net.Interface().(string) == container.HostConfig.NetworkMode {
+				ip = networks.MapIndex(net).FieldByName("IPAddress").Interface().(string)
+				t.Logf("%s %v", net, ip)
+			}
+		}
+		if ip != exp {
+			t.Errorf("InspectContainerNetworks(%q): Expected %#v. Got %#v.", id, exp, ip)
+		}
+	} else {
+		t.Errorf("InspectContainerNetworks(%q): No method Networks for NetworkSettings", id)
+	}
+
+}
+
 func TestInspectContainerNegativeSwap(t *testing.T) {
 	jsonContainer := `{
              "Id": "4fa6e0f0c6786287e131c3852c58a2e01cc697a68231826813597e4994f1d6e2",


### PR DESCRIPTION
DEPRECATE following container NetworkSettings fields in API v1.21:
EndpointID, Gateway, GlobalIPv6Address, GlobalIPv6PrefixLen, IPAddress, IPPrefixLen, IPv6Gateway and MacAddress.
Those are now specific to the bridge network. Use NetworkSettings.Networks to inspect the networking settings of a container per network