### PR TITLE
add missing ContainerNetwork.NetworkID field

### DIFF
--- a/container.go
+++ b/container.go
@@ -135,6 +135,7 @@ type ContainerNetwork struct {
 	IPAddress           string `json:"IPAddress,omitempty" yaml:"IPAddress,omitempty"`
 	Gateway             string `json:"Gateway,omitempty" yaml:"Gateway,omitempty"`
 	EndpointID          string `json:"EndpointID,omitempty" yaml:"EndpointID,omitempty"`
+	NetworkID           string `json:"NetworkID,omitempty" yaml:"NetworkID,omitempty"`
 }
 
 // NetworkSettings contains network-related information about a container


### PR DESCRIPTION
This field is documented in the response at
https://docs.docker.com/engine/reference/api/docker_remote_api_v1.22/#inspect-a-container