### PR TITLE
If there is no scheme in the endpoint, use tcp, to match docker cli behaviour

### DIFF
--- a/client.go
+++ b/client.go
@@ -793,6 +793,9 @@ func (e *Error) Error() string {
 }
 
 func parseEndpoint(endpoint string, tls bool) (*url.URL, error) {
+	if !string.Contains(endpoint, "://") {
+		endpoint = "tcp://" + endpoint
+	}
 	u, err := url.Parse(endpoint)
 	if err != nil {
 		return nil, ErrInvalidEndpoint


### PR DESCRIPTION
Happy to add a test if you think it's necessary.