### PR TITLE
events: change to API 1.22 format, maintain compatibility

### DIFF
--- a/event.go
+++ b/event.go
@@ -18,12 +18,38 @@ import (
 	"time"
 )
 
-// APIEvents represents an event returned by the API.
+// APIEvents represents events coming from the Docker API
+// The fields in the Docker API changed in API version 1.22, and
+// events for more than images and containers are now fired off.
+// To maintain forward and backward compatibility, go-dockerclient
+// replicates the event in both the new and old format as faithfully as possible.
+//
+// For events that only exist in 1.22 in later, `Status` is filled in as
+// `"Type:Action"` instead of just `Action` to allow for older clients to
+// differentiate and not break if they rely on the pre-1.22 Status types.
+//
+// The transformEvent method can be consulted for more information about how
+// events are translated from new/old API formats
 type APIEvents struct {
-	Status string `json:"Status,omitempty" yaml:"Status,omitempty"`
-	ID     string `json:"ID,omitempty" yaml:"ID,omitempty"`
-	From   string `json:"From,omitempty" yaml:"From,omitempty"`
-	Time   int64  `json:"Time,omitempty" yaml:"Time,omitempty"`
+	// New API Fields in 1.22
+	Action string   `json:"action,omitempty"`
+	Type   string   `json:"type,omitempty"`
+	Actor  APIActor `json:"actor,omitempty"`
+
+	// Old API fields for < 1.22
+	Status string `json:"status,omitempty"`
+	ID     string `json:"id,omitempty"`
+	From   string `json:"from,omitempty"`
+
+	// Fields in both
+	Time     int64 `json:"time,omitempty"`
+	TimeNano int64 `json:"timeNano,omitempty"`
+}
+
+// APIActor represents an actor that accomplishes something for an event
+type APIActor struct {
+	ID         string            `json:"id,omitempty"`
+	Attributes map[string]string `json:"attributes,omitempty"`
 }
 
 type eventMonitoringState struct {
@@ -52,6 +78,7 @@ var (
 
 	// EOFEvent is sent when the event listener receives an EOF error.
 	EOFEvent = &APIEvents{
+		Type:   "EOF",
 		Status: "EOF",
 	}
 )
@@ -297,8 +324,41 @@ func (c *Client) eventHijack(startTime int64, eventChan chan *APIEvents, errChan
 			if !c.eventMonitor.isEnabled() {
 				return
 			}
+			transformEvent(&event)
 			eventChan <- &event
 		}
 	}(res, conn)
 	return nil
+}
+
+// transformEvent takes an event and determines what version it is from
+// then populates both versions of the event
+func transformEvent(event *APIEvents) {
+	// if <= 1.21, `status` and `ID` will be populated
+	if event.Status != "" && event.ID != "" {
+		event.Action = event.Status
+		event.Actor.ID = event.ID
+		event.Actor.Attributes = map[string]string{}
+		switch event.Status {
+		case "delete", "import", "pull", "push", "tag", "untag":
+			event.Type = "image"
+		default:
+			event.Type = "container"
+			if event.From != "" {
+				event.Actor.Attributes["image"] = event.From
+			}
+		}
+	} else {
+		if event.Type == "image" || event.Type == "container" {
+			event.Status = event.Action
+		} else {
+			// Because just the Status has been overloaded with different Types
+			// if an event is not for an image or a container, we prepend the type
+			// to avoid problems for people relying on actions being only for
+			// images and containers
+			event.Status = event.Type + ":" + event.Action
+		}
+		event.ID = event.Actor.ID
+		event.From = event.Actor.Attributes["image"]
+	}
 }

