### PR TITLE
Fix volume creation API

### DIFF
--- a/volume.go
+++ b/volume.go
@@ -75,7 +75,7 @@ type CreateVolumeOptions struct {
 //
 // See https://goo.gl/pBUbZ9 for more details.
 func (c *Client) CreateVolume(opts CreateVolumeOptions) (*Volume, error) {
-	resp, err := c.do("POST", "/volumes", doOptions{data: opts})
+	resp, err := c.do("POST", "/volumes/create", doOptions{data: opts})
 	if err != nil {
 		return nil, err
 	}

--- a/volume_test.go
+++ b/volume_test.go
@@ -72,7 +72,7 @@ func TestCreateVolume(t *testing.T) {
 	if req.Method != expectedMethod {
 		t.Errorf("CreateVolume(): Wrong HTTP method. Want %s. Got %s.", expectedMethod, req.Method)
 	}
-	u, _ := url.Parse(client.getURL("/volumes"))
+	u, _ := url.Parse(client.getURL("/volumes/create"))
 	if req.URL.Path != u.Path {
 		t.Errorf("CreateVolume(): Wrong request path. Want %q. Got %q.", u.Path, req.URL.Path)
 	}


### PR DESCRIPTION
When volume creation transitioned from experimental to
supported in 1.9, the API changed slightly.
Reference: https://goo.gl/pBUbZ9

Signed-off-by: Daniel Hiltgen <daniel.hiltgen@docker.com>