### PR TITLE
Allow -distro-version to append to APIVersion

### DIFF
--- a/client.go
+++ b/client.go
@@ -60,7 +60,8 @@ func NewAPIVersion(input string) (APIVersion, error) {
 	if !strings.Contains(input, ".") {
 		return nil, fmt.Errorf("Unable to parse version %q", input)
 	}
-	arr := strings.Split(input, ".")
+	raw := strings.Split(input, "-")
+	arr := strings.Split(raw[0], ".")
 	ret := make(APIVersion, len(arr))
 	var err error
 	for i, val := range arr {

--- a/client_test.go
+++ b/client_test.go
@@ -323,25 +323,6 @@ func TestQueryString(t *testing.T) {
 	}
 }
 
-func TestNewAPIVersionFailures(t *testing.T) {
-	var tests = []struct {
-		input         string
-		expectedError string
-	}{
-		{"1-0", `Unable to parse version "1-0"`},
-		{"1.0-beta", `Unable to parse version "1.0-beta": "0-beta" is not an integer`},
-	}
-	for _, tt := range tests {
-		v, err := NewAPIVersion(tt.input)
-		if v != nil {
-			t.Errorf("Expected <nil> version, got %v.", v)
-		}
-		if err.Error() != tt.expectedError {
-			t.Errorf("NewAPIVersion(%q): wrong error. Want %q. Got %q", tt.input, tt.expectedError, err.Error())
-		}
-	}
-}
-
 func TestAPIVersions(t *testing.T) {
 	var tests = []struct {
 		a                              string


### PR DESCRIPTION
In testing on fedora+rhel errors are returned on what are valid version appenders for distributions.  

1.10.0-rc1-fc24

This is a quick fix to allow. 
