### PR TITLE
container: add Name and Driver to type Mount

### DIFF
--- a/container.go
+++ b/container.go
@@ -238,8 +238,10 @@ type Config struct {
 // It has been added in the version 1.20 of the Docker API, available since
 // Docker 1.8.
 type Mount struct {
+	Name        string
 	Source      string
 	Destination string
+	Driver      string
 	Mode        string
 	RW          bool
 }


### PR DESCRIPTION
These two fields are returned from the daemon in case we're using the new volume command for instance but aren't tracked
```
       },
        "Mounts": [
            {
                "Name": "ca7693ad662fd36f459063c17346d149784b2c40d6d0a452c0ca4761b30e2352",
                "Source": "/var/lib/docker/0.0/volumes/ca7693ad662fd36f459063c17346d149784b2c40d6d0a452c0ca4761b30e2352/_data",
                "Destination": "/test",
                "Driver": "local",
                "Mode": "",
                "RW": true
            }
        ],
        "Config": {
```

Signed-off-by: Antonio Murdaca <runcom@redhat.com>