--- a/event_test.go
+++ b/event_test.go
@@ -8,10 +8,10 @@ import (
 	"bufio"
 	"crypto/tls"
 	"crypto/x509"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -51,12 +51,147 @@ func TestTLSEventListeners(t *testing.T) {
 }
 
 func testEventListeners(testName string, t *testing.T, buildServer func(http.Handler) *httptest.Server, buildClient func(string) (*Client, error)) {
-	response := `{"status":"create","id":"dfdf82bd3881","from":"base:latest","time":1374067924}
+	response := `{"action":"pull","type":"image","actor":{"id":"busybox:latest","attributes":{}},"time":1442421700,"timeNano":1442421700598988358}
+{"action":"create","type":"container","actor":{"id":"5745704abe9caa5","attributes":{"image":"busybox"}},"time":1442421716,"timeNano":1442421716853979870}
+{"action":"attach","type":"container","actor":{"id":"5745704abe9caa5","attributes":{"image":"busybox"}},"time":1442421716,"timeNano":1442421716894759198}
+{"action":"start","type":"container","actor":{"id":"5745704abe9caa5","attributes":{"image":"busybox"}},"time":1442421716,"timeNano":1442421716983607193}
+{"status":"create","id":"dfdf82bd3881","from":"base:latest","time":1374067924}
 {"status":"start","id":"dfdf82bd3881","from":"base:latest","time":1374067924}
 {"status":"stop","id":"dfdf82bd3881","from":"base:latest","time":1374067966}
-{"status":"destroy","id":"dfdf82bd3881","from":"base:latest","time":1374067970}
-`
+{"status":"destroy","id":"dfdf82bd3881","from":"base:latest","time":1374067970}`
 
+	wantResponse := []*APIEvents{
+		{
+			Action: "pull",
+			Type:   "image",
+			Actor: APIActor{
+				ID:         "busybox:latest",
+				Attributes: map[string]string{},
+			},
+
+			Status: "pull",
+			ID:     "busybox:latest",
+
+			Time:     1442421700,
+			TimeNano: 1442421700598988358,
+		},
+		{
+			Action: "create",
+			Type:   "container",
+			Actor: APIActor{
+				ID: "5745704abe9caa5",
+				Attributes: map[string]string{
+					"image": "busybox",
+				},
+			},
+
+			Status: "create",
+			ID:     "5745704abe9caa5",
+			From:   "busybox",
+
+			Time:     1442421716,
+			TimeNano: 1442421716853979870,
+		},
+		{
+			Action: "attach",
+			Type:   "container",
+			Actor: APIActor{
+				ID: "5745704abe9caa5",
+				Attributes: map[string]string{
+					"image": "busybox",
+				},
+			},
+
+			Status: "attach",
+			ID:     "5745704abe9caa5",
+			From:   "busybox",
+
+			Time:     1442421716,
+			TimeNano: 1442421716894759198,
+		},
+		{
+			Action: "start",
+			Type:   "container",
+			Actor: APIActor{
+				ID: "5745704abe9caa5",
+				Attributes: map[string]string{
+					"image": "busybox",
+				},
+			},
+
+			Status: "start",
+			ID:     "5745704abe9caa5",
+			From:   "busybox",
+
+			Time:     1442421716,
+			TimeNano: 1442421716983607193,
+		},
+
+		{
+			Action: "create",
+			Type:   "container",
+			Actor: APIActor{
+				ID: "dfdf82bd3881",
+				Attributes: map[string]string{
+					"image": "base:latest",
+				},
+			},
+
+			Status: "create",
+			ID:     "dfdf82bd3881",
+			From:   "base:latest",
+
+			Time: 1374067924,
+		},
+		{
+			Action: "start",
+			Type:   "container",
+			Actor: APIActor{
+				ID: "dfdf82bd3881",
+				Attributes: map[string]string{
+					"image": "base:latest",
+				},
+			},
+
+			Status: "start",
+			ID:     "dfdf82bd3881",
+			From:   "base:latest",
+
+			Time: 1374067924,
+		},
+		{
+			Action: "stop",
+			Type:   "container",
+			Actor: APIActor{
+				ID: "dfdf82bd3881",
+				Attributes: map[string]string{
+					"image": "base:latest",
+				},
+			},
+
+			Status: "stop",
+			ID:     "dfdf82bd3881",
+			From:   "base:latest",
+
+			Time: 1374067966,
+		},
+		{
+			Action: "destroy",
+			Type:   "container",
+			Actor: APIActor{
+				ID: "dfdf82bd3881",
+				Attributes: map[string]string{
+					"image": "base:latest",
+				},
+			},
+
+			Status: "destroy",
+			ID:     "dfdf82bd3881",
+			From:   "base:latest",
+
+			Time: 1374067970,
+		},
+	}
 	server := buildServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		rsc := bufio.NewScanner(strings.NewReader(response))
 		for rsc.Scan() {
@@ -87,46 +222,16 @@ func testEventListeners(testName string, t *testing.T, buildServer func(http.Han
 	}
 
 	timeout := time.After(1 * time.Second)
-	var count int
 
-	for {
+	for i := 0; i < 8; i++ {
 		select {
 		case msg := <-listener:
-			t.Logf("Received: %v", *msg)
-			count++
-			err = checkEvent(count, msg)
-			if err != nil {
-				t.Fatalf("Check event failed: %s", err)
-			}
-			if count == 4 {
-				return
+			t.Logf("%d: Received: %v", i, msg)
+			if !reflect.DeepEqual(msg, wantResponse[i]) {
+				t.Fatalf("%d: wanted: %#v\n got: %#v", i, wantResponse[i], msg)
 			}
 		case <-timeout:
 			t.Fatalf("%s timed out waiting on events", testName)
 		}
 	}
-}
-
-func checkEvent(index int, event *APIEvents) error {
-	if event.ID != "dfdf82bd3881" {
-		return fmt.Errorf("event ID did not match. Expected dfdf82bd3881 got %s", event.ID)
-	}
-	if event.From != "base:latest" {
-		return fmt.Errorf("event from did not match. Expected base:latest got %s", event.From)
-	}
-	var status string
-	switch index {
-	case 1:
-		status = "create"
-	case 2:
-		status = "start"
-	case 3:
-		status = "stop"
-	case 4:
-		status = "destroy"
-	}
-	if event.Status != status {
-		return fmt.Errorf("event status did not match. Expected %s got %s", status, event.Status)
-	}
-	return nil
 }


### PR DESCRIPTION
This was a tricky one, but I think I've gotten the change completely forward and backwards compatible. 

The changes to the Docker API introduced event hooks for more than just Containers and Images, and the `Action` attribute is overridden (meaning you can 'create' networks, containers, volumes, etc). Because of this, if an event was not present before 1.22, we prepend the `Action` attribute with the `Type`, and separate them by a `:`.

This means that creating a network will have a Status of `network:create`, whereas a container create will still be just `create`, which is the way it would work with 1.21. 

There's some funny stuff that happens with `From` and `Attributes` -- I'm going to play around with the attributes for other event types to make sure it works properly.

This behavior probably deserves some documentation - let me know if you want that to live on `APIEvents` or elsewhere. 

Thoughts? Addresses #471