### PR TITLE
Remove atomic calls which segfault on ARM

### DIFF
--- a/event.go
+++ b/event.go
@@ -14,7 +14,6 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"sync"
-	"sync/atomic"
 	"time"
 )
 
@@ -162,7 +161,7 @@ func (eventState *eventMonitoringState) enableEventMonitoring(c *Client) error {
 	defer eventState.Unlock()
 	if !eventState.enabled {
 		eventState.enabled = true
-		atomic.StoreInt64(&eventState.lastSeen, 0)
+		eventState.lastSeen = 0
 		eventState.C = make(chan *APIEvents, 100)
 		eventState.errC = make(chan error, 1)
 		go eventState.monitorEvents(c)
@@ -229,7 +228,10 @@ func (eventState *eventMonitoringState) connectWithRetry(c *Client) error {
 	eventChan := eventState.C
 	errChan := eventState.errC
 	eventState.RUnlock()
-	err := c.eventHijack(atomic.LoadInt64(&eventState.lastSeen), eventChan, errChan)
+	eventState.Lock()
+	lastSeen := eventState.lastSeen
+	eventState.Unlock()
+	err := c.eventHijack(lastSeen, eventChan, errChan)
 	for ; err != nil && retries < maxMonitorConnRetries; retries++ {
 		waitTime := int64(retryInitialWaitTime * math.Pow(2, float64(retries)))
 		time.Sleep(time.Duration(waitTime) * time.Millisecond)
@@ -237,7 +239,10 @@ func (eventState *eventMonitoringState) connectWithRetry(c *Client) error {
 		eventChan = eventState.C
 		errChan = eventState.errC
 		eventState.RUnlock()
-		err = c.eventHijack(atomic.LoadInt64(&eventState.lastSeen), eventChan, errChan)
+		eventState.Lock()
+		lastSeen = eventState.lastSeen
+		eventState.Unlock()
+		err = c.eventHijack(lastSeen, eventChan, errChan)
 	}
 	return err
 }
@@ -274,8 +279,8 @@ func (eventState *eventMonitoringState) sendEvent(event *APIEvents) {
 func (eventState *eventMonitoringState) updateLastSeen(e *APIEvents) {
 	eventState.Lock()
 	defer eventState.Unlock()
-	if atomic.LoadInt64(&eventState.lastSeen) < e.Time {
-		atomic.StoreInt64(&eventState.lastSeen, e.Time)
+	if eventState.lastSeen < e.Time {
+		eventState.lastSeen = e.Time
 	}
 }
 


### PR DESCRIPTION
Fixes #525 

atomic has some known issues on ARM, this removes the atomic calls in favor of just using the base mutex locks that are already in place. This fixes the segfault error in the linked issue.