### PR TITLE
Fix send on closed channel when re-adding event listener

### DIFF
--- a/event.go
+++ b/event.go
@@ -310,7 +310,7 @@ func (c *Client) eventHijack(startTime int64, eventChan chan *APIEvents, errChan
 			var event APIEvents
 			if err = decoder.Decode(&event); err != nil {
 				if err == io.EOF || err == io.ErrUnexpectedEOF {
-					if c.eventMonitor.isEnabled() {
+					if c.eventMonitor.isEnabled() && c.eventMonitor.C == eventChan {
 						// Signal that we're exiting.
 						eventChan <- EOFEvent
 					}
@@ -321,7 +321,7 @@ func (c *Client) eventHijack(startTime int64, eventChan chan *APIEvents, errChan
 			if event.Time == 0 {
 				continue
 			}
-			if !c.eventMonitor.isEnabled() {
+			if !c.eventMonitor.isEnabled() || c.eventMonitor.C != eventChan {
 				return
 			}
 			transformEvent(&event)


### PR DESCRIPTION
When the last event listener is removed, the internal event channel (`eventMonitoringState.C`) is closed, but the running goroutine from eventHijack will remain running, waiting on the docker daemon for new events. As soon as a new event arrives from the docker daemon, the goroutine returns because it detects event monitoring is no longer enabled.

However, when a new event listener is added (or the old one re-added) before a new event arrives, the old goroutine will think everything is fine because monitoring is enabled. It will then send the event to the old, now closed, internal event channel, resulting in a "send on closed channel" panic.

This PR addresses this issue by checking not only if event monitoring is enabled, but also if the internal event channel is still the same one as the goroutine is using. If not, stop the goroutine.

I've included a test case which covers this specific case.