### PR TITLE
Use DOCKER_CONFIG env var for auth. Fixes #530

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -46,21 +46,45 @@ type dockerConfig struct {
 	Email string `json:"email"`
 }
 
-// NewAuthConfigurationsFromDockerCfg returns AuthConfigurations from the
-// ~/.dockercfg file.
-func NewAuthConfigurationsFromDockerCfg() (*AuthConfigurations, error) {
-	var r io.Reader
-	var err error
-	p := path.Join(os.Getenv("HOME"), ".docker", "config.json")
-	r, err = os.Open(p)
+// NewAuthConfigurationsFromFile returns AuthConfigurations from a path containing JSON
+// in the same format as the .dockercfg file.
+func NewAuthConfigurationsFromFile(path string) (*AuthConfigurations, error) {
+	r, err := os.Open(path)
 	if err != nil {
-		p := path.Join(os.Getenv("HOME"), ".dockercfg")
-		r, err = os.Open(p)
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 	return NewAuthConfigurations(r)
+}
+
+func cfgPaths(dockerConfigEnv string, homeEnv string) []string {
+	var paths []string
+	if dockerConfigEnv != "" {
+		paths = append(paths, path.Join(dockerConfigEnv, "config.json"))
+	}
+	if homeEnv != "" {
+		paths = append(paths, path.Join(homeEnv, ".docker", "config.json"))
+		paths = append(paths, path.Join(homeEnv, ".dockercfg"))
+	}
+	return paths
+}
+
+// NewAuthConfigurationsFromDockerCfg returns AuthConfigurations from
+// system config files. The following files are checked in the order listed:
+// - $DOCKER_CONFIG/config.json if DOCKER_CONFIG set in the environment,
+// - $HOME/.docker/config.json
+// - $HOME/.dockercfg
+func NewAuthConfigurationsFromDockerCfg() (*AuthConfigurations, error) {
+	err := fmt.Errorf("No docker configuration found")
+	var auths *AuthConfigurations
+
+	pathsToTry := cfgPaths(os.Getenv("DOCKER_CONFIG"), os.Getenv("HOME"))
+	for _, path := range pathsToTry {
+		auths, err = NewAuthConfigurationsFromFile(path)
+		if err == nil {
+			return auths, nil
+		}
+	}
+	return auths, err
 }
 
 // NewAuthConfigurations returns AuthConfigurations from a JSON encoded string in the


### PR DESCRIPTION
As described in https://github.com/fsouza/go-dockerclient/issues/530, the official docker client supports setting the environment variable `DOCKER_CONFIG` as the location in which to look for `config.json` which contains registry authentication.

This change adds that functionality to `go-dockerclient`.

It also adds a test for the function that changed.

I don't much like what I had to do for the test. My background is dynamic programming, where stubbing file reads and environment variable lookups is easy, so the result feels quite heavy-handed to me. If you have feedback regarding how I can improve the test, do comment and I'll do my best to follow it.