### PR TITLE
Add inactivityTimeout for all streamable api calls

### DIFF
--- a/cancelable.go
+++ b/cancelable.go
@@ -1,0 +1,17 @@
+// Copyright 2016 go-dockerclient authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build go1.5
+
+package docker
+
+import "net/http"
+
+func cancelable(client *http.Client, req *http.Request) func() {
+	ch := make(chan struct{})
+	req.Cancel = ch
+	return func() {
+		close(ch)
+	}
+}

--- a/cancelable_go14.go
+++ b/cancelable_go14.go
@@ -1,0 +1,19 @@
+// Copyright 2016 go-dockerclient authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !go1.5
+
+package docker
+
+import "net/http"
+
+func cancelable(client *http.Client, req *http.Request) func() {
+	return func() {
+		if rc, ok := client.Transport.(interface {
+			CancelRequest(*http.Request)
+		}); ok {
+			rc.CancelRequest(req)
+		}
+	}
+}

--- a/client_test.go
+++ b/client_test.go
@@ -10,6 +10,7 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -454,6 +455,103 @@ func TestPingErrorWithUnixSocket(t *testing.T) {
 	err := client.Ping()
 	if err == nil {
 		t.Fatal("Expected non nil error, got nil")
+	}
+}
+
+func TestClientStreamTimeoutNotHit(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		for i := 0; i < 5; i++ {
+			fmt.Fprintf(w, "%d\n", i)
+			if f, ok := w.(http.Flusher); ok {
+				f.Flush()
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+	}))
+	client, err := NewClient(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var w bytes.Buffer
+	err = client.stream("POST", "/image/create", streamOptions{
+		setRawTerminal:    true,
+		stdout:            &w,
+		inactivityTimeout: 300 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := "0\n1\n2\n3\n4\n"
+	result := w.String()
+	if result != expected {
+		t.Fatalf("expected stream result %q, got: %q", expected, result)
+	}
+}
+
+func TestClientStreamTimeout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		for i := 0; i < 5; i++ {
+			fmt.Fprintf(w, "%d\n", i)
+			if f, ok := w.(http.Flusher); ok {
+				f.Flush()
+			}
+			time.Sleep(500 * time.Millisecond)
+		}
+	}))
+	client, err := NewClient(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var w bytes.Buffer
+	err = client.stream("POST", "/image/create", streamOptions{
+		setRawTerminal:    true,
+		stdout:            &w,
+		inactivityTimeout: 100 * time.Millisecond,
+	})
+	if err != ErrInactivityTimeout {
+		t.Fatalf("expected request canceled error, got: %s", err)
+	}
+	expected := "0\n"
+	result := w.String()
+	if result != expected {
+		t.Fatalf("expected stream result %q, got: %q", expected, result)
+	}
+}
+
+func TestClientStreamTimeoutUnixSocket(t *testing.T) {
+	l, err := net.Listen("unix", "/tmp/docker_test.sock")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Close()
+	go func() {
+		http.Serve(l, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			for i := 0; i < 5; i++ {
+				fmt.Fprintf(w, "%d\n", i)
+				if f, ok := w.(http.Flusher); ok {
+					f.Flush()
+				}
+				time.Sleep(500 * time.Millisecond)
+			}
+		}))
+	}()
+	client, err := NewClient("unix:///tmp/docker_test.sock")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var w bytes.Buffer
+	err = client.stream("POST", "/image/create", streamOptions{
+		setRawTerminal:    true,
+		stdout:            &w,
+		inactivityTimeout: 100 * time.Millisecond,
+	})
+	if err != ErrInactivityTimeout {
+		t.Fatalf("expected request canceled error, got: %s", err)
+	}
+	expected := "0\n"
+	result := w.String()
+	if result != expected {
+		t.Fatalf("expected stream result %q, got: %q", expected, result)
 	}
 }
 

--- a/container_test.go
+++ b/container_test.go
@@ -1977,7 +1977,7 @@ func TestStatsTimeout(t *testing.T) {
 	statsC := make(chan *Stats)
 	done := make(chan bool)
 	go func() {
-		errC <- client.Stats(StatsOptions{"c", statsC, true, done, time.Millisecond * 100})
+		errC <- client.Stats(StatsOptions{ID: "c", Stats: statsC, Stream: true, Done: done, Timeout: time.Millisecond * 100})
 		close(errC)
 	}()
 	err = <-errC
@@ -2267,7 +2267,7 @@ func TestStats(t *testing.T) {
 	statsC := make(chan *Stats)
 	done := make(chan bool)
 	go func() {
-		errC <- client.Stats(StatsOptions{id, statsC, true, done, 0})
+		errC <- client.Stats(StatsOptions{ID: id, Stats: statsC, Stream: true, Done: done})
 		close(errC)
 	}()
 	var resultStats []*Stats
@@ -2304,7 +2304,7 @@ func TestStatsContainerNotFound(t *testing.T) {
 	client := newTestClient(&FakeRoundTripper{message: "no such container", status: http.StatusNotFound})
 	statsC := make(chan *Stats)
 	done := make(chan bool)
-	err := client.Stats(StatsOptions{"abef348", statsC, true, done, 0})
+	err := client.Stats(StatsOptions{ID: "abef348", Stats: statsC, Stream: true, Done: done})
 	expected := &NoSuchContainer{ID: "abef348"}
 	if !reflect.DeepEqual(err, expected) {
 		t.Errorf("Stats: Wrong error returned. Want %#v. Got %#v.", expected, err)


### PR DESCRIPTION
With this pull request, if no data is received in `inactivityTimeout` time the request will be canceled. This is specially useful for Pull And Push on a unreliable network that could start to silently drop packages between two hosts.