### PR TITLE
Repotags are also in docker inspect calls

### DIFF
--- a/image.go
+++ b/image.go
@@ -32,6 +32,7 @@ type APIImages struct {
 // Image is the type representing a docker image and its various properties
 type Image struct {
 	ID              string    `json:"Id" yaml:"Id"`
+	RepoTags        []string  `json:"RepoTags,omitempty" yaml:"RepoTags,omitempty"`
 	Parent          string    `json:"Parent,omitempty" yaml:"Parent,omitempty"`
 	Comment         string    `json:"Comment,omitempty" yaml:"Comment,omitempty"`
 	Created         time.Time `json:"Created,omitempty" yaml:"Created,omitempty"`


### PR DESCRIPTION
We need to get tags "aliases" from an inspect image api call. Docker inspect from command line returns a structure with RepoTags in it.

I would be nice if we could get from InspectImage also.