### PR TITLE
Fix goroutine leak

### DIFF
--- a/client.go
+++ b/client.go
@@ -725,7 +725,7 @@ func (c *Client) hijack(method, path string, hijackOptions hijackOptions) (Close
 		}
 	}
 
-	errs := make(chan error)
+	errs := make(chan error, 1)
 	quit := make(chan struct{})
 	go func() {
 		clientconn := httputil.NewClientConn(dial, nil)
@@ -739,7 +739,7 @@ func (c *Client) hijack(method, path string, hijackOptions hijackOptions) (Close
 		defer rwc.Close()
 
 		errChanOut := make(chan error, 1)
-		errChanIn := make(chan error, 1)
+		errChanIn := make(chan error, 2)
 		if hijackOptions.stdout == nil && hijackOptions.stderr == nil {
 			close(errChanOut)
 		} else {
@@ -789,14 +789,12 @@ func (c *Client) hijack(method, path string, hijackOptions hijackOptions) (Close
 		select {
 		case errIn = <-errChanIn:
 		case <-quit:
-			return
 		}
 
 		var errOut error
 		select {
 		case errOut = <-errChanOut:
 		case <-quit:
-			return
 		}
 
 		if errIn != nil {


### PR DESCRIPTION
From https://github.com/weaveworks/scope/issues/1767#issuecomment-238020841:


> The problem is two-fold:
> - there can be *two* goroutines that attempt to output an item on `errIn` but the channel only has a capacity of one, so one of the goroutines will get stuck if the closer is invoked (i.e. we hit the `<-quit` branch), which is why we see one of first two goroutines appear in the goroutine dump. We fix this by increasing the `errIn` capacity to two.
> - the waiter is waiting for input on `errs`, but invoking the closer ends up terminating the top-level goroutine without outputting on `errs`, causing the waiter to be stuck. That is the third goroutine we see in the dumps. We fix this by a) removing the returns on `<-quit`, and b) setting the capacity of `errs` to one, so that the top-level goroutine doesn't end up blocking if there is no waiter.