### PR TITLE
testing: adds swarm join/leave/inspect to test server

### DIFF
--- a/testing/server_test.go
+++ b/testing/server_test.go
@@ -2335,15 +2335,8 @@ func TestSwarmInspect(t *testing.T) {
 	server, _ := NewServer("127.0.0.1:0", nil, nil)
 	server.buildMuxer()
 	expected := &swarm.Swarm{
-		JoinTokens: swarm.JoinTokens{
-			Manager: "manager-token",
-			Worker:  "worker-token",
-		},
 		ClusterInfo: swarm.ClusterInfo{
-			Meta: swarm.Meta{
-				CreatedAt: time.Now(),
-				UpdatedAt: time.Now(),
-			},
+			ID: "swarm-id",
 		},
 	}
 	server.swarm = expected
@@ -2358,7 +2351,7 @@ func TestSwarmInspect(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SwarmInspect: got error. %s", err.Error())
 	}
-	if !reflect.DeepEqual(swarmInspect, expected) {
+	if expected.ClusterInfo.ID != swarmInspect.ClusterInfo.ID {
 		t.Fatalf("SwarmInspect: wrong response. Want %+v. Got %+v.", expected, swarmInspect)
 	}
 }

--- a/testing/server_test.go
+++ b/testing/server_test.go
@@ -2259,6 +2259,119 @@ func TestSwarmInit(t *testing.T) {
 	if id == "" {
 		t.Fatal("SwarmInit: id not found")
 	}
+	if server.swarm == nil {
+		t.Fatalf("SwarmInit: expected swarm to be set.")
+	}
+}
+
+func TestSwarmInitAlreadyInSwarm(t *testing.T) {
+	server, _ := NewServer("127.0.0.1:0", nil, nil)
+	server.buildMuxer()
+	server.swarm = &swarm.Swarm{}
+	recorder := httptest.NewRecorder()
+	request, _ := http.NewRequest("POST", "/swarm/init", nil)
+	server.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusNotAcceptable {
+		t.Fatalf("SwarmInit: wrong status. Want %d. Got %d.", http.StatusNotAcceptable, recorder.Code)
+	}
+}
+
+func TestSwarmJoin(t *testing.T) {
+	server, _ := NewServer("127.0.0.1:0", nil, nil)
+	server.buildMuxer()
+	recorder := httptest.NewRecorder()
+	request, _ := http.NewRequest("POST", "/swarm/join", nil)
+	server.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("SwarmJoin: wrong status. Want %d. Got %d.", http.StatusOK, recorder.Code)
+	}
+	if server.swarm == nil {
+		t.Fatalf("SwarmJoin: expected swarm to be set.")
+	}
+}
+
+func TestSwarmJoinAlreadyInSwarm(t *testing.T) {
+	server, _ := NewServer("127.0.0.1:0", nil, nil)
+	server.buildMuxer()
+	server.swarm = &swarm.Swarm{}
+	recorder := httptest.NewRecorder()
+	request, _ := http.NewRequest("POST", "/swarm/join", nil)
+	server.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusNotAcceptable {
+		t.Fatalf("SwarmJoin: wrong status. Want %d. Got %d.", http.StatusNotAcceptable, recorder.Code)
+	}
+}
+
+func TestSwarmLeave(t *testing.T) {
+	server, _ := NewServer("127.0.0.1:0", nil, nil)
+	server.buildMuxer()
+	server.swarm = &swarm.Swarm{}
+	recorder := httptest.NewRecorder()
+	request, _ := http.NewRequest("POST", "/swarm/leave", nil)
+	server.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("SwarmLeave: wrong status. Want %d. Got %d.", http.StatusOK, recorder.Code)
+	}
+	if server.swarm != nil {
+		t.Fatalf("SwarmLeave: expected swarm to be nil. Got %+v.", server.swarm)
+	}
+}
+
+func TestSwarmLeaveNotInSwarm(t *testing.T) {
+	server, _ := NewServer("127.0.0.1:0", nil, nil)
+	server.buildMuxer()
+	recorder := httptest.NewRecorder()
+	request, _ := http.NewRequest("POST", "/swarm/leave", nil)
+	server.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusNotAcceptable {
+		t.Fatalf("SwarmLeave: wrong status. Want %d. Got %d.", http.StatusNotAcceptable, recorder.Code)
+	}
+	if server.swarm != nil {
+		t.Fatalf("SwarmLeave: expected swarm to be nil. Got %+v.", server.swarm)
+	}
+}
+
+func TestSwarmInspect(t *testing.T) {
+	server, _ := NewServer("127.0.0.1:0", nil, nil)
+	server.buildMuxer()
+	expected := &swarm.Swarm{
+		JoinTokens: swarm.JoinTokens{
+			Manager: "manager-token",
+			Worker:  "worker-token",
+		},
+		ClusterInfo: swarm.ClusterInfo{
+			Meta: swarm.Meta{
+				CreatedAt: time.Now(),
+				UpdatedAt: time.Now(),
+			},
+		},
+	}
+	server.swarm = expected
+	recorder := httptest.NewRecorder()
+	request, _ := http.NewRequest("GET", "/swarm", nil)
+	server.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("SwarmInspect: wrong status. Want %d. Got %d.", http.StatusOK, recorder.Code)
+	}
+	var swarmInspect *swarm.Swarm
+	err := json.Unmarshal(recorder.Body.Bytes(), &swarmInspect)
+	if err != nil {
+		t.Fatalf("SwarmInspect: got error. %s", err.Error())
+	}
+	if !reflect.DeepEqual(swarmInspect, expected) {
+		t.Fatalf("SwarmInspect: wrong response. Want %+v. Got %+v.", expected, swarmInspect)
+	}
+}
+
+func TestSwarmInspectNotInSwarm(t *testing.T) {
+	server, _ := NewServer("127.0.0.1:0", nil, nil)
+	server.buildMuxer()
+	recorder := httptest.NewRecorder()
+	request, _ := http.NewRequest("GET", "/swarm", nil)
+	server.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusNotAcceptable {
+		t.Fatalf("SwarmInspect: wrong status. Want %d. Got %d.", http.StatusNotAcceptable, recorder.Code)
+	}
 }
 
 func TestServiceCreate(t *testing.T) {


### PR DESCRIPTION
This PR adds a simple implementation of swarm join/leave/inspect and refactors the init swarm function. It uses a simple pointer to `swarm.Swarm` to store some fake swarm metadata.