### PR TITLE
Add comment about deprecation of registry parameter

### DIFF
--- a/image.go
+++ b/image.go
@@ -280,8 +280,12 @@ func (c *Client) PushImage(opts PushImageOptions, auth AuthConfiguration) error 
 // See https://goo.gl/iJkZjD for more details.
 type PullImageOptions struct {
 	Repository string `qs:"fromImage"`
-	Registry   string
 	Tag        string
+
+	// Only required for Docker Engine 1.9 or 1.10 w/ Remote API < 1.21
+	// and Docker Engine < 1.9
+	// This parameter was removed in Docker Engine 1.11
+	Registry string
 
 	OutputStream      io.Writer     `qs:"-"`
 	RawJSONStream     bool          `qs:"-"`


### PR DESCRIPTION
I was wondering why the `Registry` parameter had absolutely no effect in my context and why it's not even documented in the Docker Remote API reference, then I went back in time, walked through some old versions and realised it was just removed at one point.

Hopefully this will save folks reading the code time if nothing else.
I guess the library could stop sending this parameter completely to the Remote API for certain versions, but I'm not sure about the intentions of this library in regards to backward compatibility.

-----

The same parameter in `PushImageOptions` is _actually_ unused from what I can see, check the oldest available Remote API Reference: https://docs.docker.com/v1.4/reference/api/docker_remote_api_v1.11/#push-an-image-on-the-registry - there is zero notion of that parameter.