### PR TITLE
Add support for Tmpfs option in HostConfig

### DIFF
--- a/container.go
+++ b/container.go
@@ -655,6 +655,7 @@ type HostConfig struct {
 	OomScoreAdj          int                    `json:"OomScoreAdj,omitempty" yaml:"OomScoreAdj,omitempty"`
 	PidsLimit            int64                  `json:"PidsLimit,omitempty" yaml:"PidsLimit,omitempty"`
 	ShmSize              int64                  `json:"ShmSize,omitempty" yaml:"ShmSize,omitempty"`
+	Tmpfs                map[string]string      `json:"Tmpfs,omitempty" yaml:"Tmpfs,omitempty"`
 }
 
 // NetworkingConfig represents the container's networking configuration for each of its interfaces


### PR DESCRIPTION
This PR adds support for the `Tmpfs` field added to `HostConfig` in https://github.com/docker/docker/pull/13587