### PR TITLE
Add json and yaml tags to network and container

### DIFF
--- a/container.go
+++ b/container.go
@@ -668,7 +668,7 @@ type HostConfig struct {
 // NetworkingConfig represents the container's networking configuration for each of its interfaces
 // Carries the networking configs specified in the `docker run` and `docker network connect` commands
 type NetworkingConfig struct {
-	EndpointsConfig map[string]*EndpointConfig // Endpoint configs for each connecting network
+	EndpointsConfig map[string]*EndpointConfig `json:"EndpointsConfig" yaml:"EndpointsConfig"` // Endpoint configs for each connecting network
 }
 
 // StartContainer starts a container, returning an error in case of failure.

--- a/network.go
+++ b/network.go
@@ -206,18 +206,18 @@ type NetworkConnectionOptions struct {
 //
 // See https://goo.gl/RV7BJU for more details.
 type EndpointConfig struct {
-	IPAMConfig          *EndpointIPAMConfig
-	Links               []string
-	Aliases             []string
-	NetworkID           string
-	EndpointID          string
-	Gateway             string
-	IPAddress           string
-	IPPrefixLen         int
-	IPv6Gateway         string
-	GlobalIPv6Address   string
-	GlobalIPv6PrefixLen int
-	MacAddress          string
+	IPAMConfig          *EndpointIPAMConfig `json:"IPAMConfig,omitempty" yaml:"IPAMConfig,omitempty"`
+	Links               []string            `json:"Links,omitempty" yaml:"Links,omitempty"`
+	Aliases             []string            `json:"Aliases,omitempty" yaml:"Aliases,omitempty"`
+	NetworkID           string              `json:"NetworkID,omitempty" yaml:"NetworkID,omitempty"`
+	EndpointID          string              `json:"EndpointID,omitempty" yaml:"EndpointID,omitempty"`
+	Gateway             string              `json:"Gateway,omitempty" yaml:"Gateway,omitempty"`
+	IPAddress           string              `json:"IPAddress,omitempty" yaml:"IPAddress,omitempty"`
+	IPPrefixLen         int                 `json:"IPPrefixLen,omitempty" yaml:"IPPrefixLen,omitempty"`
+	IPv6Gateway         string              `json:"IPv6Gateway,omitempty" yaml:"IPv6Gateway,omitempty"`
+	GlobalIPv6Address   string              `json:"GlobalIPv6Address,omitempty" yaml:"GlobalIPv6Address,omitempty"`
+	GlobalIPv6PrefixLen int                 `json:"GlobalIPv6PrefixLen,omitempty" yaml:"GlobalIPv6PrefixLen,omitempty"`
+	MacAddress          string              `json:"MacAddress,omitempty" yaml:"MacAddress,omitempty"`
 }
 
 // EndpointIPAMConfig represents IPAM configurations for an

--- a/network.go
+++ b/network.go
@@ -108,21 +108,21 @@ func (c *Client) NetworkInfo(id string) (*Network, error) {
 //
 // See https://goo.gl/6GugX3 for more details.
 type CreateNetworkOptions struct {
-	Name           string                 `json:"Name"`
-	CheckDuplicate bool                   `json:"CheckDuplicate"`
-	Driver         string                 `json:"Driver"`
-	IPAM           IPAMOptions            `json:"IPAM"`
-	Options        map[string]interface{} `json:"Options"`
-	Internal       bool                   `json:"Internal"`
-	EnableIPv6     bool                   `json:"EnableIPv6"`
+	Name           string                 `json:"Name" yaml:"Name"`
+	CheckDuplicate bool                   `json:"CheckDuplicate" yaml:"CheckDuplicate"`
+	Driver         string                 `json:"Driver" yaml:"Driver"`
+	IPAM           IPAMOptions            `json:"IPAM" yaml:"IPAM"`
+	Options        map[string]interface{} `json:"Options" yaml:"Options"`
+	Internal       bool                   `json:"Internal yaml:"Internal""`
+	EnableIPv6     bool                   `json:"EnableIPv6" yaml:"EnableIPv6"`
 }
 
 // IPAMOptions controls IP Address Management when creating a network
 //
 // See https://goo.gl/T8kRVH for more details.
 type IPAMOptions struct {
-	Driver string       `json:"Driver"`
-	Config []IPAMConfig `json:"Config"`
+	Driver string       `json:"Driver" yaml:"Driver"`
+	Config []IPAMConfig `json:"Config" yaml:"Config"`
 }
 
 // IPAMConfig represents IPAM configurations


### PR DESCRIPTION
This allows specifying for example "Alias" on the networking config for a container.