### PR TITLE
Add AuthStatus for /auth API call

### DIFF
--- a/auth_test.go
+++ b/auth_test.go
@@ -105,15 +105,15 @@ func TestAuthConfig(t *testing.T) {
 func TestAuthCheck(t *testing.T) {
 	fakeRT := &FakeRoundTripper{status: http.StatusOK}
 	client := newTestClient(fakeRT)
-	if err := client.AuthCheck(nil); err == nil {
+	if _, err := client.AuthCheck(nil); err == nil {
 		t.Fatalf("expected error on nil auth config")
 	}
 	// test good auth
-	if err := client.AuthCheck(&AuthConfiguration{}); err != nil {
+	if _, err := client.AuthCheck(&AuthConfiguration{}); err != nil {
 		t.Fatal(err)
 	}
 	*fakeRT = FakeRoundTripper{status: http.StatusUnauthorized}
-	if err := client.AuthCheck(&AuthConfiguration{}); err == nil {
+	if _, err := client.AuthCheck(&AuthConfiguration{}); err == nil {
 		t.Fatal("expected failure from unauthorized auth")
 	}
 }


### PR DESCRIPTION
Signed-off-by: Peter Edge <peter.edge@gmail.com>

The main thing to consider is whether we should return `(AuthStatus, error)` or `(*AuthStatus, error)`. I generally like returning pointers (and nil if there is no data), but since only Docker API versions >= 1.23 will return a struct that would be non-nil in this implementation, I think a non-pointer might be better. I want to default to no panics for nil access over what would be a silent error (ie the fields just won't be filled out).

What do you think? Also what do you think of the name `AuthStatus`?