### PR TITLE
Add some Network, Container and Misc changes from the 1.22 API

### DIFF
--- a/container.go
+++ b/container.go
@@ -53,7 +53,7 @@ type APIContainers struct {
 	SizeRootFs int64             `json:"SizeRootFs,omitempty" yaml:"SizeRootFs,omitempty"`
 	Names      []string          `json:"Names,omitempty" yaml:"Names,omitempty"`
 	Labels     map[string]string `json:"Labels,omitempty" yaml:"Labels,omitempty"`
-	Networks   NetworkList       `json:"NetworkSettings,omitempty" yaml:"NetworkSettings,omitempty`
+	Networks   NetworkList       `json:"NetworkSettings,omitempty" yaml:"NetworkSettings,omitempty"`
 }
 
 type NetworkList struct {
@@ -523,7 +523,7 @@ type BlockWeight struct {
 // See https://goo.gl/FSdP0H for more details.
 type BlockLimit struct {
 	Path string `json:"Path,omitempty"`
-	Rate string `json:"Rate",omitempty`
+	Rate string `json:"Rate,omitempty"`
 }
 
 // HostConfig contains the container options related to starting a container on

--- a/container.go
+++ b/container.go
@@ -52,7 +52,12 @@ type APIContainers struct {
 	SizeRw     int64             `json:"SizeRw,omitempty" yaml:"SizeRw,omitempty"`
 	SizeRootFs int64             `json:"SizeRootFs,omitempty" yaml:"SizeRootFs,omitempty"`
 	Names      []string          `json:"Names,omitempty" yaml:"Names,omitempty"`
-	Labels     map[string]string `json:"Labels,omitempty" yaml:"Labels, omitempty"`
+	Labels     map[string]string `json:"Labels,omitempty" yaml:"Labels,omitempty"`
+	Networks   NetworkList       `json:"NetworkSettings,omitempty" yaml:"NetworkSettings,omitempty`
+}
+
+type NetworkList struct {
+	Networks map[string]ContainerNetwork `json:"Networks" yaml:"Networks,omitempty"`
 }
 
 // ListContainers returns a slice of containers matching the given criteria.
@@ -314,6 +319,34 @@ type Container struct {
 	AppArmorProfile string `json:"AppArmorProfile,omitempty" yaml:"AppArmorProfile,omitempty"`
 }
 
+// UpdateContainerOptions specify parameters to the UpdateContainer function.
+//
+// See https://goo.gl/Y6fXUy for more details.
+type UpdateContainerOptions struct {
+	BlkioWeight       int    `json:"BlkioWeight"`
+	CPUShares         int    `json:"CpuShares"`
+	CPUPeriod         int    `json:"CpuPeriod"`
+	CPUQuota          int    `json:"CpuQuota"`
+	CpusetCpus        string `json:"CpusetCpus"`
+	CpusetMems        string `json:"CpusetMems"`
+	Memory            int    `json:"Memory"`
+	MemorySwap        int    `json:"MemorySwap"`
+	MemoryReservation int    `json:"MemoryReservation"`
+	KernelMemory      int    `json:"KernelMemory"`
+}
+
+// UpdateContainer updates the container at ID with the options
+//
+// See https://goo.gl/Y6fXUy for more details.
+func (c *Client) UpdateContainer(id string, opts UpdateContainerOptions) error {
+	resp, err := c.do("POST", fmt.Sprintf("/containers/"+id+"/update"), doOptions{data: opts, forceJSON: true})
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	return nil
+}
+
 // RenameContainerOptions specify parameters to the RenameContainer function.
 //
 // See https://goo.gl/laSOIy for more details.
@@ -475,48 +508,71 @@ type Device struct {
 	CgroupPermissions string `json:"CgroupPermissions,omitempty" yaml:"CgroupPermissions,omitempty"`
 }
 
+// BlockWeight represents a relative device weight for an individual device inside
+// of a container
+//
+// See https://goo.gl/FSdP0H for more details.
+type BlockWeight struct {
+	Path   string `json:"Path,omitempty"`
+	Weight string `json:"Weight,omitempty"`
+}
+
+// BlockLimit represents a read/write limit in IOPS or Bandwidth for a device
+// inside of a container
+//
+// See https://goo.gl/FSdP0H for more details.
+type BlockLimit struct {
+	Path string `json:"Path,omitempty"`
+	Rate string `json:"Rate",omitempty`
+}
+
 // HostConfig contains the container options related to starting a container on
 // a given host
 type HostConfig struct {
-	Binds            []string               `json:"Binds,omitempty" yaml:"Binds,omitempty"`
-	CapAdd           []string               `json:"CapAdd,omitempty" yaml:"CapAdd,omitempty"`
-	CapDrop          []string               `json:"CapDrop,omitempty" yaml:"CapDrop,omitempty"`
-	GroupAdd         []string               `json:"GroupAdd,omitempty" yaml:"GroupAdd,omitempty"`
-	ContainerIDFile  string                 `json:"ContainerIDFile,omitempty" yaml:"ContainerIDFile,omitempty"`
-	LxcConf          []KeyValuePair         `json:"LxcConf,omitempty" yaml:"LxcConf,omitempty"`
-	Privileged       bool                   `json:"Privileged,omitempty" yaml:"Privileged,omitempty"`
-	PortBindings     map[Port][]PortBinding `json:"PortBindings,omitempty" yaml:"PortBindings,omitempty"`
-	Links            []string               `json:"Links,omitempty" yaml:"Links,omitempty"`
-	PublishAllPorts  bool                   `json:"PublishAllPorts,omitempty" yaml:"PublishAllPorts,omitempty"`
-	DNS              []string               `json:"Dns,omitempty" yaml:"Dns,omitempty"` // For Docker API v1.10 and above only
-	DNSOptions       []string               `json:"DnsOptions,omitempty" yaml:"DnsOptions,omitempty"`
-	DNSSearch        []string               `json:"DnsSearch,omitempty" yaml:"DnsSearch,omitempty"`
-	ExtraHosts       []string               `json:"ExtraHosts,omitempty" yaml:"ExtraHosts,omitempty"`
-	VolumesFrom      []string               `json:"VolumesFrom,omitempty" yaml:"VolumesFrom,omitempty"`
-	NetworkMode      string                 `json:"NetworkMode,omitempty" yaml:"NetworkMode,omitempty"`
-	IpcMode          string                 `json:"IpcMode,omitempty" yaml:"IpcMode,omitempty"`
-	PidMode          string                 `json:"PidMode,omitempty" yaml:"PidMode,omitempty"`
-	UTSMode          string                 `json:"UTSMode,omitempty" yaml:"UTSMode,omitempty"`
-	RestartPolicy    RestartPolicy          `json:"RestartPolicy,omitempty" yaml:"RestartPolicy,omitempty"`
-	Devices          []Device               `json:"Devices,omitempty" yaml:"Devices,omitempty"`
-	LogConfig        LogConfig              `json:"LogConfig,omitempty" yaml:"LogConfig,omitempty"`
-	ReadonlyRootfs   bool                   `json:"ReadonlyRootfs,omitempty" yaml:"ReadonlyRootfs,omitempty"`
-	SecurityOpt      []string               `json:"SecurityOpt,omitempty" yaml:"SecurityOpt,omitempty"`
-	CgroupParent     string                 `json:"CgroupParent,omitempty" yaml:"CgroupParent,omitempty"`
-	Memory           int64                  `json:"Memory,omitempty" yaml:"Memory,omitempty"`
-	MemorySwap       int64                  `json:"MemorySwap,omitempty" yaml:"MemorySwap,omitempty"`
-	MemorySwappiness int64                  `json:"MemorySwappiness,omitempty" yaml:"MemorySwappiness,omitempty"`
-	OOMKillDisable   bool                   `json:"OomKillDisable,omitempty" yaml:"OomKillDisable"`
-	CPUShares        int64                  `json:"CpuShares,omitempty" yaml:"CpuShares,omitempty"`
-	CPUSet           string                 `json:"Cpuset,omitempty" yaml:"Cpuset,omitempty"`
-	CPUSetCPUs       string                 `json:"CpusetCpus,omitempty" yaml:"CpusetCpus,omitempty"`
-	CPUSetMEMs       string                 `json:"CpusetMems,omitempty" yaml:"CpusetMems,omitempty"`
-	CPUQuota         int64                  `json:"CpuQuota,omitempty" yaml:"CpuQuota,omitempty"`
-	CPUPeriod        int64                  `json:"CpuPeriod,omitempty" yaml:"CpuPeriod,omitempty"`
-	BlkioWeight      int64                  `json:"BlkioWeight,omitempty" yaml:"BlkioWeight"`
-	Ulimits          []ULimit               `json:"Ulimits,omitempty" yaml:"Ulimits,omitempty"`
-	VolumeDriver     string                 `json:"VolumeDriver,omitempty" yaml:"VolumeDriver,omitempty"`
-	OomScoreAdj      int                    `json:"OomScoreAdj,omitempty" yaml:"OomScoreAdj,omitempty"`
+	Binds                []string               `json:"Binds,omitempty" yaml:"Binds,omitempty"`
+	CapAdd               []string               `json:"CapAdd,omitempty" yaml:"CapAdd,omitempty"`
+	CapDrop              []string               `json:"CapDrop,omitempty" yaml:"CapDrop,omitempty"`
+	GroupAdd             []string               `json:"GroupAdd,omitempty" yaml:"GroupAdd,omitempty"`
+	ContainerIDFile      string                 `json:"ContainerIDFile,omitempty" yaml:"ContainerIDFile,omitempty"`
+	LxcConf              []KeyValuePair         `json:"LxcConf,omitempty" yaml:"LxcConf,omitempty"`
+	Privileged           bool                   `json:"Privileged,omitempty" yaml:"Privileged,omitempty"`
+	PortBindings         map[Port][]PortBinding `json:"PortBindings,omitempty" yaml:"PortBindings,omitempty"`
+	Links                []string               `json:"Links,omitempty" yaml:"Links,omitempty"`
+	PublishAllPorts      bool                   `json:"PublishAllPorts,omitempty" yaml:"PublishAllPorts,omitempty"`
+	DNS                  []string               `json:"Dns,omitempty" yaml:"Dns,omitempty"` // For Docker API v1.10 and above only
+	DNSOptions           []string               `json:"DnsOptions,omitempty" yaml:"DnsOptions,omitempty"`
+	DNSSearch            []string               `json:"DnsSearch,omitempty" yaml:"DnsSearch,omitempty"`
+	ExtraHosts           []string               `json:"ExtraHosts,omitempty" yaml:"ExtraHosts,omitempty"`
+	VolumesFrom          []string               `json:"VolumesFrom,omitempty" yaml:"VolumesFrom,omitempty"`
+	NetworkMode          string                 `json:"NetworkMode,omitempty" yaml:"NetworkMode,omitempty"`
+	IpcMode              string                 `json:"IpcMode,omitempty" yaml:"IpcMode,omitempty"`
+	PidMode              string                 `json:"PidMode,omitempty" yaml:"PidMode,omitempty"`
+	UTSMode              string                 `json:"UTSMode,omitempty" yaml:"UTSMode,omitempty"`
+	RestartPolicy        RestartPolicy          `json:"RestartPolicy,omitempty" yaml:"RestartPolicy,omitempty"`
+	Devices              []Device               `json:"Devices,omitempty" yaml:"Devices,omitempty"`
+	LogConfig            LogConfig              `json:"LogConfig,omitempty" yaml:"LogConfig,omitempty"`
+	ReadonlyRootfs       bool                   `json:"ReadonlyRootfs,omitempty" yaml:"ReadonlyRootfs,omitempty"`
+	SecurityOpt          []string               `json:"SecurityOpt,omitempty" yaml:"SecurityOpt,omitempty"`
+	CgroupParent         string                 `json:"CgroupParent,omitempty" yaml:"CgroupParent,omitempty"`
+	Memory               int64                  `json:"Memory,omitempty" yaml:"Memory,omitempty"`
+	MemorySwap           int64                  `json:"MemorySwap,omitempty" yaml:"MemorySwap,omitempty"`
+	MemorySwappiness     int64                  `json:"MemorySwappiness,omitempty" yaml:"MemorySwappiness,omitempty"`
+	OOMKillDisable       bool                   `json:"OomKillDisable,omitempty" yaml:"OomKillDisable"`
+	CPUShares            int64                  `json:"CpuShares,omitempty" yaml:"CpuShares,omitempty"`
+	CPUSet               string                 `json:"Cpuset,omitempty" yaml:"Cpuset,omitempty"`
+	CPUSetCPUs           string                 `json:"CpusetCpus,omitempty" yaml:"CpusetCpus,omitempty"`
+	CPUSetMEMs           string                 `json:"CpusetMems,omitempty" yaml:"CpusetMems,omitempty"`
+	CPUQuota             int64                  `json:"CpuQuota,omitempty" yaml:"CpuQuota,omitempty"`
+	CPUPeriod            int64                  `json:"CpuPeriod,omitempty" yaml:"CpuPeriod,omitempty"`
+	BlkioWeight          int64                  `json:"BlkioWeight,omitempty" yaml:"BlkioWeight"`
+	BlkioWeightDevice    []BlockWeight          `json:"BlkioWeightDevice,omitempty" yaml:"BlkioWeightDevice"`
+	BlkioDeviceReadBps   []BlockLimit           `json:"BlkioDeviceReadBps,omitempty" yaml:"BlkioDeviceReadBps"`
+	BlkioDeviceReadIOps  []BlockLimit           `json:"BlkioDeviceReadIOps,omitempty" yaml:"BlkioDeviceReadIOps"`
+	BlkioDeviceWriteBps  []BlockLimit           `json:"BlkioDeviceWriteBps,omitempty" yaml:"BlkioDeviceWriteBps"`
+	BlkioDeviceWriteIOps []BlockLimit           `json:"BlkioDeviceWriteIOps,omitempty" yaml:"BlkioDeviceWriteIOps"`
+	Ulimits              []ULimit               `json:"Ulimits,omitempty" yaml:"Ulimits,omitempty"`
+	VolumeDriver         string                 `json:"VolumeDriver,omitempty" yaml:"VolumeDriver,omitempty"`
+	OomScoreAdj          int                    `json:"OomScoreAdj,omitempty" yaml:"OomScoreAdj,omitempty"`
 }
 
 // StartContainer starts a container, returning an error in case of failure.

--- a/container_test.go
+++ b/container_test.go
@@ -752,15 +752,15 @@ func TestUpdateContainer(t *testing.T) {
 	}
 	req := fakeRT.requests[0]
 	if req.Method != "POST" {
-		t.Errorf("UpdateContainer: wrong HTTP method. Want %q. Got %q.", id, "POST", req.Method)
+		t.Errorf("UpdateContainer: wrong HTTP method. Want %q. Got %q.", "POST", req.Method)
 	}
 	expectedURL, _ := url.Parse(client.getURL("/containers/" + id + "/update"))
 	if gotPath := req.URL.Path; gotPath != expectedURL.Path {
-		t.Errorf("UpdateContainer: Wrong path in request. Want %q. Got %q.", id, expectedURL.Path, gotPath)
+		t.Errorf("UpdateContainer: Wrong path in request. Want %q. Got %q.", expectedURL.Path, gotPath)
 	}
 	expectedContentType := "application/json"
 	if contentType := req.Header.Get("Content-Type"); contentType != expectedContentType {
-		t.Errorf("UpdateContainer: Wrong content-type in request. Want %q. Got %q.", id, expectedContentType, contentType)
+		t.Errorf("UpdateContainer: Wrong content-type in request. Want %q. Got %q.", expectedContentType, contentType)
 	}
 	var out UpdateContainerOptions
 	if err := json.NewDecoder(req.Body).Decode(&out); err != nil {

--- a/container_test.go
+++ b/container_test.go
@@ -741,6 +741,36 @@ func TestCreateContainerWithHostConfig(t *testing.T) {
 	}
 }
 
+func TestUpdateContainer(t *testing.T) {
+	fakeRT := &FakeRoundTripper{message: "", status: http.StatusOK}
+	client := newTestClient(fakeRT)
+	id := "4fa6e0f0c6786287e131c3852c58a2e01cc697a68231826813597e4994f1d6e2"
+	update := UpdateContainerOptions{Memory: 12345, CpusetMems: "0,1"}
+	err := client.UpdateContainer(id, update)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := fakeRT.requests[0]
+	if req.Method != "POST" {
+		t.Errorf("UpdateContainer: wrong HTTP method. Want %q. Got %q.", id, "POST", req.Method)
+	}
+	expectedURL, _ := url.Parse(client.getURL("/containers/" + id + "/update"))
+	if gotPath := req.URL.Path; gotPath != expectedURL.Path {
+		t.Errorf("UpdateContainer: Wrong path in request. Want %q. Got %q.", id, expectedURL.Path, gotPath)
+	}
+	expectedContentType := "application/json"
+	if contentType := req.Header.Get("Content-Type"); contentType != expectedContentType {
+		t.Errorf("UpdateContainer: Wrong content-type in request. Want %q. Got %q.", id, expectedContentType, contentType)
+	}
+	var out UpdateContainerOptions
+	if err := json.NewDecoder(req.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(out, update) {
+		t.Errorf("UpdateContainer: wrong body, got: %#v, want %#v", out, update)
+	}
+}
+
 func TestStartContainer(t *testing.T) {
 	fakeRT := &FakeRoundTripper{message: "", status: http.StatusOK}
 	client := newTestClient(fakeRT)

--- a/misc.go
+++ b/misc.go
@@ -4,7 +4,10 @@
 
 package docker
 
-import "strings"
+import (
+	"encoding/json"
+	"strings"
+)
 
 // Version returns version information about the docker server.
 //
@@ -22,17 +25,81 @@ func (c *Client) Version() (*Env, error) {
 	return &env, nil
 }
 
+// DockerInfo contains information about the Docker server
+//
+// See https://goo.gl/bHUoz9 for more details.
+type DockerInfo struct {
+	ID                 string
+	Containers         int
+	ContainersRunning  int
+	ContainersPaused   int
+	ContainersStopped  int
+	Images             int
+	Driver             string
+	DriverStatus       [][2]string
+	SystemStatus       [][2]string
+	Plugins            PluginsInfo
+	MemoryLimit        bool
+	SwapLimit          bool
+	KernelMemory       bool
+	CPUCfsPeriod       bool `json:"CpuCfsPeriod"`
+	CPUCfsQuota        bool `json:"CpuCfsQuota"`
+	CPUShares          bool
+	CPUSet             bool
+	IPv4Forwarding     bool
+	BridgeNfIptables   bool
+	BridgeNfIP6tables  bool `json:"BridgeNfIp6tables"`
+	Debug              bool
+	NFd                int
+	OomKillDisable     bool
+	NGoroutines        int
+	SystemTime         string
+	ExecutionDriver    string
+	LoggingDriver      string
+	CgroupDriver       string
+	NEventsListener    int
+	KernelVersion      string
+	OperatingSystem    string
+	OSType             string
+	Architecture       string
+	IndexServerAddress string
+	NCPU               int
+	MemTotal           int64
+	DockerRootDir      string
+	HTTPProxy          string `json:"HttpProxy"`
+	HTTPSProxy         string `json:"HttpsProxy"`
+	NoProxy            string
+	Name               string
+	Labels             []string
+	ExperimentalBuild  bool
+	ServerVersion      string
+	ClusterStore       string
+	ClusterAdvertise   string
+}
+
+// PluginsInfo is a struct with the plugins registered with the docker daemon
+//
+// for more information, see: https://goo.gl/bHUoz9
+type PluginsInfo struct {
+	// List of Volume plugins registered
+	Volume []string
+	// List of Network plugins registered
+	Network []string
+	// List of Authorization plugins registered
+	Authorization []string
+}
+
 // Info returns system-wide information about the Docker server.
 //
 // See https://goo.gl/ElTHi2 for more details.
-func (c *Client) Info() (*Env, error) {
+func (c *Client) Info() (*DockerInfo, error) {
 	resp, err := c.do("GET", "/info", doOptions{})
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
-	var info Env
-	if err := info.Decode(resp.Body); err != nil {
+	var info DockerInfo
+	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
 		return nil, err
 	}
 	return &info, nil

--- a/misc_test.go
+++ b/misc_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"net/url"
 	"reflect"
-	"sort"
 	"testing"
 )
 
@@ -71,32 +70,29 @@ func TestInfo(t *testing.T) {
 	body := `{
      "Containers":11,
      "Images":16,
-     "Debug":0,
+     "Debug":false,
      "NFd":11,
      "NGoroutines":21,
-     "MemoryLimit":1,
-     "SwapLimit":0
+     "MemoryLimit":true,
+     "SwapLimit":false
 }`
 	fakeRT := FakeRoundTripper{message: body, status: http.StatusOK}
 	client := newTestClient(&fakeRT)
-	expected := Env{}
-	expected.SetInt("Containers", 11)
-	expected.SetInt("Images", 16)
-	expected.SetBool("Debug", false)
-	expected.SetInt("NFd", 11)
-	expected.SetInt("NGoroutines", 21)
-	expected.SetBool("MemoryLimit", true)
-	expected.SetBool("SwapLimit", false)
+	expected := &DockerInfo{
+		Containers:  11,
+		Images:      16,
+		Debug:       false,
+		NFd:         11,
+		NGoroutines: 21,
+		MemoryLimit: true,
+		SwapLimit:   false,
+	}
 	info, err := client.Info()
 	if err != nil {
 		t.Fatal(err)
 	}
-	infoSlice := []string(*info)
-	expectedSlice := []string(expected)
-	sort.Strings(infoSlice)
-	sort.Strings(expectedSlice)
-	if !reflect.DeepEqual(expectedSlice, infoSlice) {
-		t.Errorf("Info(): Wrong result.\nWant %#v.\nGot %#v.", expected, *info)
+	if !reflect.DeepEqual(expected, info) {
+		t.Errorf("Info(): Wrong result.\nWant %#v.\nGot %#v.", expected, info)
 	}
 	req := fakeRT.requests[0]
 	if req.Method != "GET" {

--- a/network_test.go
+++ b/network_test.go
@@ -42,6 +42,39 @@ func TestListNetworks(t *testing.T) {
 	}
 }
 
+func TestFilteredListNetworks(t *testing.T) {
+	jsonNetworks := `[
+     {
+             "ID": "9fb1e39c",
+             "Name": "foo",
+             "Type": "bridge",
+             "Endpoints":[{"ID": "c080be979dda", "Name": "lllll2222", "Network": "9fb1e39c"}]
+     }
+]`
+	var expected []Network
+	err := json.Unmarshal([]byte(jsonNetworks), &expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantQuery := "filters={\"name\":{\"blah\":true}}\n"
+	fakeRT := &FakeRoundTripper{message: jsonNetworks, status: http.StatusOK}
+	client := newTestClient(fakeRT)
+	opts := NetworkFilterOpts{
+		"name": map[string]bool{"blah": true},
+	}
+	containers, err := client.FilteredListNetworks(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(containers, expected) {
+		t.Errorf("ListNetworks: Expected %#v. Got %#v.", expected, containers)
+	}
+	query := fakeRT.requests[0].URL.RawQuery
+	if query != wantQuery {
+		t.Errorf("FilteredListNetworks: Expected query: %q, got: %q", wantQuery, query)
+	}
+}
+
 func TestNetworkInfo(t *testing.T) {
 	jsonNetwork := `{
              "ID": "8dfafdbc3a40",
@@ -118,7 +151,7 @@ func TestNetworkConnect(t *testing.T) {
 	id := "8dfafdbc3a40"
 	fakeRT := &FakeRoundTripper{message: "", status: http.StatusNoContent}
 	client := newTestClient(fakeRT)
-	opts := NetworkConnectionOptions{"foobar"}
+	opts := NetworkConnectionOptions{"foobar", false}
 	err := client.ConnectNetwork(id, opts)
 	if err != nil {
 		t.Fatal(err)
@@ -136,7 +169,7 @@ func TestNetworkConnect(t *testing.T) {
 
 func TestNetworkConnectNotFound(t *testing.T) {
 	client := newTestClient(&FakeRoundTripper{message: "no such network container", status: http.StatusNotFound})
-	opts := NetworkConnectionOptions{"foobar"}
+	opts := NetworkConnectionOptions{"foobar", false}
 	err := client.ConnectNetwork("8dfafdbc3a40", opts)
 	if serr, ok := err.(*NoSuchNetworkOrContainer); !ok {
 		t.Errorf("ConnectNetwork: wrong error type: %s.", serr)
@@ -147,7 +180,7 @@ func TestNetworkDisconnect(t *testing.T) {
 	id := "8dfafdbc3a40"
 	fakeRT := &FakeRoundTripper{message: "", status: http.StatusNoContent}
 	client := newTestClient(fakeRT)
-	opts := NetworkConnectionOptions{"foobar"}
+	opts := NetworkConnectionOptions{"foobar", false}
 	err := client.DisconnectNetwork(id, opts)
 	if err != nil {
 		t.Fatal(err)
@@ -165,7 +198,7 @@ func TestNetworkDisconnect(t *testing.T) {
 
 func TestNetworkDisconnectNotFound(t *testing.T) {
 	client := newTestClient(&FakeRoundTripper{message: "no such network container", status: http.StatusNotFound})
-	opts := NetworkConnectionOptions{"foobar"}
+	opts := NetworkConnectionOptions{"foobar", false}
 	err := client.DisconnectNetwork("8dfafdbc3a40", opts)
 	if serr, ok := err.(*NoSuchNetworkOrContainer); !ok {
 		t.Errorf("DisconnectNetwork: wrong error type: %s.", serr)


### PR DESCRIPTION
This PR adds the following capabilities from the 1.22 API:

* POST /container/(name)/update updates the resources of a container.
* GET /containers/json now returns the list of networks of containers.
* GET /info Now returns Architecture and OSType fields, providing information about the host architecture and operating system type that the daemon runs on.
* POST /containers/create now allows you to set a read/write rate limit for a device (in bytes per second or IO per second).
* GET /networks now supports filtering by name, id and type.
* GET /info now includes the number of containers running, stopped, and paused.
* POST /networks/create now supports restricting external access to the network by setting the internal field.
* POST /networks/(id)/disconnect now includes a Force option to forcefully disconnect a container from network
* GET /info can now return a SystemStatus field useful for returning additional information about applications that are built on top of engine.

Most of the changes are completely backward compatible - the biggest breaking change is that the info route now returns a proper struct. If this change is too breaking, let me know and I can create a new method returning this info (or something else!)

I tried to match the style of the other endpoints and tests, let me know if anything looks awry! 

I'd love to get the Event changes in, as well as some of the IP/IPAM changes. Those are next on my list.

Should address #474