### PR TITLE
Swarm: Add APIS (Init, Join, Leave and Update)

### DIFF
--- a/swarm.go
+++ b/swarm.go
@@ -14,14 +14,14 @@ import (
 	"github.com/docker/engine-api/types/swarm"
 )
 
-type SwarmInitOptions struct {
+type InitSwarmOptions struct {
 	swarm.InitRequest
 	Context context.Context
 }
 
-// SwarmInit initializes a new Swarm and returns the node ID.
+// InitSwarm initializes a new Swarm and returns the node ID.
 // See https://goo.gl/hzkgWu for more details.
-func (c *Client) SwarmInit(opts SwarmInitOptions) (string, error) {
+func (c *Client) InitSwarm(opts InitSwarmOptions) (string, error) {
 	path := "/swarm/init"
 	resp, err := c.do("POST", path, doOptions{
 		data:      opts.InitRequest,
@@ -39,14 +39,14 @@ func (c *Client) SwarmInit(opts SwarmInitOptions) (string, error) {
 	return response, nil
 }
 
-type SwarmJoinOptions struct {
+type JoinSwarmOptions struct {
 	swarm.JoinRequest
 	Context context.Context
 }
 
-// SwarmJoin joins an existing Swarm.
+// JoinSwarm joins an existing Swarm.
 // See https://goo.gl/TdhJWU for more details.
-func (c *Client) SwarmJoin(opts SwarmJoinOptions) error {
+func (c *Client) JoinSwarm(opts JoinSwarmOptions) error {
 	path := "/swarm/join"
 	_, err := c.do("POST", path, doOptions{
 		data:      opts.JoinRequest,
@@ -56,14 +56,14 @@ func (c *Client) SwarmJoin(opts SwarmJoinOptions) error {
 	return err
 }
 
-type SwarmLeaveOptions struct {
+type LeaveSwarmOptions struct {
 	Force   bool
 	Context context.Context
 }
 
-// SwarmLeave leaves a Swarm.
+// LeaveSwarm leaves a Swarm.
 // See https://goo.gl/UWDlLg for more details.
-func (c *Client) SwarmLeave(opts SwarmLeaveOptions) error {
+func (c *Client) LeaveSwarm(opts LeaveSwarmOptions) error {
 	params := make(url.Values)
 	if opts.Force {
 		params.Set("force", "1")
@@ -75,7 +75,7 @@ func (c *Client) SwarmLeave(opts SwarmLeaveOptions) error {
 	return err
 }
 
-type SwarmUpdateOptions struct {
+type UpdateSwarmOptions struct {
 	Version            int
 	RotateWorkerToken  bool
 	RotateManagerToken bool
@@ -85,7 +85,7 @@ type SwarmUpdateOptions struct {
 
 // SwarmUpdate updates a Swarm.
 // See https://goo.gl/vFbq36 for more details.
-func (c *Client) SwarmUpdate(opts SwarmUpdateOptions) error {
+func (c *Client) UpdateSwarm(opts UpdateSwarmOptions) error {
 	params := make(url.Values)
 	params.Set("version", strconv.Itoa(opts.Version))
 	params.Set("rotateWorkerToken", strconv.FormatBool(opts.RotateWorkerToken))

--- a/swarm.go
+++ b/swarm.go
@@ -14,6 +14,8 @@ import (
 	"github.com/docker/engine-api/types/swarm"
 )
 
+// InitSwarmOptions specify parameters to the InitSwarm function.
+// See https://goo.gl/hzkgWu for more details.
 type InitSwarmOptions struct {
 	swarm.InitRequest
 	Context context.Context
@@ -39,6 +41,8 @@ func (c *Client) InitSwarm(opts InitSwarmOptions) (string, error) {
 	return response, nil
 }
 
+// JoinSwarmOptions specify parameters to the JoinSwarm function.
+// See https://goo.gl/TdhJWU for more details.
 type JoinSwarmOptions struct {
 	swarm.JoinRequest
 	Context context.Context
@@ -56,6 +60,8 @@ func (c *Client) JoinSwarm(opts JoinSwarmOptions) error {
 	return err
 }
 
+// LeaveSwarmOptions specify parameters to the LeaveSwarm function.
+// See https://goo.gl/UWDlLg for more details.
 type LeaveSwarmOptions struct {
 	Force   bool
 	Context context.Context
@@ -75,6 +81,8 @@ func (c *Client) LeaveSwarm(opts LeaveSwarmOptions) error {
 	return err
 }
 
+// UpdateSwarmOptions specify parameters to the UpdateSwarm function.
+// See https://goo.gl/vFbq36 for more details.
 type UpdateSwarmOptions struct {
 	Version            int
 	RotateWorkerToken  bool
@@ -83,7 +91,7 @@ type UpdateSwarmOptions struct {
 	Context            context.Context
 }
 
-// SwarmUpdate updates a Swarm.
+// UpdateSwarm updates a Swarm.
 // See https://goo.gl/vFbq36 for more details.
 func (c *Client) UpdateSwarm(opts UpdateSwarmOptions) error {
 	params := make(url.Values)

--- a/swarm.go
+++ b/swarm.go
@@ -70,9 +70,7 @@ type LeaveSwarmOptions struct {
 // See https://goo.gl/UWDlLg for more details.
 func (c *Client) LeaveSwarm(opts LeaveSwarmOptions) error {
 	params := make(url.Values)
-	if opts.Force {
-		params.Set("force", "1")
-	}
+	params.Set("force", strconv.FormatBool(opts.Force))
 	path := "/swarm/leave?" + params.Encode()
 	_, err := c.do("POST", path, doOptions{
 		context: opts.Context,

--- a/swarm.go
+++ b/swarm.go
@@ -7,6 +7,7 @@ package docker
 import (
 	"encoding/json"
 	"net/url"
+	"strconv"
 
 	"github.com/docker/engine-api/types/swarm"
 )
@@ -44,5 +45,25 @@ func (c *Client) SwarmLeave(force bool) error {
 	}
 	path := "/swarm/leave?" + params.Encode()
 	_, err := c.do("POST", path, doOptions{})
+	return err
+}
+
+type SwarmUpdateOptions struct {
+	Version            int
+	RotateWorkerToken  bool
+	RotateManagerToken bool
+	Swarm              swarm.Spec
+}
+
+func (c *Client) SwarmUpdate(opts SwarmUpdateOptions) error {
+	params := make(url.Values)
+	params.Set("version", strconv.Itoa(opts.Version))
+	params.Set("rotateWorkerToken", strconv.FormatBool(opts.RotateWorkerToken))
+	params.Set("rotateManagerToken", strconv.FormatBool(opts.RotateManagerToken))
+	path := "/swarm/update?" + params.Encode()
+	_, err := c.do("POST", path, doOptions{
+		data:      opts.Swarm,
+		forceJSON: true,
+	})
 	return err
 }

--- a/swarm.go
+++ b/swarm.go
@@ -1,0 +1,28 @@
+// Copyright 2016 go-dockerclient authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package docker
+
+import (
+	"encoding/json"
+
+	"github.com/docker/engine-api/types/swarm"
+)
+
+func (c *Client) SwarmInit(opts swarm.InitRequest) (string, error) {
+	path := "/swarm/init"
+	resp, err := c.do("POST", path, doOptions{
+		data:      opts,
+		forceJSON: true,
+	})
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	var response string
+	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+		return "", err
+	}
+	return response, nil
+}

--- a/swarm.go
+++ b/swarm.go
@@ -6,6 +6,7 @@ package docker
 
 import (
 	"encoding/json"
+	"net/url"
 
 	"github.com/docker/engine-api/types/swarm"
 )
@@ -33,5 +34,15 @@ func (c *Client) SwarmJoin(opts swarm.JoinRequest) error {
 		data:      opts,
 		forceJSON: true,
 	})
+	return err
+}
+
+func (c *Client) SwarmLeave(force bool) error {
+	params := make(url.Values)
+	if force {
+		params.Set("force", "1")
+	}
+	path := "/swarm/leave?" + params.Encode()
+	_, err := c.do("POST", path, doOptions{})
 	return err
 }

--- a/swarm.go
+++ b/swarm.go
@@ -15,13 +15,15 @@ import (
 	"golang.org/x/net/context"
 )
 
-// ErrNodeAlreadyInSwarm is the error returned by InitSwarm and JoinSwarm
-// when the node is already part of a Swarm.
-var ErrNodeAlreadyInSwarm = errors.New("node already in a Swarm")
+var (
+	// ErrNodeAlreadyInSwarm is the error returned by InitSwarm and JoinSwarm
+	// when the node is already part of a Swarm.
+	ErrNodeAlreadyInSwarm = errors.New("node already in a Swarm")
 
-// ErrNodeNotInSwarm is the error returned by LeaveSwarm and UpdateSwarm
-// when the node is not part of a Swarm.
-var ErrNodeNotInSwarm = errors.New("node is not in a Swarm")
+	// ErrNodeNotInSwarm is the error returned by LeaveSwarm and UpdateSwarm
+	// when the node is not part of a Swarm.
+	ErrNodeNotInSwarm = errors.New("node is not in a Swarm")
+)
 
 // InitSwarmOptions specify parameters to the InitSwarm function.
 // See https://goo.gl/hzkgWu for more details.

--- a/swarm.go
+++ b/swarm.go
@@ -26,3 +26,12 @@ func (c *Client) SwarmInit(opts swarm.InitRequest) (string, error) {
 	}
 	return response, nil
 }
+
+func (c *Client) SwarmJoin(opts swarm.JoinRequest) error {
+	path := "/swarm/join"
+	_, err := c.do("POST", path, doOptions{
+		data:      opts,
+		forceJSON: true,
+	})
+	return err
+}

--- a/swarm.go
+++ b/swarm.go
@@ -9,9 +9,8 @@ import (
 	"net/url"
 	"strconv"
 
-	"golang.org/x/net/context"
-
 	"github.com/docker/engine-api/types/swarm"
+	"golang.org/x/net/context"
 )
 
 // InitSwarmOptions specify parameters to the InitSwarm function.

--- a/swarm_test.go
+++ b/swarm_test.go
@@ -95,11 +95,17 @@ func TestUpdateSwarm(t *testing.T) {
 	if req.Method != expectedMethod {
 		t.Errorf("SwarmUpdate: Wrong HTTP method. Want %s. Got %s.", expectedMethod, req.Method)
 	}
-	expected, _ := url.Parse(client.getURL("/swarm/update?version=10&rotateManagerToken=true&rotateWorkerToken=false"))
-	if req.URL.Path != expected.Path {
-		t.Errorf("SwarmUpdate: Wrong request path. Want %q. Got %q.", expected.Path, req.URL.Path)
+	expectedPath := "/swarm/update"
+	if req.URL.Path != expectedPath {
+		t.Errorf("SwarmUpdate: Wrong request path. Want %q. Got %q.", expectedPath, req.URL.Path)
 	}
-	if !reflect.DeepEqual(req.URL.Query(), expected.Query()) {
-		t.Errorf("SwarmUpdate: Wrong request query. Want %v. Got %v", expected.Query(), req.URL.Query())
+	expected := map[string][]string{
+		"version":            {"10"},
+		"rotateManagerToken": {"true"},
+		"rotateWorkerToken":  {"false"},
+	}
+	got := map[string][]string(req.URL.Query())
+	if !reflect.DeepEqual(got, expected) {
+		t.Errorf("SwarmUpdate: Wrong request query. Want %v. Got %v", expected, got)
 	}
 }

--- a/swarm_test.go
+++ b/swarm_test.go
@@ -48,6 +48,33 @@ func TestSwarmJoin(t *testing.T) {
 	}
 	u, _ := url.Parse(client.getURL("/swarm/join"))
 	if req.URL.Path != u.Path {
-		t.Errorf("SwarmInit: Wrong request path. Want %q. Got %q.", u.Path, req.URL.Path)
+		t.Errorf("SwarmJoin: Wrong request path. Want %q. Got %q.", u.Path, req.URL.Path)
+	}
+}
+
+func TestSwarmLeave(t *testing.T) {
+	fakeRT := &FakeRoundTripper{message: "", status: http.StatusOK}
+	client := newTestClient(fakeRT)
+	var testData = []struct {
+		force       bool
+		expectedURI string
+	}{
+		{false, "/swarm/leave?"},
+		{true, "/swarm/leave?force=1"},
+	}
+	for i, tt := range testData {
+		err := client.SwarmLeave(tt.force)
+		if err != nil {
+			t.Fatal(err)
+		}
+		expectedMethod := "POST"
+		req := fakeRT.requests[i]
+		if req.Method != expectedMethod {
+			t.Errorf("SwarmLeave: Wrong HTTP method. Want %s. Got %s.", expectedMethod, req.Method)
+		}
+		expected, _ := url.Parse(client.getURL(tt.expectedURI))
+		if req.URL.String() != expected.String() {
+			t.Errorf("SwarmLeave: Wrong request string. Want %q. Got %q.", expected.String(), req.URL.String())
+		}
 	}
 }

--- a/swarm_test.go
+++ b/swarm_test.go
@@ -58,8 +58,8 @@ func TestLeaveSwarm(t *testing.T) {
 		force       bool
 		expectedURI string
 	}{
-		{false, "/swarm/leave?"},
-		{true, "/swarm/leave?force=1"},
+		{false, "/swarm/leave?force=false"},
+		{true, "/swarm/leave?force=true"},
 	}
 	for i, tt := range testData {
 		err := client.LeaveSwarm(LeaveSwarmOptions{Force: tt.force})

--- a/swarm_test.go
+++ b/swarm_test.go
@@ -9,14 +9,12 @@ import (
 	"net/url"
 	"reflect"
 	"testing"
-
-	"github.com/docker/engine-api/types/swarm"
 )
 
 func TestSwarmInit(t *testing.T) {
 	fakeRT := &FakeRoundTripper{message: `"body"`, status: http.StatusOK}
 	client := newTestClient(fakeRT)
-	response, err := client.SwarmInit(swarm.InitRequest{})
+	response, err := client.SwarmInit(SwarmInitOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -38,7 +36,7 @@ func TestSwarmInit(t *testing.T) {
 func TestSwarmJoin(t *testing.T) {
 	fakeRT := &FakeRoundTripper{message: "", status: http.StatusOK}
 	client := newTestClient(fakeRT)
-	err := client.SwarmJoin(swarm.JoinRequest{})
+	err := client.SwarmJoin(SwarmJoinOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -64,7 +62,7 @@ func TestSwarmLeave(t *testing.T) {
 		{true, "/swarm/leave?force=1"},
 	}
 	for i, tt := range testData {
-		err := client.SwarmLeave(tt.force)
+		err := client.SwarmLeave(SwarmLeaveOptions{Force: tt.force})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/swarm_test.go
+++ b/swarm_test.go
@@ -1,0 +1,35 @@
+// Copyright 2016 go-dockerclient authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package docker
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/docker/engine-api/types/swarm"
+)
+
+func TestSwarmInit(t *testing.T) {
+	fakeRT := &FakeRoundTripper{message: `"body"`, status: http.StatusOK}
+	client := newTestClient(fakeRT)
+	response, err := client.SwarmInit(swarm.InitRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := fakeRT.requests[0]
+	expectedMethod := "POST"
+	if req.Method != expectedMethod {
+		t.Errorf("SwarmInit: Wrong HTTP method. Want %s. Got %s.", expectedMethod, req.Method)
+	}
+	u, _ := url.Parse(client.getURL("/swarm/init"))
+	if req.URL.Path != u.Path {
+		t.Errorf("SwarmInit: Wrong request path. Want %q. Got %q.", u.Path, req.URL.Path)
+	}
+	expected := "body"
+	if response != expected {
+		t.Errorf("SwarmInit: Wrong response. Want %q. Got %q.", expected, response)
+	}
+}

--- a/swarm_test.go
+++ b/swarm_test.go
@@ -33,3 +33,21 @@ func TestSwarmInit(t *testing.T) {
 		t.Errorf("SwarmInit: Wrong response. Want %q. Got %q.", expected, response)
 	}
 }
+
+func TestSwarmJoin(t *testing.T) {
+	fakeRT := &FakeRoundTripper{message: "", status: http.StatusOK}
+	client := newTestClient(fakeRT)
+	err := client.SwarmJoin(swarm.JoinRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := fakeRT.requests[0]
+	expectedMethod := "POST"
+	if req.Method != expectedMethod {
+		t.Errorf("SwarmJoin: Wrong HTTP method. Want %s. Got %s.", expectedMethod, req.Method)
+	}
+	u, _ := url.Parse(client.getURL("/swarm/join"))
+	if req.URL.Path != u.Path {
+		t.Errorf("SwarmInit: Wrong request path. Want %q. Got %q.", u.Path, req.URL.Path)
+	}
+}

--- a/swarm_test.go
+++ b/swarm_test.go
@@ -11,10 +11,10 @@ import (
 	"testing"
 )
 
-func TestSwarmInit(t *testing.T) {
+func TestInitSwarm(t *testing.T) {
 	fakeRT := &FakeRoundTripper{message: `"body"`, status: http.StatusOK}
 	client := newTestClient(fakeRT)
-	response, err := client.SwarmInit(SwarmInitOptions{})
+	response, err := client.InitSwarm(InitSwarmOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -33,10 +33,10 @@ func TestSwarmInit(t *testing.T) {
 	}
 }
 
-func TestSwarmJoin(t *testing.T) {
+func TestJoinSwarm(t *testing.T) {
 	fakeRT := &FakeRoundTripper{message: "", status: http.StatusOK}
 	client := newTestClient(fakeRT)
-	err := client.SwarmJoin(SwarmJoinOptions{})
+	err := client.JoinSwarm(JoinSwarmOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -51,7 +51,7 @@ func TestSwarmJoin(t *testing.T) {
 	}
 }
 
-func TestSwarmLeave(t *testing.T) {
+func TestLeaveSwarm(t *testing.T) {
 	fakeRT := &FakeRoundTripper{message: "", status: http.StatusOK}
 	client := newTestClient(fakeRT)
 	var testData = []struct {
@@ -62,7 +62,7 @@ func TestSwarmLeave(t *testing.T) {
 		{true, "/swarm/leave?force=1"},
 	}
 	for i, tt := range testData {
-		err := client.SwarmLeave(SwarmLeaveOptions{Force: tt.force})
+		err := client.LeaveSwarm(LeaveSwarmOptions{Force: tt.force})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -78,15 +78,15 @@ func TestSwarmLeave(t *testing.T) {
 	}
 }
 
-func TestSwarmUpdate(t *testing.T) {
+func TestUpdateSwarm(t *testing.T) {
 	fakeRT := &FakeRoundTripper{message: "", status: http.StatusOK}
 	client := newTestClient(fakeRT)
-	opts := SwarmUpdateOptions{
+	opts := UpdateSwarmOptions{
 		Version:            10,
 		RotateManagerToken: true,
 		RotateWorkerToken:  false,
 	}
-	err := client.SwarmUpdate(opts)
+	err := client.UpdateSwarm(opts)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/swarm_test.go
+++ b/swarm_test.go
@@ -21,15 +21,23 @@ func TestInitSwarm(t *testing.T) {
 	req := fakeRT.requests[0]
 	expectedMethod := "POST"
 	if req.Method != expectedMethod {
-		t.Errorf("SwarmInit: Wrong HTTP method. Want %s. Got %s.", expectedMethod, req.Method)
+		t.Errorf("InitSwarm: Wrong HTTP method. Want %s. Got %s.", expectedMethod, req.Method)
 	}
 	u, _ := url.Parse(client.getURL("/swarm/init"))
 	if req.URL.Path != u.Path {
-		t.Errorf("SwarmInit: Wrong request path. Want %q. Got %q.", u.Path, req.URL.Path)
+		t.Errorf("InitSwarm: Wrong request path. Want %q. Got %q.", u.Path, req.URL.Path)
 	}
 	expected := "body"
 	if response != expected {
-		t.Errorf("SwarmInit: Wrong response. Want %q. Got %q.", expected, response)
+		t.Errorf("InitSwarm: Wrong response. Want %q. Got %q.", expected, response)
+	}
+}
+
+func TestInitSwarmAlreadyInSwarm(t *testing.T) {
+	client := newTestClient(&FakeRoundTripper{message: "", status: http.StatusNotAcceptable})
+	_, err := client.InitSwarm(InitSwarmOptions{})
+	if err != ErrNodeAlreadyInSwarm {
+		t.Errorf("InitSwarm: Wrong error type. Want %#v. Got %#v", ErrNodeAlreadyInSwarm, err)
 	}
 }
 
@@ -43,11 +51,19 @@ func TestJoinSwarm(t *testing.T) {
 	req := fakeRT.requests[0]
 	expectedMethod := "POST"
 	if req.Method != expectedMethod {
-		t.Errorf("SwarmJoin: Wrong HTTP method. Want %s. Got %s.", expectedMethod, req.Method)
+		t.Errorf("JoinSwarm: Wrong HTTP method. Want %s. Got %s.", expectedMethod, req.Method)
 	}
 	u, _ := url.Parse(client.getURL("/swarm/join"))
 	if req.URL.Path != u.Path {
-		t.Errorf("SwarmJoin: Wrong request path. Want %q. Got %q.", u.Path, req.URL.Path)
+		t.Errorf("JoinSwarm: Wrong request path. Want %q. Got %q.", u.Path, req.URL.Path)
+	}
+}
+
+func TestJoinSwarmAlreadyInSwarm(t *testing.T) {
+	client := newTestClient(&FakeRoundTripper{message: "", status: http.StatusNotAcceptable})
+	err := client.JoinSwarm(JoinSwarmOptions{})
+	if err != ErrNodeAlreadyInSwarm {
+		t.Errorf("JoinSwarm: Wrong error type. Want %#v. Got %#v", ErrNodeAlreadyInSwarm, err)
 	}
 }
 
@@ -69,12 +85,20 @@ func TestLeaveSwarm(t *testing.T) {
 		expectedMethod := "POST"
 		req := fakeRT.requests[i]
 		if req.Method != expectedMethod {
-			t.Errorf("SwarmLeave: Wrong HTTP method. Want %s. Got %s.", expectedMethod, req.Method)
+			t.Errorf("LeaveSwarm: Wrong HTTP method. Want %s. Got %s.", expectedMethod, req.Method)
 		}
 		expected, _ := url.Parse(client.getURL(tt.expectedURI))
 		if req.URL.String() != expected.String() {
-			t.Errorf("SwarmLeave: Wrong request string. Want %q. Got %q.", expected.String(), req.URL.String())
+			t.Errorf("LeaveSwarm: Wrong request string. Want %q. Got %q.", expected.String(), req.URL.String())
 		}
+	}
+}
+
+func TestLeaveSwarmNotInSwarm(t *testing.T) {
+	client := newTestClient(&FakeRoundTripper{message: "", status: http.StatusNotAcceptable})
+	err := client.LeaveSwarm(LeaveSwarmOptions{})
+	if err != ErrNodeNotInSwarm {
+		t.Errorf("LeaveSwarm: Wrong error type. Want %#v. Got %#v", ErrNodeNotInSwarm, err)
 	}
 }
 
@@ -93,11 +117,11 @@ func TestUpdateSwarm(t *testing.T) {
 	req := fakeRT.requests[0]
 	expectedMethod := "POST"
 	if req.Method != expectedMethod {
-		t.Errorf("SwarmUpdate: Wrong HTTP method. Want %s. Got %s.", expectedMethod, req.Method)
+		t.Errorf("UpdateSwarm: Wrong HTTP method. Want %s. Got %s.", expectedMethod, req.Method)
 	}
 	expectedPath := "/swarm/update"
 	if req.URL.Path != expectedPath {
-		t.Errorf("SwarmUpdate: Wrong request path. Want %q. Got %q.", expectedPath, req.URL.Path)
+		t.Errorf("UpdateSwarm: Wrong request path. Want %q. Got %q.", expectedPath, req.URL.Path)
 	}
 	expected := map[string][]string{
 		"version":            {"10"},
@@ -106,6 +130,14 @@ func TestUpdateSwarm(t *testing.T) {
 	}
 	got := map[string][]string(req.URL.Query())
 	if !reflect.DeepEqual(got, expected) {
-		t.Errorf("SwarmUpdate: Wrong request query. Want %v. Got %v", expected, got)
+		t.Errorf("UpdateSwarm: Wrong request query. Want %v. Got %v", expected, got)
+	}
+}
+
+func TestUpdateSwarmNotInSwarm(t *testing.T) {
+	client := newTestClient(&FakeRoundTripper{message: "", status: http.StatusNotAcceptable})
+	err := client.UpdateSwarm(UpdateSwarmOptions{})
+	if err != ErrNodeNotInSwarm {
+		t.Errorf("UpdateSwarm: Wrong error type. Want %#v. Got %#v", ErrNodeNotInSwarm, err)
 	}
 }


### PR DESCRIPTION
This PR adds support to the swarm api: init, join, leave and update.

related to #555 