### PR TITLE
Cancel request

### DIFF
--- a/container.go
+++ b/container.go
@@ -1264,6 +1264,7 @@ type LogsOptions struct {
 	Since             int64
 	Timestamps        bool
 	Tail              string
+	CancelChannel     chan struct{}
 
 	// Use raw terminal? Usually true when the container contains a TTY.
 	RawTerminal bool `qs:"-"`
@@ -1285,6 +1286,7 @@ func (c *Client) Logs(opts LogsOptions) error {
 		stdout:            opts.OutputStream,
 		stderr:            opts.ErrorStream,
 		inactivityTimeout: opts.InactivityTimeout,
+		cancelChannel:     opts.CancelChannel,
 	})
 }
 


### PR DESCRIPTION
Currently, there is only one way of cancelling streaming API request - inactive timeout. I wanted to cancel request when user interrupts reading data in client code. So I introduced new parameter in streamOptions type.