### PR TITLE
Change querystring key for Message

### DIFF
--- a/container.go
+++ b/container.go
@@ -976,7 +976,7 @@ type CommitContainerOptions struct {
 	Container  string
 	Repository string `qs:"repo"`
 	Tag        string
-	Message    string `qs:"m"`
+	Message    string `qs:"comment"`
 	Author     string
 	Run        *Config `qs:"-"`
 }

--- a/container_test.go
+++ b/container_test.go
@@ -1081,7 +1081,7 @@ func TestCommitContainerParams(t *testing.T) {
 		{CommitContainerOptions{Container: "44c004db4b17"}, map[string][]string{"container": {"44c004db4b17"}}, nil},
 		{
 			CommitContainerOptions{Container: "44c004db4b17", Repository: "tsuru/python", Message: "something"},
-			map[string][]string{"container": {"44c004db4b17"}, "repo": {"tsuru/python"}, "m": {"something"}},
+			map[string][]string{"container": {"44c004db4b17"}, "repo": {"tsuru/python"}, "comment": {"something"}},
 			nil,
 		},
 		{


### PR DESCRIPTION
According to the documentation the correct key is `comment`, not `m`: https://docs.docker.com/engine/reference/api/docker_remote_api_v1.20/#create-a-new-image-from-a-container-s-changes