### PR TITLE
Fixed parsing of docker client configuration.

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -82,10 +82,12 @@ func parseDockerConfig(r io.Reader) (map[string]dockerConfig, error) {
 	buf.ReadFrom(r)
 	byteData := buf.Bytes()
 
-	var confsWrapper map[string]map[string]dockerConfig
+	confsWrapper := struct {
+		Auths map[string]dockerConfig `json:"auths"`
+	}{}
 	if err := json.Unmarshal(byteData, &confsWrapper); err == nil {
-		if confs, ok := confsWrapper["auths"]; ok {
-			return confs, nil
+		if len(confsWrapper.Auths) > 0 {
+			return confsWrapper.Auths, nil
 		}
 	}
 

--- a/auth_test.go
+++ b/auth_test.go
@@ -49,6 +49,34 @@ func TestAuthBadConfig(t *testing.T) {
 	}
 }
 
+func TestAuthAndOtherFields(t *testing.T) {
+	auth := base64.StdEncoding.EncodeToString([]byte("user:pass"))
+	read := strings.NewReader(fmt.Sprintf(`{
+		"auths":{"docker.io":{"auth":"%s","email":"user@example.com"}},
+		"detachKeys": "ctrl-e,e",
+		"HttpHeaders": { "MyHeader": "MyValue" }}`, auth))
+
+	ac, err := NewAuthConfigurations(read)
+	if err != nil {
+		t.Error(err)
+	}
+	c, ok := ac.Configs["docker.io"]
+	if !ok {
+		t.Error("NewAuthConfigurations: Expected Configs to contain docker.io")
+	}
+	if got, want := c.Email, "user@example.com"; got != want {
+		t.Errorf(`AuthConfigurations.Configs["docker.io"].Email: wrong result. Want %q. Got %q`, want, got)
+	}
+	if got, want := c.Username, "user"; got != want {
+		t.Errorf(`AuthConfigurations.Configs["docker.io"].Username: wrong result. Want %q. Got %q`, want, got)
+	}
+	if got, want := c.Password, "pass"; got != want {
+		t.Errorf(`AuthConfigurations.Configs["docker.io"].Password: wrong result. Want %q. Got %q`, want, got)
+	}
+	if got, want := c.ServerAddress, "docker.io"; got != want {
+		t.Errorf(`AuthConfigurations.Configs["docker.io"].ServerAddress: wrong result. Want %q. Got %q`, want, got)
+	}
+}
 func TestAuthConfig(t *testing.T) {
 	auth := base64.StdEncoding.EncodeToString([]byte("user:pass"))
 	read := strings.NewReader(fmt.Sprintf(`{"auths":{"docker.io":{"auth":"%s","email":"user@example.com"}}}`, auth))


### PR DESCRIPTION
If file ~/docker/config.json contains something except auth information parsing will fail. But according to the [doc](https://docs.docker.com/engine/reference/commandline/cli/) config.json could contain a bunch of other information: HttpHeaders, detachKeys etc...
 This patch solves this issue. 

