### PR TITLE
node/task: add support for node and tasks apis

### DIFF
--- a/node.go
+++ b/node.go
@@ -1,0 +1,128 @@
+// Copyright 2016 go-dockerclient authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package docker
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strconv"
+
+	"github.com/docker/engine-api/types/swarm"
+	"golang.org/x/net/context"
+)
+
+// NoSuchNode is the error returned when a given node does not exist.
+type NoSuchNode struct {
+	ID  string
+	Err error
+}
+
+func (err *NoSuchNode) Error() string {
+	if err.Err != nil {
+		return err.Err.Error()
+	}
+	return "No such node: " + err.ID
+}
+
+// ListNodesOptions specify parameters to the ListNodes function.
+//
+// See http://goo.gl/3K4GwU for more details.
+type ListNodesOptions struct {
+	Filters map[string][]string
+	Context context.Context
+}
+
+// ListNodes returns a slice of nodes matching the given criteria.
+//
+// See http://goo.gl/3K4GwU for more details.
+func (c *Client) ListNodes(opts ListNodesOptions) ([]swarm.Node, error) {
+	path := "/nodes?" + queryString(opts)
+	resp, err := c.do("GET", path, doOptions{context: opts.Context})
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	var nodes []swarm.Node
+	if err := json.NewDecoder(resp.Body).Decode(&nodes); err != nil {
+		return nil, err
+	}
+	return nodes, nil
+}
+
+// InspectNode returns information about a node by its ID.
+//
+// See http://goo.gl/WjkTOk for more details.
+func (c *Client) InspectNode(id string) (*swarm.Node, error) {
+	resp, err := c.do("GET", "/nodes/"+id, doOptions{})
+	if err != nil {
+		if e, ok := err.(*Error); ok && e.Status == http.StatusNotFound {
+			return nil, &NoSuchNode{ID: id}
+		}
+		return nil, err
+	}
+	defer resp.Body.Close()
+	var node swarm.Node
+	if err := json.NewDecoder(resp.Body).Decode(&node); err != nil {
+		return nil, err
+	}
+	return &node, nil
+}
+
+// UpdateNodeOptions specify parameters to the NodeUpdate function.
+//
+// See http://goo.gl/VPBFgA for more details.
+type UpdateNodeOptions struct {
+	swarm.NodeSpec
+	Version int
+	Context context.Context
+}
+
+// UpdateNode updates a node.
+//
+// See http://goo.gl/VPBFgA for more details.
+func (c *Client) UpdateNode(id string, opts UpdateNodeOptions) error {
+	params := make(url.Values)
+	params.Set("version", strconv.Itoa(opts.Version))
+	path := "/nodes/" + id + "/update?" + params.Encode()
+	_, err := c.do("POST", path, doOptions{
+		context:   opts.Context,
+		forceJSON: true,
+		data:      opts.NodeSpec,
+	})
+	if err != nil {
+		if e, ok := err.(*Error); ok && e.Status == http.StatusNotFound {
+			return &NoSuchNode{ID: id}
+		}
+		return err
+	}
+	return nil
+}
+
+// RemoveNodeOptions specify parameters to the RemoveNode function.
+//
+// See http://goo.gl/0SNvYg for more details.
+type RemoveNodeOptions struct {
+	ID      string
+	Force   bool
+	Context context.Context
+}
+
+// RemoveNode removes a node.
+//
+// See http://goo.gl/0SNvYg for more details.
+func (c *Client) RemoveNode(opts RemoveNodeOptions) error {
+	params := make(url.Values)
+	params.Set("force", strconv.FormatBool(opts.Force))
+	path := "/nodes/" + opts.ID + "?" + params.Encode()
+	_, err := c.do("DELETE", path, doOptions{context: opts.Context})
+	if err != nil {
+		if e, ok := err.(*Error); ok && e.Status == http.StatusNotFound {
+			return &NoSuchNode{ID: opts.ID}
+		}
+		return err
+	}
+	return nil
+}

