### PR TITLE
client: prevent leak of file descriptors with multiple clients

### DIFF
--- a/client.go
+++ b/client.go
@@ -688,13 +688,13 @@ func (c *Client) unixClient() *http.Client {
 		return c.unixHTTPClient
 	}
 	socketPath := c.endpointURL.Path
-	c.unixHTTPClient = &http.Client{
-		Transport: &http.Transport{
-			Dial: func(network, addr string) (net.Conn, error) {
-				return c.Dialer.Dial("unix", socketPath)
-			},
+	tr := &http.Transport{
+		Dial: func(network, addr string) (net.Conn, error) {
+			return c.Dialer.Dial("unix", socketPath)
 		},
 	}
+	cleanhttp.SetTransportFinalizer(tr)
+	c.unixHTTPClient = &http.Client{Transport: tr}
 	return c.unixHTTPClient
 }
 

--- a/external/github.com/hashicorp/go-cleanhttp/cleanhttp.go
+++ b/external/github.com/hashicorp/go-cleanhttp/cleanhttp.go
@@ -3,13 +3,14 @@ package cleanhttp
 import (
 	"net"
 	"net/http"
+	"runtime"
 	"time"
 )
 
 // DefaultTransport returns a new http.Transport with the same default values
 // as http.DefaultTransport
 func DefaultTransport() *http.Transport {
-	return &http.Transport{
+	transport := &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
 		Dial: (&net.Dialer{
 			Timeout:   30 * time.Second,
@@ -17,6 +18,8 @@ func DefaultTransport() *http.Transport {
 		}).Dial,
 		TLSHandshakeTimeout: 10 * time.Second,
 	}
+	SetTransportFinalizer(transport)
+	return transport
 }
 
 // DefaultClient returns a new http.Client with the same default values as
@@ -25,4 +28,13 @@ func DefaultClient() *http.Client {
 	return &http.Client{
 		Transport: DefaultTransport(),
 	}
+}
+
+// SetTransportFinalizer sets a finalizer on the transport to ensure that
+// idle connections are closed prior to garbage collection; otherwise
+// these may leak
+func SetTransportFinalizer(transport *http.Transport) {
+	runtime.SetFinalizer(&transport, func(t **http.Transport) {
+		(*t).CloseIdleConnections()
+	})
 }


### PR DESCRIPTION
Each HTTP client keeps alive up to 2 connections, so the number of clients created in the lifetime of an application must be constant to prevent exhaustion of file descriptors.  The options to fix this are:

- do not keep connections open (as done in this patch)
- keep one global client
- keep a global pool of clients or transports
- export and document a method to close connections that calls `(*http.Transport).CloseIdleConnections()`
- document that users can only instantiate a small number of clients during the lifetime of an application