### PR TITLE
add RootFS to Image, added in Docker 1.11.0

### DIFF
--- a/image.go
+++ b/image.go
@@ -29,6 +29,7 @@ type APIImages struct {
 	Labels      map[string]string `json:"Labels,omitempty" yaml:"Labels,omitempty"`
 }
 
+// RootFS represents the underlying layers used by an image
 type RootFS struct {
 	Type   string   `json:"Type,omitempty" yaml:"Type,omitempty"`
 	Layers []string `json:"Layers,omitempty" yaml:"Layers,omitempty"`

--- a/image.go
+++ b/image.go
@@ -29,6 +29,11 @@ type APIImages struct {
 	Labels      map[string]string `json:"Labels,omitempty" yaml:"Labels,omitempty"`
 }
 
+type RootFS struct {
+	Type   string   `json:"Type,omitempty" yaml:"Type,omitempty"`
+	Layers []string `json:"Layers,omitempty" yaml:"Layers,omitempty"`
+}
+
 // Image is the type representing a docker image and its various properties
 type Image struct {
 	ID              string    `json:"Id" yaml:"Id"`
@@ -45,6 +50,7 @@ type Image struct {
 	Size            int64     `json:"Size,omitempty" yaml:"Size,omitempty"`
 	VirtualSize     int64     `json:"VirtualSize,omitempty" yaml:"VirtualSize,omitempty"`
 	RepoDigests     []string  `json:"RepoDigests,omitempty" yaml:"RepoDigests,omitempty"`
+	RootFS          *RootFS   `json:"RootFS,omitempty" yaml:"RootFS,omitempty"`
 }
 
 // ImagePre012 serves the same purpose as the Image type except that it is for

--- a/image_test.go
+++ b/image_test.go
@@ -243,7 +243,14 @@ func TestInspectImage(t *testing.T) {
      "Created":"2013-03-23T22:24:18.818426Z",
      "Container":"3d67245a8d72ecf13f33dffac9f79dcdf70f75acb84d308770391510e0c23ad0",
      "ContainerConfig":{"Memory":1},
-     "VirtualSize":12345
+     "VirtualSize":12345,
+     "RootFS": {
+       "Type": "layers",
+       "Layers": [
+         "sha256:05a0deb2e405eb3095ab646dc1695a26bffe8bd4071e3af90efcf16e9d3f6d93",
+         "sha256:4c5db681b9aa9ab1cf666ec969a810c8ff4410e70e06394670dc4f3bf595532f"
+       ]
+    }
 }`
 
 	created, err := time.Parse(time.RFC3339Nano, "2013-03-23T22:24:18.818426Z")
@@ -260,6 +267,13 @@ func TestInspectImage(t *testing.T) {
 			Memory: 1,
 		},
 		VirtualSize: 12345,
+		RootFS: &RootFS{
+			Type: "layers",
+			Layers: []string{
+				"sha256:05a0deb2e405eb3095ab646dc1695a26bffe8bd4071e3af90efcf16e9d3f6d93",
+				"sha256:4c5db681b9aa9ab1cf666ec969a810c8ff4410e70e06394670dc4f3bf595532f",
+			},
+		},
 	}
 	fakeRT := &FakeRoundTripper{message: body, status: http.StatusOK}
 	client := newTestClient(fakeRT)


### PR DESCRIPTION
This was missed in the [v1.23 API changes](https://docs.docker.com/engine/reference/api/docker_remote_api/#v1-23-api-changes).

Upstream PR: docker/docker#21370

cc/ #500 