### PR TITLE
Add MemoryReservation to HostConfig struct

### DIFF
--- a/container.go
+++ b/container.go
@@ -626,6 +626,7 @@ type HostConfig struct {
 	SecurityOpt          []string               `json:"SecurityOpt,omitempty" yaml:"SecurityOpt,omitempty"`
 	CgroupParent         string                 `json:"CgroupParent,omitempty" yaml:"CgroupParent,omitempty"`
 	Memory               int64                  `json:"Memory,omitempty" yaml:"Memory,omitempty"`
+	MemoryReservation    int64                  `json:"MemoryReservation,omitempty" yaml:"MemoryReservation,omitempty"`
 	MemorySwap           int64                  `json:"MemorySwap,omitempty" yaml:"MemorySwap,omitempty"`
 	MemorySwappiness     int64                  `json:"MemorySwappiness,omitempty" yaml:"MemorySwappiness,omitempty"`
 	OOMKillDisable       bool                   `json:"OomKillDisable,omitempty" yaml:"OomKillDisable"`


### PR DESCRIPTION
Setting MemoryReservation must be done via HostConfig not Config. It's ok to leave the MemoryReservation field in the Config stuct for backward compatibility and to not break the api because the docker api will just ignore it anyway.