### PR TITLE
Change struct alignment to work on both 32 and 64 bit OS

### DIFF
--- a/event.go
+++ b/event.go
@@ -53,10 +53,12 @@ type APIActor struct {
 }
 
 type eventMonitoringState struct {
+	// `sync/atomic` expects the first word in an allocated struct to be 64-bit
+	// aligned on both ARM and x86-32. See https://goo.gl/zW7dgq for more details.
+	lastSeen int64
 	sync.RWMutex
 	sync.WaitGroup
 	enabled   bool
-	lastSeen  int64
 	C         chan *APIEvents
 	errC      chan error
 	listeners []chan<- *APIEvents


### PR DESCRIPTION
We bumped into these runtime errors while running a `go-dockerclient`-depending project on `i386` and `armhf` containers that run 32bit OSes:

## armhf
```
root@raspberrypi2:~# uname -ar
Linux raspberrypi2 4.1.21 #1 SMP Wed May 11 09:55:41 CEST 2016 armv7l GNU/Linux

root@raspberrypi2:~# docker logs d98964d460b1
# logspout v3.1 by gliderlabs
# adapters: udp tls raw syslog tcp
# options : persist:/mnt/routes
# jobs    : http[logs,routes]:80 pump routes
# routes  :
#   ADAPTER	ADDRESS			CONTAINERS	SOURCES	OPTIONS
#   syslog+tls	api.logentries.com:26465			map[structuredData:5313bf05-37f7-474b-bdaf-28ecefb1450f]
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x4 pc=0xfa7bc]

goroutine 20 [running]:
sync/atomic.storeUint64(0x1070e98c, 0x0, 0x0)
	/usr/lib/go/src/sync/atomic/64bit_arm.go:20 +0x40
github.com/fsouza/go-dockerclient.(*eventMonitoringState).enableEventMonitoring(0x1070e960, 0x1070e9b0, 0x0, 0x0)
	/go/src/github.com/fsouza/go-dockerclient/event.go:165 +0xc0
github.com/fsouza/go-dockerclient.(*Client).AddEventListener(0x1070e9b0, 0x10a363c0, 0x0, 0x0)
	/go/src/github.com/fsouza/go-dockerclient/event.go:92 +0x58
github.com/gliderlabs/logspout/router.(*LogsPump).Run(0x1070d7c0, 0x0, 0x0)
	/go/src/github.com/gliderlabs/logspout/router/pump.go:113 +0x27c
main.main.func1(0x76d353e0, 0x1070d7c0)
	/go/src/github.com/gliderlabs/logspout/logspout.go:72 +0x48
created by main.main
	/go/src/github.com/gliderlabs/logspout/logspout.go:73 +0xffc

goroutine 1 [select (no cases)]:
main.main()
	/go/src/github.com/gliderlabs/logspout/logspout.go:76 +0x101c
[...]
```

## i386

```
root@edison:~# uname -ar
Linux edison 3.10.17-yocto-standard #1 SMP PREEMPT Mon May 9 14:18:26 CEST 2016 i686 GNU/Linux

root@edison:~# docker logs 9f3cb326d5bd
# logspout v3.1 by gliderlabs
# adapters: udp tls raw syslog tcp
# options : persist:/mnt/routes
# jobs    : http[logs,routes]:80 pump routes
# routes  :
#   ADAPTER	ADDRESS			CONTAINERS	SOURCES	OPTIONS
#   syslog+tls	api.logentries.com:26562			map[structuredData:da159c76-b475-48c4-a64a-6eed4afb24aa]
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x0 pc=0x811792b]

goroutine 20 [running]:
sync/atomic.StoreUint64(0x1870e98c, 0x0, 0x0)
	/usr/lib/go/src/sync/atomic/asm_386.s:190 +0xb
github.com/fsouza/go-dockerclient.(*eventMonitoringState).enableEventMonitoring(0x1870e960, 0x1870e9b0, 0x0, 0x0)
	/go/src/github.com/fsouza/go-dockerclient/event.go:165 +0xa9
github.com/fsouza/go-dockerclient.(*Client).AddEventListener(0x1870e9b0, 0x18a522c0, 0x0, 0x0)
	/go/src/github.com/fsouza/go-dockerclient/event.go:92 +0x59
github.com/gliderlabs/logspout/router.(*LogsPump).Run(0x1870d7c0, 0x0, 0x0)
	/go/src/github.com/gliderlabs/logspout/router/pump.go:113 +0x277
main.main.func1(0xb75763e0, 0x1870d7c0)
	/go/src/github.com/gliderlabs/logspout/logspout.go:72 +0x49
created by main.main
	/go/src/github.com/gliderlabs/logspout/logspout.go:73 +0xfbb

goroutine 1 [select (no cases)]:
main.main()
	/go/src/github.com/gliderlabs/logspout/logspout.go:76 +0xfdc
[...]
```

Noting that `go-dockerclient` worked fine on an `amd64` device:
```
root@intel-corei7-64:~# uname -ar
Linux intel-corei7-64 4.1.8-yocto-standard #1 SMP PREEMPT Thu Apr 28 00:42:12 CEST 2016 x86_64 GNU/Linux
```

### Fix

Our solution was to change the alignment of the `eventMonitoringState` structure fields, which apparently fixes the runtime error for the `i386` arch. Haven't tested `armhf` yet but it should work.

This seems like an instance of https://github.com/golang/go/issues/13868