### PR TITLE
fix buildarg serialization

### DIFF
--- a/image.go
+++ b/image.go
@@ -465,7 +465,11 @@ func (c *Client) BuildImage(opts BuildImageOptions) error {
 	}
 
 	if len(opts.BuildArgs) > 0 {
-		if b, err := json.Marshal(opts.BuildArgs); err == nil {
+		v := make(map[string]string)
+		for _, arg := range opts.BuildArgs {
+			v[arg.Name] = arg.Value
+		}
+		if b, err := json.Marshal(v); err == nil {
 			item := url.Values(map[string][]string{})
 			item.Add("buildargs", string(b))
 			qs = fmt.Sprintf("%s&%s", qs, item.Encode())

--- a/image_test.go
+++ b/image_test.go
@@ -708,7 +708,7 @@ func TestBuildImageParameters(t *testing.T) {
 		"cpuperiod":  {"100000"},
 		"cpusetcpus": {"0-3"},
 		"ulimits":    {`[{"Name":"nofile","Soft":100,"Hard":200}]`},
-		"buildargs":  {`[{"Name":"SOME_VAR","Value":"some_value"}]`},
+		"buildargs":  {`{"SOME_VAR":"some_value"}`},
 	}
 	got := map[string][]string(req.URL.Query())
 	if !reflect.DeepEqual(got, expected) {


### PR DESCRIPTION
When using go-dockerclient on docker 1.10.1, I encountered this error:

```
2016/02/22 13:39:48 API error (500): json: cannot unmarshal array into Go value of type map[string]string
```

I tracked it down to the serialization of the BuildArg structs.  I switched it out with a regular string map and it works now.

Previous: `[{"Name":"SOME_VAR","Value":"some_value"}]`
New: `{"SOME_VAR":"some_value"}`