--- a/node_test.go
+++ b/node_test.go
@@ -1,0 +1,254 @@
+// Copyright 2016 go-dockerclient authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package docker
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"reflect"
+	"testing"
+
+	"github.com/docker/engine-api/types/swarm"
+)
+
+func TestListNodes(t *testing.T) {
+	jsonNodes := `[
+  {
+    "ID": "24ifsmvkjbyhk",
+    "Version": {
+      "Index": 8
+    },
+    "CreatedAt": "2016-06-07T20:31:11.853781916Z",
+    "UpdatedAt": "2016-06-07T20:31:11.999868824Z",
+    "Spec": {
+      "Name": "my-node",
+      "Role": "manager",
+      "Availability": "active",
+      "Labels": {
+          "foo": "bar"
+      }
+    },
+    "Description": {
+      "Hostname": "bf3067039e47",
+      "Platform": {
+        "Architecture": "x86_64",
+        "OS": "linux"
+      },
+      "Resources": {
+        "NanoCPUs": 4000000000,
+        "MemoryBytes": 8272408576
+      },
+      "Engine": {
+        "EngineVersion": "1.12.0-dev",
+        "Labels": {
+            "foo": "bar"
+        },
+        "Plugins": [
+          {
+            "Type": "Volume",
+            "Name": "local"
+          },
+          {
+            "Type": "Network",
+            "Name": "bridge"
+          },
+          {
+            "Type": "Network",
+            "Name": "null"
+          },
+          {
+            "Type": "Network",
+            "Name": "overlay"
+          }
+        ]
+      }
+    },
+    "Status": {
+      "State": "ready"
+    },
+    "ManagerStatus": {
+      "Leader": true,
+      "Reachability": "reachable",
+      "Addr": "172.17.0.2:2377"
+    }
+  }
+]`
+	var expected []swarm.Node
+	err := json.Unmarshal([]byte(jsonNodes), &expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := newTestClient(&FakeRoundTripper{message: jsonNodes, status: http.StatusOK})
+	nodes, err := client.ListNodes(ListNodesOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(nodes, expected) {
+		t.Errorf("ListNodes: Expected %#v. Got %#v.", expected, nodes)
+	}
+
+}
+
+func TestInspectNode(t *testing.T) {
+	jsonNode := `{
+  "ID": "24ifsmvkjbyhk",
+  "Version": {
+    "Index": 8
+  },
+  "CreatedAt": "2016-06-07T20:31:11.853781916Z",
+  "UpdatedAt": "2016-06-07T20:31:11.999868824Z",
+  "Spec": {
+    "Name": "my-node",
+    "Role": "manager",
+    "Availability": "active",
+    "Labels": {
+        "foo": "bar"
+    }
+  },
+  "Description": {
+    "Hostname": "bf3067039e47",
+    "Platform": {
+      "Architecture": "x86_64",
+      "OS": "linux"
+    },
+    "Resources": {
+      "NanoCPUs": 4000000000,
+      "MemoryBytes": 8272408576
+    },
+    "Engine": {
+      "EngineVersion": "1.12.0-dev",
+      "Labels": {
+          "foo": "bar"
+      },
+      "Plugins": [
+        {
+          "Type": "Volume",
+          "Name": "local"
+        },
+        {
+          "Type": "Network",
+          "Name": "bridge"
+        },
+        {
+          "Type": "Network",
+          "Name": "null"
+        },
+        {
+          "Type": "Network",
+          "Name": "overlay"
+        }
+      ]
+    }
+  },
+  "Status": {
+    "State": "ready"
+  },
+  "ManagerStatus": {
+    "Leader": true,
+    "Reachability": "reachable",
+    "Addr": "172.17.0.2:2377"
+  }
+}`
+
+	var expected swarm.Node
+	err := json.Unmarshal([]byte(jsonNode), &expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fakeRT := &FakeRoundTripper{message: jsonNode, status: http.StatusOK}
+	client := newTestClient(fakeRT)
+	id := "24ifsmvkjbyhk"
+	node, err := client.InspectNode(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(*node, expected) {
+		t.Errorf("InspectNode(%q): Expected %#v. Got %#v.", id, expected, node)
+	}
+	expectedURL, _ := url.Parse(client.getURL("/nodes/24ifsmvkjbyhk"))
+	if gotPath := fakeRT.requests[0].URL.Path; gotPath != expectedURL.Path {
+		t.Errorf("InspectNode(%q): Wrong path in request. Want %q. Got %q.", id, expectedURL.Path, gotPath)
+	}
+
+}
+
+func TestInspectNodeNotFound(t *testing.T) {
+	client := newTestClient(&FakeRoundTripper{message: "no such node", status: http.StatusNotFound})
+	node, err := client.InspectNode("notfound")
+	if node != nil {
+		t.Errorf("InspectNode: Expected <nil> task, got %#v", node)
+	}
+	expected := &NoSuchNode{ID: "notfound"}
+	if !reflect.DeepEqual(err, expected) {
+		t.Errorf("InspectNode: Wrong error returned. Want %#v. Got %#v.", expected, err)
+	}
+}
+
+func TestUpdateNode(t *testing.T) {
+	fakeRT := &FakeRoundTripper{message: "", status: http.StatusOK}
+	client := newTestClient(fakeRT)
+	id := "4fa6e0f0c6786287e131c3852c58a2e01cc697a68231826813597e4994f1d6e2"
+	opts := UpdateNodeOptions{}
+	err := client.UpdateNode(id, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := fakeRT.requests[0]
+	if req.Method != "POST" {
+		t.Errorf("UpdateNode: wrong HTTP method. Want %q. Got %q.", "POST", req.Method)
+	}
+	expectedURL, _ := url.Parse(client.getURL("/nodes/" + id + "/update"))
+	if gotPath := req.URL.Path; gotPath != expectedURL.Path {
+		t.Errorf("UpdateNode: Wrong path in request. Want %q. Got %q.", expectedURL.Path, gotPath)
+	}
+	expectedContentType := "application/json"
+	if contentType := req.Header.Get("Content-Type"); contentType != expectedContentType {
+		t.Errorf("UpdateNode: Wrong content-type in request. Want %q. Got %q.", expectedContentType, contentType)
+	}
+	var out UpdateNodeOptions
+	if err := json.NewDecoder(req.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(out, opts) {
+		t.Errorf("UpdateNode: wrong body, got: %#v, want %#v", out, opts)
+	}
+}
+
+func TestUpdateNodeNotFound(t *testing.T) {
+	client := newTestClient(&FakeRoundTripper{message: "no such node", status: http.StatusNotFound})
+	err := client.UpdateNode("notfound", UpdateNodeOptions{})
+	expected := &NoSuchNode{ID: "notfound"}
+	if !reflect.DeepEqual(err, expected) {
+		t.Errorf("UpdateNode: Wrong error returned. Want %#v. Got %#v.", expected, err)
+	}
+}
+
+func TestRemoveNode(t *testing.T) {
+	fakeRT := &FakeRoundTripper{message: "", status: http.StatusOK}
+	client := newTestClient(fakeRT)
+	id := "4fa6e0f0c6786287e131c3852c58a2e01cc697a68231826813597e4994f1d6e2"
+	err := client.RemoveNode(RemoveNodeOptions{ID: id})
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := fakeRT.requests[0]
+	if req.Method != "DELETE" {
+		t.Errorf("RemoveNode(%q): wrong HTTP method. Want %q. Got %q.", id, "DELETE", req.Method)
+	}
+	expectedURL, _ := url.Parse(client.getURL("/nodes/" + id))
+	if gotPath := req.URL.Path; gotPath != expectedURL.Path {
+		t.Errorf("RemoveNode(%q): Wrong path in request. Want %q. Got %q.", id, expectedURL.Path, gotPath)
+	}
+}
+
+func TestRemoveNodeNotFound(t *testing.T) {
+	client := newTestClient(&FakeRoundTripper{message: "no such node", status: http.StatusNotFound})
+	err := client.RemoveNode(RemoveNodeOptions{ID: "notfound"})
+	expected := &NoSuchNode{ID: "notfound"}
+	if !reflect.DeepEqual(err, expected) {
+		t.Errorf("RemoveNode: Wrong error returned. Want %#v. Got %#v.", expected, err)
+	}
+}

--- a/task.go
+++ b/task.go
@@ -1,0 +1,70 @@
+// Copyright 2016 go-dockerclient authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package docker
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/docker/engine-api/types/swarm"
+	"golang.org/x/net/context"
+)
+
+// NoSuchTask is the error returned when a given task does not exist.
+type NoSuchTask struct {
+	ID  string
+	Err error
+}
+
+func (err *NoSuchTask) Error() string {
+	if err.Err != nil {
+		return err.Err.Error()
+	}
+	return "No such task: " + err.ID
+}
+
+// ListTasksOptions specify parameters to the ListTasks function.
+//
+// See http://goo.gl/rByLzw for more details.
+type ListTasksOptions struct {
+	Filters map[string][]string
+	Context context.Context
+}
+
+// ListTasks returns a slice of tasks matching the given criteria.
+//
+// See http://goo.gl/rByLzw for more details.
+func (c *Client) ListTasks(opts ListTasksOptions) ([]swarm.Task, error) {
+	path := "/tasks?" + queryString(opts)
+	resp, err := c.do("GET", path, doOptions{context: opts.Context})
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	var tasks []swarm.Task
+	if err := json.NewDecoder(resp.Body).Decode(&tasks); err != nil {
+		return nil, err
+	}
+	return tasks, nil
+}
+
+// InspectTask returns information about a task by its ID.
+//
+// See http://goo.gl/kyziuq for more details.
+func (c *Client) InspectTask(id string) (*swarm.Task, error) {
+	resp, err := c.do("GET", "/tasks/"+id, doOptions{})
+	if err != nil {
+		if e, ok := err.(*Error); ok && e.Status == http.StatusNotFound {
+			return nil, &NoSuchTask{ID: id}
+		}
+		return nil, err
+	}
+	defer resp.Body.Close()
+	var task swarm.Task
+	if err := json.NewDecoder(resp.Body).Decode(&task); err != nil {
+		return nil, err
+	}
+	return &task, nil
+}

--- a/task_test.go
+++ b/task_test.go
@@ -1,0 +1,373 @@
+// Copyright 2016 go-dockerclient authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package docker
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"reflect"
+	"testing"
+
+	"github.com/docker/engine-api/types/swarm"
+)
+
+func TestListTasks(t *testing.T) {
+	jsonTasks := `[
+  {
+    "ID": "0kzzo1i0y4jz6027t0k7aezc7",
+    "Version": {
+      "Index": 71
+    },
+    "CreatedAt": "2016-06-07T21:07:31.171892745Z",
+    "UpdatedAt": "2016-06-07T21:07:31.376370513Z",
+    "Name": "hopeful_cori",
+    "Spec": {
+      "ContainerSpec": {
+        "Image": "redis"
+      },
+      "Resources": {
+        "Limits": {},
+        "Reservations": {}
+      },
+      "RestartPolicy": {
+        "Condition": "ANY"
+      },
+      "Placement": {}
+    },
+    "ServiceID": "9mnpnzenvg8p8tdbtq4wvbkcz",
+    "Instance": 1,
+    "NodeID": "24ifsmvkjbyhk",
+    "ServiceAnnotations": {},
+    "Status": {
+      "Timestamp": "2016-06-07T21:07:31.290032978Z",
+      "State": "FAILED",
+      "Message": "execution failed",
+      "ContainerStatus": {}
+    },
+    "DesiredState": "SHUTDOWN",
+    "NetworksAttachments": [
+      {
+        "Network": {
+          "ID": "4qvuz4ko70xaltuqbt8956gd1",
+          "Version": {
+            "Index": 18
+          },
+          "CreatedAt": "2016-06-07T20:31:11.912919752Z",
+          "UpdatedAt": "2016-06-07T21:07:29.955277358Z",
+          "Spec": {
+            "Name": "ingress",
+            "Labels": {
+              "com.docker.swarm.internal": "true"
+            },
+            "DriverConfiguration": {},
+            "IPAM": {
+              "Driver": {},
+              "Configs": [
+                {
+                  "Family": "UNKNOWN",
+                  "Subnet": "10.255.0.0/16"
+                }
+              ]
+            }
+          },
+          "DriverState": {
+            "Name": "overlay",
+            "Options": {
+              "com.docker.network.driver.overlay.vxlanid_list": "256"
+            }
+          },
+          "IPAM": {
+            "Driver": {
+              "Name": "default"
+            },
+            "Configs": [
+              {
+                "Family": "UNKNOWN",
+                "Subnet": "10.255.0.0/16"
+              }
+            ]
+          }
+        },
+        "Addresses": [
+          "10.255.0.10/16"
+        ]
+      }
+    ],
+    "Endpoint": {
+      "Spec": {},
+      "ExposedPorts": [
+        {
+          "Protocol": "tcp",
+          "Port": 6379,
+          "PublicPort": 30000
+        }
+      ],
+      "VirtualIPs": [
+        {
+          "NetworkID": "4qvuz4ko70xaltuqbt8956gd1",
+          "Addr": "10.255.0.2/16"
+        },
+        {
+          "NetworkID": "4qvuz4ko70xaltuqbt8956gd1",
+          "Addr": "10.255.0.3/16"
+        }
+      ]
+    }
+  },
+  {
+    "ID": "1yljwbmlr8er2waf8orvqpwms",
+    "Version": {
+      "Index": 30
+    },
+    "CreatedAt": "2016-06-07T21:07:30.019104782Z",
+    "UpdatedAt": "2016-06-07T21:07:30.231958098Z",
+    "Name": "hopeful_cori",
+    "Spec": {
+      "ContainerSpec": {
+        "Image": "redis"
+      },
+      "Resources": {
+        "Limits": {},
+        "Reservations": {}
+      },
+      "RestartPolicy": {
+        "Condition": "ANY"
+      },
+      "Placement": {}
+    },
+    "ServiceID": "9mnpnzenvg8p8tdbtq4wvbkcz",
+    "Instance": 1,
+    "NodeID": "24ifsmvkjbyhk",
+    "ServiceAnnotations": {},
+    "Status": {
+      "Timestamp": "2016-06-07T21:07:30.202183143Z",
+      "State": "FAILED",
+      "Message": "execution failed",
+      "ContainerStatus": {}
+    },
+    "DesiredState": "SHUTDOWN",
+    "NetworksAttachments": [
+      {
+        "Network": {
+          "ID": "4qvuz4ko70xaltuqbt8956gd1",
+          "Version": {
+            "Index": 18
+          },
+          "CreatedAt": "2016-06-07T20:31:11.912919752Z",
+          "UpdatedAt": "2016-06-07T21:07:29.955277358Z",
+          "Spec": {
+            "Name": "ingress",
+            "Labels": {
+              "com.docker.swarm.internal": "true"
+            },
+            "DriverConfiguration": {},
+            "IPAM": {
+              "Driver": {},
+              "Configs": [
+                {
+                  "Family": "UNKNOWN",
+                  "Subnet": "10.255.0.0/16"
+                }
+              ]
+            }
+          },
+          "DriverState": {
+            "Name": "overlay",
+            "Options": {
+              "com.docker.network.driver.overlay.vxlanid_list": "256"
+            }
+          },
+          "IPAM": {
+            "Driver": {
+              "Name": "default"
+            },
+            "Configs": [
+              {
+                "Family": "UNKNOWN",
+                "Subnet": "10.255.0.0/16"
+              }
+            ]
+          }
+        },
+        "Addresses": [
+          "10.255.0.5/16"
+        ]
+      }
+    ],
+    "Endpoint": {
+      "Spec": {},
+      "ExposedPorts": [
+        {
+          "Protocol": "tcp",
+          "Port": 6379,
+          "PublicPort": 30000
+        }
+      ],
+      "VirtualIPs": [
+        {
+          "NetworkID": "4qvuz4ko70xaltuqbt8956gd1",
+          "Addr": "10.255.0.2/16"
+        },
+        {
+          "NetworkID": "4qvuz4ko70xaltuqbt8956gd1",
+          "Addr": "10.255.0.3/16"
+        }
+      ]
+    }
+  }
+]`
+	var expected []swarm.Task
+	err := json.Unmarshal([]byte(jsonTasks), &expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := newTestClient(&FakeRoundTripper{message: jsonTasks, status: http.StatusOK})
+	tasks, err := client.ListTasks(ListTasksOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(tasks, expected) {
+		t.Errorf("ListTasks: Expected %#v. Got %#v.", expected, tasks)
+	}
+
+}
+
+func TestInspectTask(t *testing.T) {
+	jsonTask := `{
+  "ID": "0kzzo1i0y4jz6027t0k7aezc7",
+  "Version": {
+    "Index": 71
+  },
+  "CreatedAt": "2016-06-07T21:07:31.171892745Z",
+  "UpdatedAt": "2016-06-07T21:07:31.376370513Z",
+  "Name": "hopeful_cori",
+  "Spec": {
+    "ContainerSpec": {
+      "Image": "redis"
+    },
+    "Resources": {
+      "Limits": {},
+      "Reservations": {}
+    },
+    "RestartPolicy": {
+      "Condition": "ANY"
+    },
+    "Placement": {}
+  },
+  "ServiceID": "9mnpnzenvg8p8tdbtq4wvbkcz",
+  "Instance": 1,
+  "NodeID": "24ifsmvkjbyhk",
+  "ServiceAnnotations": {},
+  "Status": {
+    "Timestamp": "2016-06-07T21:07:31.290032978Z",
+    "State": "FAILED",
+    "Message": "execution failed",
+    "ContainerStatus": {}
+  },
+  "DesiredState": "SHUTDOWN",
+  "NetworksAttachments": [
+    {
+      "Network": {
+        "ID": "4qvuz4ko70xaltuqbt8956gd1",
+        "Version": {
+          "Index": 18
+        },
+        "CreatedAt": "2016-06-07T20:31:11.912919752Z",
+        "UpdatedAt": "2016-06-07T21:07:29.955277358Z",
+        "Spec": {
+          "Name": "ingress",
+          "Labels": {
+            "com.docker.swarm.internal": "true"
+          },
+          "DriverConfiguration": {},
+          "IPAM": {
+            "Driver": {},
+            "Configs": [
+              {
+                "Family": "UNKNOWN",
+                "Subnet": "10.255.0.0/16"
+              }
+            ]
+          }
+        },
+        "DriverState": {
+          "Name": "overlay",
+          "Options": {
+            "com.docker.network.driver.overlay.vxlanid_list": "256"
+          }
+        },
+        "IPAM": {
+          "Driver": {
+            "Name": "default"
+          },
+          "Configs": [
+            {
+              "Family": "UNKNOWN",
+              "Subnet": "10.255.0.0/16"
+            }
+          ]
+        }
+      },
+      "Addresses": [
+        "10.255.0.10/16"
+      ]
+    }
+  ],
+  "Endpoint": {
+    "Spec": {},
+    "ExposedPorts": [
+      {
+        "Protocol": "tcp",
+        "Port": 6379,
+        "PublicPort": 30000
+      }
+    ],
+    "VirtualIPs": [
+      {
+        "NetworkID": "4qvuz4ko70xaltuqbt8956gd1",
+        "Addr": "10.255.0.2/16"
+      },
+      {
+        "NetworkID": "4qvuz4ko70xaltuqbt8956gd1",
+        "Addr": "10.255.0.3/16"
+      }
+    ]
+  }
+}`
+
+	var expected swarm.Task
+	err := json.Unmarshal([]byte(jsonTask), &expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fakeRT := &FakeRoundTripper{message: jsonTask, status: http.StatusOK}
+	client := newTestClient(fakeRT)
+	id := "0kzzo1i0y4jz6027t0k7aezc7"
+	task, err := client.InspectTask(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(*task, expected) {
+		t.Errorf("InspectTask(%q): Expected %#v. Got %#v.", id, expected, task)
+	}
+	expectedURL, _ := url.Parse(client.getURL("/tasks/0kzzo1i0y4jz6027t0k7aezc7"))
+	if gotPath := fakeRT.requests[0].URL.Path; gotPath != expectedURL.Path {
+		t.Errorf("InspectTask(%q): Wrong path in request. Want %q. Got %q.", id, expectedURL.Path, gotPath)
+	}
+
+}
+
+func TestInspectTaskNotFound(t *testing.T) {
+	client := newTestClient(&FakeRoundTripper{message: "no such task", status: http.StatusNotFound})
+	task, err := client.InspectTask("notfound")
+	if task != nil {
+		t.Errorf("InspectTask: Expected <nil> task, got %#v", task)
+	}
+	expected := &NoSuchTask{ID: "notfound"}
+	if !reflect.DeepEqual(err, expected) {
+		t.Errorf("InspectTask: Wrong error returned. Want %#v. Got %#v.", expected, err)
+	}
+}


### PR DESCRIPTION
Adds support to the node and tasks apis, introduced in docker 1.12. Related to #555 