### PR TITLE
Implement testing server docker remote api version endpoint

### DIFF
--- a/testing/server.go
+++ b/testing/server.go
@@ -145,6 +145,7 @@ func (s *DockerServer) buildMuxer() {
 	s.mux.Path("/volumes/{name:.*}").Methods("GET").HandlerFunc(s.handlerWrapper(s.inspectVolume))
 	s.mux.Path("/volumes/{name:.*}").Methods("DELETE").HandlerFunc(s.handlerWrapper(s.removeVolume))
 	s.mux.Path("/info").Methods("GET").HandlerFunc(s.handlerWrapper(s.infoDocker))
+	s.mux.Path("/version").Methods("GET").HandlerFunc(s.handlerWrapper(s.versionDocker))
 }
 
 // SetHook changes the hook function used by the server.
@@ -1328,6 +1329,22 @@ func (s *DockerServer) infoDocker(w http.ResponseWriter, r *http.Request) {
 		"ServerVersion":     "1.10.1",
 		"ClusterStore":      "",
 		"ClusterAdvertise":  "",
+	}
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(envs)
+}
+
+func (s *DockerServer) versionDocker(w http.ResponseWriter, r *http.Request) {
+	envs := map[string]interface{}{
+		"Version":       "1.10.1",
+		"Os":            "linux",
+		"KernelVersion": "3.13.0-77-generic",
+		"GoVersion":     "go1.4.2",
+		"GitCommit":     "9e83765",
+		"Arch":          "amd64",
+		"ApiVersion":    "1.22",
+		"BuildTime":     "2015-12-01T07:09:13.444803460+00:00",
+		"Experimental":  false,
 	}
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(envs)

--- a/testing/server_test.go
+++ b/testing/server_test.go
@@ -2135,3 +2135,14 @@ func TestInfoDocker(t *testing.T) {
 		t.Fatalf("InfoDocker: wrong docker root. Want /var/lib/docker. Got %s.", infoData["DockerRootDir"])
 	}
 }
+
+func TestVersionDocker(t *testing.T) {
+	server, _ := NewServer("127.0.0.1:0", nil, nil)
+	server.buildMuxer()
+	recorder := httptest.NewRecorder()
+	request, _ := http.NewRequest("GET", "/version", nil)
+	server.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("VersionDocker: wrong status. Want %d. Got %d.", http.StatusOK, recorder.Code)
+	}
+}


### PR DESCRIPTION
The following commit breaks the testing server start container endpoint:
https://github.com/fsouza/go-dockerclient/commit/67c30ae246a11510ed1c3b72145e2daf76e4d664
```go
	if c.serverAPIVersion == nil {
		c.checkAPIVersion()
	}
	if c.serverAPIVersion != nil && c.serverAPIVersion.LessThan(apiVersion124) {
		opts = doOptions{data: hostConfig, forceJSON: true}
	}
```

The request to `checkAPIVersion()` returns 404, setting `c.serverAPIVersion = nil`, and start container endpoint returns `API error (500): EOF` when trying to unmarshal nil HostConfig.

https://github.com/fsouza/go-dockerclient/blob/9d5fef7969a53796f7405827c3e68804f533b1ee/testing/server.go#L561-L565
```go
	err = json.NewDecoder(r.Body).Decode(&hostConfig)
	if err != nil {
		http.Error(w, err.Error(), http.StatusInternalServerError)
		return
	}
```
