### PR TITLE
Fix JSON property name for IPAMOptions.Config.

### DIFF
--- a/network.go
+++ b/network.go
@@ -122,7 +122,7 @@ type CreateNetworkOptions struct {
 // See https://goo.gl/T8kRVH for more details.
 type IPAMOptions struct {
 	Driver string       `json:"Driver"`
-	Config []IPAMConfig `json:"IPAMConfig"`
+	Config []IPAMConfig `json:"Config"`
 }
 
 // IPAMConfig represents IPAM configurations


### PR DESCRIPTION
See for example [docs here](https://docs.docker.com/engine/reference/api/docker_remote_api_v1.23/#2-5-networks) (`[0].IPAM.Config`).

This was causing the `NetworkInfo` function to return empty config every time.