### PR TITLE
Added volumes api to the test server.

### DIFF
--- a/testing/server.go
+++ b/testing/server.go
@@ -56,6 +56,13 @@ type DockerServer struct {
 	customHandlers map[string]http.Handler
 	handlerMutex   sync.RWMutex
 	cChan          chan<- *docker.Container
+	volStore       map[string]*volumeCounter
+	volMut         sync.RWMutex
+}
+
+type volumeCounter struct {
+	volume docker.Volume
+	count  int
 }
 
 // NewServer returns a new instance of the fake server, in standalone mode. Use
@@ -130,6 +137,10 @@ func (s *DockerServer) buildMuxer() {
 	s.mux.Path("/networks").Methods("GET").HandlerFunc(s.handlerWrapper(s.listNetworks))
 	s.mux.Path("/networks/{id:.*}").Methods("GET").HandlerFunc(s.handlerWrapper(s.networkInfo))
 	s.mux.Path("/networks").Methods("POST").HandlerFunc(s.handlerWrapper(s.createNetwork))
+	s.mux.Path("/volumes").Methods("GET").HandlerFunc(s.handlerWrapper(s.listVolumes))
+	s.mux.Path("/volumes/create").Methods("POST").HandlerFunc(s.handlerWrapper(s.createVolume))
+	s.mux.Path("/volumes/{name:.*}").Methods("GET").HandlerFunc(s.handlerWrapper(s.inspectVolume))
+	s.mux.Path("/volumes/{name:.*}").Methods("DELETE").HandlerFunc(s.handlerWrapper(s.removeVolume))
 }
 
 // SetHook changes the hook function used by the server.
@@ -1116,4 +1127,112 @@ func (s *DockerServer) createNetwork(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusCreated)
 	var c = struct{ ID string }{ID: network.ID}
 	json.NewEncoder(w).Encode(c)
+}
+
+func (s *DockerServer) listVolumes(w http.ResponseWriter, r *http.Request) {
+	s.volMut.RLock()
+	result := make([]docker.Volume, 0, len(s.volStore))
+	for _, volumeCounter := range s.volStore {
+		result = append(result, docker.Volume{
+			Name:       volumeCounter.volume.Name,
+			Driver:     volumeCounter.volume.Driver,
+			Mountpoint: volumeCounter.volume.Mountpoint,
+		})
+	}
+	s.volMut.RUnlock()
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(result)
+}
+
+func (s *DockerServer) createVolume(w http.ResponseWriter, r *http.Request) {
+	var data struct {
+		*docker.CreateVolumeOptions
+	}
+	defer r.Body.Close()
+	err := json.NewDecoder(r.Body).Decode(&data)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	volume := &docker.Volume{
+		Name:   data.CreateVolumeOptions.Name,
+		Driver: data.CreateVolumeOptions.Driver,
+	}
+	// If the name is not specified, generate one.  Just using generateID for now
+	if len(volume.Name) == 0 {
+		volume.Name = s.generateID()
+	}
+	// If driver is not specified, use local
+	if len(volume.Driver) == 0 {
+		volume.Driver = "local"
+	}
+	// Mount point is a default one with name
+	volume.Mountpoint = "/var/lib/docker/volumes/" + volume.Name
+
+	// If the volume already exists, don't re-add it.
+	exists := false
+	s.volMut.RLock()
+	if s.volStore != nil {
+		for _, vol := range s.volStore {
+			if vol.volume.Name == volume.Name {
+				exists = true
+				break
+			}
+		}
+	} else {
+		// No volumes, create volStore
+		s.volStore = make(map[string]*volumeCounter)
+	}
+	if !exists {
+		s.volStore[volume.Name] = &volumeCounter{
+			volume: *volume,
+			count:  0,
+		}
+	}
+	s.volMut.RUnlock()
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(volume)
+}
+
+func (s *DockerServer) inspectVolume(w http.ResponseWriter, r *http.Request) {
+	name := mux.Vars(r)["name"]
+	vol, err := s.findVolume(name)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(vol.volume)
+}
+
+func (s *DockerServer) findVolume(name string) (*volumeCounter, error) {
+	s.volMut.RLock()
+	defer s.volMut.RUnlock()
+	if s.volStore != nil {
+		for _, vol := range s.volStore {
+			if vol.volume.Name == name {
+				return vol, nil
+			}
+		}
+	}
+	return nil, errors.New("No such volume")
+}
+
+func (s *DockerServer) removeVolume(w http.ResponseWriter, r *http.Request) {
+	name := mux.Vars(r)["name"]
+	s.volMut.RLock()
+	defer s.volMut.RUnlock()
+	vol, err := s.findVolume(name)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+	if vol.count != 0 {
+		http.Error(w, "volume in use and cannot be removed", http.StatusConflict)
+		return
+	}
+	s.volStore[vol.volume.Name] = nil
+	w.WriteHeader(http.StatusNoContent)
 }

