### PR TITLE
testing: lock before find on removal, otherwise index may not exist

### DIFF
--- a/testing/server.go
+++ b/testing/server.go
@@ -718,7 +718,9 @@ func (s *DockerServer) waitContainer(w http.ResponseWriter, r *http.Request) {
 func (s *DockerServer) removeContainer(w http.ResponseWriter, r *http.Request) {
 	id := mux.Vars(r)["id"]
 	force := r.URL.Query().Get("force")
-	container, index, err := s.findContainer(id)
+	s.cMut.Lock()
+	defer s.cMut.Unlock()
+	container, index, err := s.findContainerWithLock(id, false)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusNotFound)
 		return
@@ -729,12 +731,8 @@ func (s *DockerServer) removeContainer(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
-	s.cMut.Lock()
-	defer s.cMut.Unlock()
-	if s.containers[index].ID == id || s.containers[index].Name == id {
-		s.containers[index] = s.containers[len(s.containers)-1]
-		s.containers = s.containers[:len(s.containers)-1]
-	}
+	s.containers[index] = s.containers[len(s.containers)-1]
+	s.containers = s.containers[:len(s.containers)-1]
 }
 
 func (s *DockerServer) commitContainer(w http.ResponseWriter, r *http.Request) {
@@ -777,8 +775,14 @@ func (s *DockerServer) commitContainer(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *DockerServer) findContainer(idOrName string) (*docker.Container, int, error) {
-	s.cMut.RLock()
-	defer s.cMut.RUnlock()
+	return s.findContainerWithLock(idOrName, true)
+}
+
+func (s *DockerServer) findContainerWithLock(idOrName string, shouldLock bool) (*docker.Container, int, error) {
+	if shouldLock {
+		s.cMut.RLock()
+		defer s.cMut.RUnlock()
+	}
 	for i, container := range s.containers {
 		if container.ID == idOrName || container.Name == idOrName {
 			return container, i, nil


### PR DESCRIPTION
I think this problem also exist on some other handlers using the `index` return argument from `findContainer` however this problem is more evident in `removeContainer` as it's quite easy to trigger a index out of range panic with some simultaneous removals.