### PR TITLE
add restart policy 'unless-stopped'

### DIFF
--- a/container.go
+++ b/container.go
@@ -546,6 +546,8 @@ type KeyValuePair struct {
 //   - always: the docker daemon will always restart the container
 //   - on-failure: the docker daemon will restart the container on failures, at
 //                 most MaximumRetryCount times
+//   - unless-stopped: the docker daemon will always restart the container except
+//                 when user has manually stopped the container
 //   - no: the docker daemon will not restart the container automatically
 type RestartPolicy struct {
 	Name              string `json:"Name,omitempty" yaml:"Name,omitempty"`
@@ -562,6 +564,12 @@ func AlwaysRestart() RestartPolicy {
 // restart the container on failures, trying at most maxRetry times.
 func RestartOnFailure(maxRetry int) RestartPolicy {
 	return RestartPolicy{Name: "on-failure", MaximumRetryCount: maxRetry}
+}
+
+// RestartUnlessStopped returns a restart policy that tells the Docker daemon to
+// always restart the container except when user has manually stopped the container.
+func RestartUnlessStopped() RestartPolicy {
+	return RestartPolicy{Name: "unless-stopped"}
 }
 
 // NeverRestart returns a restart policy that tells the Docker daemon to never

--- a/container_test.go
+++ b/container_test.go
@@ -1870,6 +1870,16 @@ func TestRestartOnFailure(t *testing.T) {
 	}
 }
 
+func TestRestartUnlessStopped(t *testing.T) {
+	policy := RestartUnlessStopped()
+	if policy.Name != "unless-stopped" {
+		t.Errorf("RestartUnlessStopped(): wrong policy name. Want %q. Got %q", "unless-stopped", policy.Name)
+	}
+	if policy.MaximumRetryCount != 0 {
+		t.Errorf("RestartUnlessStopped(): wrong MaximumRetryCount. Want 0. Got %d", policy.MaximumRetryCount)
+	}
+}
+
 func TestNeverRestart(t *testing.T) {
 	policy := NeverRestart()
 	if policy.Name != "no" {


### PR DESCRIPTION
Hi,

I've add the 'unless-stopped' restart policy, which allows Docker daemon always restart the container except when user has stopped it.

Please refer to  https://docs.docker.com/engine/reference/api/docker_remote_api_v1.21/

Thanks!