--- a/testing/server_test.go
+++ b/testing/server_test.go
@@ -1887,12 +1887,7 @@ func TestListVolumes(t *testing.T) {
 		Name:       "test-vol-1",
 		Driver:     "local",
 		Mountpoint: "/var/lib/docker/volumes/test-vol-1",
-	},
-		docker.Volume{
-			Name:       "test-vol-2",
-			Driver:     "local",
-			Mountpoint: "/var/lib/docker/volumes/test-vol-2",
-		}}
+	}}
 	server.volStore = make(map[string]*volumeCounter)
 	for _, vol := range expected {
 		server.volStore[vol.Name] = &volumeCounter{

--- a/testing/server_test.go
+++ b/testing/server_test.go
@@ -1879,3 +1879,199 @@ func TestCreateNetworkDuplicateName(t *testing.T) {
 		t.Errorf("CreateNetwork: wrong status. Want %d. Got %d.", http.StatusForbidden, recorder.Code)
 	}
 }
+
+func TestListVolumes(t *testing.T) {
+	server := DockerServer{}
+	server.buildMuxer()
+	expected := []docker.Volume{docker.Volume{
+		Name:       "test-vol-1",
+		Driver:     "local",
+		Mountpoint: "/var/lib/docker/volumes/test-vol-1",
+	},
+		docker.Volume{
+			Name:       "test-vol-2",
+			Driver:     "local",
+			Mountpoint: "/var/lib/docker/volumes/test-vol-2",
+		}}
+	server.volStore = make(map[string]*volumeCounter)
+	for _, vol := range expected {
+		server.volStore[vol.Name] = &volumeCounter{
+			volume: vol,
+			count:  0,
+		}
+	}
+	recorder := httptest.NewRecorder()
+	request, _ := http.NewRequest("GET", "/volumes", nil)
+	server.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusOK {
+		t.Errorf("ListVolumes: wrong status.  Want %d. Got %d.", http.StatusCreated, recorder.Code)
+	}
+	var got []docker.Volume
+	err := json.NewDecoder(recorder.Body).Decode(&got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(got, expected) {
+		t.Errorf("ListVolumes.  Want %#v.  Got %#v.", expected, got)
+	}
+}
+
+func TestCreateVolume(t *testing.T) {
+	server := DockerServer{}
+	server.buildMuxer()
+	recorder := httptest.NewRecorder()
+	body := `{"Name":"test-volume"}`
+	request, _ := http.NewRequest("POST", "/volumes/create", strings.NewReader(body))
+	server.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusCreated {
+		t.Errorf("CreateVolume: wrong status.  Want %d. Got %d.", http.StatusCreated, recorder.Code)
+	}
+	var returned docker.Volume
+	err := json.NewDecoder(recorder.Body).Decode(&returned)
+	if err != nil {
+		t.Error(err)
+	}
+	if returned.Name != "test-volume" {
+		t.Errorf("CreateVolume: Name mismatch.  Expected: test-volume.  Returned %q.", returned.Name)
+	}
+	if returned.Driver != "local" {
+		t.Errorf("CreateVolume: Driver mismatch.  Expected: local.  Returned: %q", returned.Driver)
+	}
+	if returned.Mountpoint != "/var/lib/docker/volumes/test-volume" {
+		t.Errorf("CreateVolume:  Mountpoint mismatch.  Expected: /var/lib/docker/volumes/test-volume.  Returned: %q.", returned.Mountpoint)
+	}
+}
+
+func TestCreateVolumeAlreadExists(t *testing.T) {
+	server := DockerServer{}
+	server.buildMuxer()
+	server.volStore = make(map[string]*volumeCounter)
+	server.volStore["test-volume"] = &volumeCounter{
+		volume: docker.Volume{
+			Name:       "test-volume",
+			Driver:     "local",
+			Mountpoint: "/var/lib/docker/volumes/test-volume",
+		},
+		count: 0,
+	}
+	body := `{"Name":"test-volume"}`
+	recorder := httptest.NewRecorder()
+	request, _ := http.NewRequest("POST", "/volumes/create", strings.NewReader(body))
+	server.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusCreated {
+		t.Errorf("CreateVolumeAlreadExists: wrong status.  Want %d. Got %d.", http.StatusCreated, recorder.Code)
+	}
+	var returned docker.Volume
+	err := json.NewDecoder(recorder.Body).Decode(&returned)
+	if err != nil {
+		t.Error(err)
+	}
+	if returned.Name != "test-volume" {
+		t.Errorf("CreateVolumeAlreadExists: Name mismatch.  Expected: test-volume.  Returned %q.", returned.Name)
+	}
+	if returned.Driver != "local" {
+		t.Errorf("CreateVolumeAlreadExists: Driver mismatch.  Expected: local.  Returned: %q", returned.Driver)
+	}
+	if returned.Mountpoint != "/var/lib/docker/volumes/test-volume" {
+		t.Errorf("CreateVolumeAlreadExists:  Mountpoint mismatch.  Expected: /var/lib/docker/volumes/test-volume.  Returned: %q.", returned.Mountpoint)
+	}
+}
+
+func TestInspectVolume(t *testing.T) {
+	server := DockerServer{}
+	server.buildMuxer()
+	recorder := httptest.NewRecorder()
+	expected := docker.Volume{
+		Name:       "test-volume",
+		Driver:     "local",
+		Mountpoint: "/var/lib/docker/volumes/test-volume",
+	}
+	volC := &volumeCounter{
+		volume: expected,
+		count:  0,
+	}
+	volStore := make(map[string]*volumeCounter)
+	volStore["test-volume"] = volC
+	server.volStore = volStore
+	request, _ := http.NewRequest("GET", "/volumes/test-volume", nil)
+	server.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusOK {
+		t.Errorf("InspectVolume: wrong status.  Want %d.  God %d.", http.StatusOK, recorder.Code)
+	}
+	var returned docker.Volume
+	err := json.NewDecoder(recorder.Body).Decode(&returned)
+	if err != nil {
+		t.Error(err)
+	}
+	if returned.Name != "test-volume" {
+		t.Errorf("InspectVolume: Name mismatch.  Expected: test-volume.  Returned %q.", returned.Name)
+	}
+	if returned.Driver != "local" {
+		t.Errorf("InspectVolume: Driver mismatch.  Expected: local.  Returned: %q", returned.Driver)
+	}
+	if returned.Mountpoint != "/var/lib/docker/volumes/test-volume" {
+		t.Errorf("InspectVolume:  Mountpoint mismatch.  Expected: /var/lib/docker/volumes/test-volume.  Returned: %q.", returned.Mountpoint)
+	}
+}
+
+func TestInspectVolumeNotFound(t *testing.T) {
+	server := DockerServer{}
+	server.buildMuxer()
+	recorder := httptest.NewRecorder()
+	request, _ := http.NewRequest("GET", "/volumes/test-volume", nil)
+	server.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusNotFound {
+		t.Errorf("RemoveMissingVolume: wrong status.  Want %d.  Got %d.", http.StatusNotFound, recorder.Code)
+	}
+}
+
+func TestRemoveVolume(t *testing.T) {
+	server := DockerServer{}
+	server.buildMuxer()
+	server.volStore = make(map[string]*volumeCounter)
+	server.volStore["test-volume"] = &volumeCounter{
+		volume: docker.Volume{
+			Name:       "test-volume",
+			Driver:     "local",
+			Mountpoint: "/var/lib/docker/volumes/test-volume",
+		},
+		count: 0,
+	}
+	recorder := httptest.NewRecorder()
+	request, _ := http.NewRequest("DELETE", "/volumes/test-volume", nil)
+	server.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusNoContent {
+		t.Errorf("RemoveVolume: wrong status.  Want %d.  Got %d.", http.StatusNoContent, recorder.Code)
+	}
+}
+
+func TestRemoveMissingVolume(t *testing.T) {
+	server := DockerServer{}
+	server.buildMuxer()
+	recorder := httptest.NewRecorder()
+	request, _ := http.NewRequest("DELETE", "/volumes/test-volume", nil)
+	server.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusNotFound {
+		t.Errorf("RemoveMissingVolume: wrong status.  Want %d.  Got %d.", http.StatusNotFound, recorder.Code)
+	}
+}
+
+func TestRemoveVolumeInuse(t *testing.T) {
+	server := DockerServer{}
+	server.buildMuxer()
+	server.volStore = make(map[string]*volumeCounter)
+	server.volStore["test-volume"] = &volumeCounter{
+		volume: docker.Volume{
+			Name:       "test-volume",
+			Driver:     "local",
+			Mountpoint: "/var/lib/docker/volumes/test-volume",
+		},
+		count: 1,
+	}
+	recorder := httptest.NewRecorder()
+	request, _ := http.NewRequest("DELETE", "/volumes/test-volume", nil)
+	server.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusConflict {
+		t.Errorf("RemoveVolume: wrong status.  Want %d.  Got %d.", http.StatusConflict, recorder.Code)
+	}
+}


### PR DESCRIPTION
Hi.  I'm using the go-dockerclient library for a project, and needed support for volumes in my unit tests.  This pull request covers adding the volume APIs for docker based on the remote 1.21 api to the test server.  So far it has been working for me in emulating my needs for volumes, which mainly pertains to the create/deletion of volumes.

Added support for the following volume API's:

List Volumes: GET /volumes
Create Volume: POST /volumes/create
Inspect Volume: GTET /volumes/(name)
Remove Volume: DELETE /volumes/(name)