### PR TITLE
Fix network structs for Docker 1.9

### DIFF
--- a/network.go
+++ b/network.go
@@ -17,21 +17,25 @@ var ErrNetworkAlreadyExists = errors.New("network already exists")
 
 // Network represents a network.
 //
-// See https://goo.gl/FDkCdQ for more details.
+// See https://goo.gl/1kmPKZ for more details.
 type Network struct {
-	Name      string      `json:"name"`
-	ID        string      `json:"id"`
-	Type      string      `json:"type"`
-	Endpoints []*Endpoint `json:"endpoints"`
+	Name       string
+	ID         string `json:"Id"`
+	Scope      string
+	Driver     string
+	Containers map[string]Endpoint
+	Options    map[string]string
 }
 
-// Endpoint represents an endpoint.
+// Endpoint contains network resources allocated and used for a container in a network
 //
-// See https://goo.gl/FDkCdQ for more details.
+// See https://goo.gl/1kmPKZ for more details.
 type Endpoint struct {
-	Name    string `json:"name"`
-	ID      string `json:"id"`
-	Network string `json:"network"`
+	Name        string
+	ID          string `json:"EndpointID"`
+	MacAddress  string
+	IPv4Address string
+	IPv6Address string
 }
 
 // ListNetworks returns all networks.
@@ -113,7 +117,7 @@ func (c *Client) CreateNetwork(opts CreateNetworkOptions) (*Network, error) {
 
 	network.Name = opts.Name
 	network.ID = cnr.ID
-	network.Type = opts.Driver
+	network.Driver = opts.Driver
 
 	return &network, nil
 }

--- a/network.go
+++ b/network.go
@@ -40,7 +40,7 @@ type Endpoint struct {
 
 // ListNetworks returns all networks.
 //
-// See https://goo.gl/4hCNtZ for more details.
+// See https://goo.gl/1kmPKZ for more details.
 func (c *Client) ListNetworks() ([]Network, error) {
 	resp, err := c.do("GET", "/networks", doOptions{})
 	if err != nil {
@@ -56,7 +56,7 @@ func (c *Client) ListNetworks() ([]Network, error) {
 
 // NetworkInfo returns information about a network by its ID.
 //
-// See https://goo.gl/4hCNtZ for more details.
+// See https://goo.gl/1kmPKZ for more details.
 func (c *Client) NetworkInfo(id string) (*Network, error) {
 	path := "/networks/" + id
 	resp, err := c.do("GET", path, doOptions{})
@@ -87,7 +87,7 @@ type CreateNetworkOptions struct {
 // CreateNetwork creates a new network, returning the network instance,
 // or an error in case of failure.
 //
-// See https://goo.gl/FDkCdQ for more details.
+// See https://goo.gl/1kmPKZ for more details.
 func (c *Client) CreateNetwork(opts CreateNetworkOptions) (*Network, error) {
 	resp, err := c.do(
 		"POST",
@@ -124,7 +124,7 @@ func (c *Client) CreateNetwork(opts CreateNetworkOptions) (*Network, error) {
 
 // RemoveNetwork removes a network or an error in case of failure.
 //
-// See https://goo.gl/FDkCdQ for more details.
+// See https://goo.gl/1kmPKZ for more details.
 func (c *Client) RemoveNetwork(id string) error {
 	resp, err := c.do("DELETE", "/networks/"+id, doOptions{})
 	if err != nil {

--- a/network_test.go
+++ b/network_test.go
@@ -75,7 +75,7 @@ func TestNetworkCreate(t *testing.T) {
 	jsonNetwork := `{
              "ID": "8dfafdbc3a40",
              "Name": "foobar",
-             "Type": "bridge"
+             "Driver": "bridge"
         }`
 	var expected Network
 	err := json.Unmarshal([]byte(jsonNetwork), &expected)

--- a/testing/server.go
+++ b/testing/server.go
@@ -1085,9 +1085,9 @@ func (s *DockerServer) createNetwork(w http.ResponseWriter, r *http.Request) {
 
 	generatedID := s.generateID()
 	network := docker.Network{
-		Name: config.Name,
-		ID:   generatedID,
-		Type: config.Driver,
+		Name:   config.Name,
+		ID:     generatedID,
+		Driver: config.Driver,
 	}
 	s.netMut.Lock()
 	s.networks = append(s.networks, &network)

--- a/testing/server_test.go
+++ b/testing/server_test.go
@@ -1749,14 +1749,13 @@ func addNetworks(server *DockerServer, n int) {
 	for i := 0; i < n; i++ {
 		netid := fmt.Sprintf("%x", rand.Int()%10000)
 		network := docker.Network{
-			Name: netid,
-			ID:   fmt.Sprintf("%x", rand.Int()%10000),
-			Type: "bridge",
-			Endpoints: []*docker.Endpoint{
-				{
-					Name:    "blah",
-					ID:      fmt.Sprintf("%x", rand.Int()%10000),
-					Network: netid,
+			Name:   netid,
+			ID:     fmt.Sprintf("%x", rand.Int()%10000),
+			Driver: "bridge",
+			Containers: map[string]docker.Endpoint{
+				"blah": {
+					Name: "blah",
+					ID:   fmt.Sprintf("%x", rand.Int()%10000),
 				},
 			},
 		}
@@ -1777,10 +1776,10 @@ func TestListNetworks(t *testing.T) {
 	expected := make([]docker.Network, 2)
 	for i, network := range server.networks {
 		expected[i] = docker.Network{
-			ID:        network.ID,
-			Name:      network.Name,
-			Type:      network.Type,
-			Endpoints: network.Endpoints,
+			ID:         network.ID,
+			Name:       network.Name,
+			Driver:     network.Driver,
+			Containers: network.Containers,
 		}
 	}
 	var got []docker.Network


### PR DESCRIPTION
Resolves part of #407 and also #426.

Perhaps the previous code was working off a pre-release version of the API?

Note in most cases I have gone with the current Docker field names, e.g. `Type` -> `Driver`, `Endpoints` -> `Containers`, which will break people's code, but that code couldn't have worked very well anyway against Docker 1.9.