### PR TITLE
network: add new network connection params for 1.22

### DIFF
--- a/network.go
+++ b/network.go
@@ -187,10 +187,33 @@ func (c *Client) RemoveNetwork(id string) error {
 
 // NetworkConnectionOptions specify parameters to the ConnectNetwork and DisconnectNetwork function.
 //
-// See https://goo.gl/6GugX3 for more details.
+// See https://goo.gl/RV7BJU for more details.
 type NetworkConnectionOptions struct {
 	Container string
-	Force     bool
+
+	// EndpointConfig is only applicable to the ConnectNetwork call
+	EndpointConfig *EndpointConfig `json:"EndpointConfig,omitempty"`
+
+	// Force is only applicable to the DisconnectNetwork call
+	Force bool
+}
+
+// EndpointConfig stores network endpoint details
+//
+// See https://goo.gl/RV7BJU for more details.
+type EndpointConfig struct {
+	IPAMConfig *EndpointIPAMConfig
+	Links      []string
+	Aliases    []string
+}
+
+// EndpointIPAMCOnfig represents IPAM configurations for an
+// endpoint
+//
+// See https://goo.gl/RV7BJU for more details.
+type EndpointIPAMConfig struct {
+	IPv4Address string `json:",omitempty"`
+	IPv6Address string `json:",omitempty"`
 }
 
 // ConnectNetwork adds a container to a network or returns an error in case of failure.


### PR DESCRIPTION
This duplicates #469 - it implements the endpoint change in 1.22:

* POST /networks/(id)/connect now allows you to set the static IPv4 and/or IPv6 address for the container.

Unfortunately, the struct accepted in both ConnectNetwork and DisconnectNetwork has grown different, but it would be a breaking change to move to using different structs in the client. Not the end of the world, but it will cause some extra bytes to get sent over the network.

If we're willing to make the breaking change, I'd gladly split the two structs up, but I figure it's best to keep compatibility here. 