### PR TITLE
Add support for Windows named pipes

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,15 @@
+version: '{build}'
+platform: x64
+clone_depth: 2
+clone_folder: c:\gopath\src\github.com\fsouza\go-dockerclient
+environment:
+  GOPATH: c:\gopath
+  GOVERSION: 1.7.1
+install:
+  - set PATH=%GOPATH%\bin;c:\go\bin;%PATH%
+  - rmdir c:\go /s /q
+  - appveyor DownloadFile https://storage.googleapis.com/golang/go%GOVERSION%.windows-amd64.zip
+  - 7z x go%GOVERSION%.windows-amd64.zip -y -oC:\ > NUL
+build_script:
+  - go get -d -t ./...
+  - go test -race ./...

--- a/build_test.go
+++ b/build_test.go
@@ -10,6 +10,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 
@@ -48,6 +49,7 @@ func TestBuildImageContextDirDockerignoreParsing(t *testing.T) {
 			t.Errorf("error removing symlink on demand: %s", err)
 		}
 	}()
+	workingdir, err := os.Getwd()
 
 	var buf bytes.Buffer
 	opts := BuildImageOptions{
@@ -57,9 +59,9 @@ func TestBuildImageContextDirDockerignoreParsing(t *testing.T) {
 		RmTmpContainer:      true,
 		ForceRmTmpContainer: true,
 		OutputStream:        &buf,
-		ContextDir:          "testing/data",
+		ContextDir:          filepath.Join(workingdir, "testing", "data"),
 	}
-	err := client.BuildImage(opts)
+	err = client.BuildImage(opts)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client.go
+++ b/client.go
@@ -832,7 +832,7 @@ func (c *Client) hijack(method, path string, hijackOptions hijackOptions) (Close
 
 func (c *Client) getURL(path string) string {
 	urlStr := strings.TrimRight(c.endpointURL.String(), "/")
-	if c.endpointURL.Scheme == "unix" {
+	if c.endpointURL.Scheme == unixProtocol || c.endpointURL.Scheme == namedPipeProtocol {
 		urlStr = ""
 	}
 	if c.requestedAPIVersion != nil {

--- a/client.go
+++ b/client.go
@@ -29,6 +29,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/docker/docker/opts"
 	"github.com/docker/docker/pkg/homedir"
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/hashicorp/go-cleanhttp"
@@ -1001,10 +1002,7 @@ func getDockerEnv() (*dockerEnv, error) {
 	dockerHost := os.Getenv("DOCKER_HOST")
 	var err error
 	if dockerHost == "" {
-		dockerHost, err = DefaultDockerHost()
-		if err != nil {
-			return nil, err
-		}
+		dockerHost = opts.DefaultHost
 	}
 	dockerTLSVerify := os.Getenv("DOCKER_TLS_VERIFY") != ""
 	var dockerCertPath string

--- a/client_test.go
+++ b/client_test.go
@@ -302,7 +302,7 @@ func TestGetFakeUnixURL(t *testing.T) {
 		client, _ := NewClient(tt.endpoint)
 		client.endpoint = tt.endpoint
 		client.SkipServerVersionCheck = true
-		got := client.getFakeUnixURL(tt.path)
+		got := client.getFakeNativeURL(tt.path)
 		if got != tt.expected {
 			t.Errorf("getURL(%q): Got %s. Want %s.", tt.path, got, tt.expected)
 		}

--- a/client_test.go
+++ b/client_test.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -34,8 +33,8 @@ func TestNewAPIClient(t *testing.T) {
 	if client.endpoint != endpoint {
 		t.Errorf("Expected endpoint %s. Got %s.", endpoint, client.endpoint)
 	}
-	// test unix socket endpoints
-	endpoint = "unix:///var/run/docker.sock"
+	// test native endpoints
+	endpoint = nativeRealEndpoint
 	client, err = NewClient(endpoint)
 	if err != nil {
 		t.Fatal(err)
@@ -171,37 +170,6 @@ func TestNewTLSVersionedClientInvalidCA(t *testing.T) {
 	}
 }
 
-func TestNewTSLAPIClientUnixEndpoint(t *testing.T) {
-	srv, cleanup, err := newUnixServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte("ok"))
-	}))
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer cleanup()
-	srv.Start()
-	defer srv.Close()
-	endpoint := "unix://" + srv.Listener.Addr().String()
-	client, err := newTLSClient(endpoint)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if client.endpoint != endpoint {
-		t.Errorf("Expected endpoint %s. Got %s.", endpoint, client.endpoint)
-	}
-	rsp, err := client.do("GET", "/", doOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	data, err := ioutil.ReadAll(rsp.Body)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(data) != "ok" {
-		t.Fatalf("Expected response to be %q, got: %q", "ok", string(data))
-	}
-}
-
 func TestNewClientInvalidEndpoint(t *testing.T) {
 	cases := []string{
 		"htp://localhost:3243", "http://localhost:a",
@@ -275,7 +243,7 @@ func TestGetURL(t *testing.T) {
 		{"http://localhost:4243", "/containers/ps", "http://localhost:4243/containers/ps"},
 		{"tcp://localhost:4243", "/containers/ps", "http://localhost:4243/containers/ps"},
 		{"http://localhost:4243/////", "/", "http://localhost:4243/"},
-		{"unix:///var/run/docker.socket", "/containers", "/containers"},
+		{nativeRealEndpoint, "/containers", "/containers"},
 	}
 	for _, tt := range tests {
 		client, _ := NewClient(tt.endpoint)
@@ -288,15 +256,15 @@ func TestGetURL(t *testing.T) {
 	}
 }
 
-func TestGetFakeUnixURL(t *testing.T) {
+func TestGetFakeNativeURL(t *testing.T) {
 	var tests = []struct {
 		endpoint string
 		path     string
 		expected string
 	}{
-		{"unix://var/run/docker.sock", "/", "http://unix.sock/"},
-		{"unix://var/run/docker.socket", "/", "http://unix.sock/"},
-		{"unix://var/run/docker.sock", "/containers/ps", "http://unix.sock/containers/ps"},
+		{nativeRealEndpoint, "/", "http://unix.sock/"},
+		{nativeRealEndpoint, "/", "http://unix.sock/"},
+		{nativeRealEndpoint, "/containers/ps", "http://unix.sock/containers/ps"},
 	}
 	for _, tt := range tests {
 		client, _ := NewClient(tt.endpoint)
@@ -439,8 +407,8 @@ func TestPingFailingWrongStatus(t *testing.T) {
 	}
 }
 
-func TestPingErrorWithUnixSocket(t *testing.T) {
-	srv, cleanup, err := newUnixServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+func TestPingErrorWithNativeClient(t *testing.T) {
+	srv, cleanup, err := newNativeServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("aaaaaaaaaaa-invalid-aaaaaaaaaaa"))
 	}))
 	if err != nil {
@@ -449,7 +417,7 @@ func TestPingErrorWithUnixSocket(t *testing.T) {
 	defer cleanup()
 	srv.Start()
 	defer srv.Close()
-	endpoint := "unix:///tmp/echo.sock"
+	endpoint := nativeBadEndpoint
 	client, err := NewClient(endpoint)
 	if err != nil {
 		t.Fatal(err)
@@ -630,8 +598,8 @@ func TestClientDoContextCancel(t *testing.T) {
 	}
 }
 
-func TestClientStreamTimeoutUnixSocket(t *testing.T) {
-	srv, cleanup, err := newUnixServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+func TestClientStreamTimeoutNativeClient(t *testing.T) {
+	srv, cleanup, err := newNativeServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		for i := 0; i < 5; i++ {
 			fmt.Fprintf(w, "%d\n", i)
 			if f, ok := w.(http.Flusher); ok {
@@ -646,7 +614,7 @@ func TestClientStreamTimeoutUnixSocket(t *testing.T) {
 	defer cleanup()
 	srv.Start()
 	defer srv.Close()
-	client, err := NewClient("unix://" + srv.Listener.Addr().String())
+	client, err := NewClient(nativeProtocol + "://" + srv.Listener.Addr().String())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -674,14 +642,14 @@ func TestClientDoConcurrentStress(t *testing.T) {
 		reqs = append(reqs, r)
 		mu.Unlock()
 	})
-	var unixSrvs []*httptest.Server
+	var nativeSrvs []*httptest.Server
 	for i := 0; i < 3; i++ {
-		srv, cleanup, err := newUnixServer(handler)
+		srv, cleanup, err := newNativeServer(handler)
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer cleanup()
-		unixSrvs = append(unixSrvs, srv)
+		nativeSrvs = append(nativeSrvs, srv)
 	}
 	var tests = []struct {
 		srv           *httptest.Server
@@ -691,11 +659,11 @@ func TestClientDoConcurrentStress(t *testing.T) {
 		withTLSClient bool
 	}{
 		{srv: httptest.NewUnstartedServer(handler), scheme: "http"},
-		{srv: unixSrvs[0], scheme: "unix"},
+		{srv: nativeSrvs[0], scheme: nativeProtocol},
 		{srv: httptest.NewUnstartedServer(handler), scheme: "http", withTimeout: true},
-		{srv: unixSrvs[1], scheme: "unix", withTimeout: true},
+		{srv: nativeSrvs[1], scheme: nativeProtocol, withTimeout: true},
 		{srv: httptest.NewUnstartedServer(handler), scheme: "https", withTLSServer: true, withTLSClient: true},
-		{srv: unixSrvs[2], scheme: "unix", withTLSServer: false, withTLSClient: true},
+		{srv: nativeSrvs[2], scheme: nativeProtocol, withTLSServer: false, withTLSClient: nativeProtocol == unixProtocol}, // TLS client only works with unix protocol
 	}
 	for _, tt := range tests {
 		reqs = nil
@@ -776,21 +744,6 @@ func TestClientDoConcurrentStress(t *testing.T) {
 		}
 		tt.srv.Close()
 	}
-}
-
-func newUnixServer(handler http.Handler) (*httptest.Server, func(), error) {
-	tmpdir, err := ioutil.TempDir("", "socket")
-	if err != nil {
-		return nil, nil, err
-	}
-	socketPath := filepath.Join(tmpdir, "docker_test_stress.sock")
-	l, err := net.Listen("unix", socketPath)
-	if err != nil {
-		return nil, nil, err
-	}
-	srv := httptest.NewUnstartedServer(handler)
-	srv.Listener = l
-	return srv, func() { os.RemoveAll(tmpdir) }, nil
 }
 
 type FakeRoundTripper struct {

--- a/client_unix.go
+++ b/client_unix.go
@@ -1,0 +1,38 @@
+// +build !windows
+// Copyright 2016 go-dockerclient authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package docker provides a client for the Docker remote API.
+//
+// See https://goo.gl/G3plxW for more details on the remote API.
+package docker
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+
+	"github.com/docker/docker/opts"
+	"github.com/hashicorp/go-cleanhttp"
+)
+
+// DefaultDockerHost returns the default docker socket for the current OS
+func DefaultDockerHost() (string, error) {
+	// If we do not have a host, default to unix socket
+	return opts.ValidateHost(fmt.Sprintf("unix://%s", opts.DefaultUnixSocket))
+}
+
+// initializeNativeClient initializes the native Unix domain socket client on
+// Unix-style operating systems
+func (c *Client) initializeNativeClient() {
+	if c.endpointURL.Scheme != unixProtocol {
+		return
+	}
+	socketPath := c.endpointURL.Path
+	tr := cleanhttp.DefaultTransport()
+	tr.Dial = func(network, addr string) (net.Conn, error) {
+		return c.Dialer.Dial(unixProtocol, socketPath)
+	}
+	c.nativeHTTPClient = &http.Client{Transport: tr}
+}

--- a/client_unix.go
+++ b/client_unix.go
@@ -9,19 +9,11 @@
 package docker
 
 import (
-	"fmt"
 	"net"
 	"net/http"
 
-	"github.com/docker/docker/opts"
 	"github.com/hashicorp/go-cleanhttp"
 )
-
-// DefaultDockerHost returns the default docker socket for the current OS
-func DefaultDockerHost() (string, error) {
-	// If we do not have a host, default to unix socket
-	return opts.ValidateHost(fmt.Sprintf("unix://%s", opts.DefaultUnixSocket))
-}
 
 // initializeNativeClient initializes the native Unix domain socket client on
 // Unix-style operating systems

--- a/client_unix_test.go
+++ b/client_unix_test.go
@@ -1,0 +1,68 @@
+// +build !windows
+// Copyright 2016 go-dockerclient authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package docker
+
+import (
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const (
+	nativeProtocol     = unixProtocol
+	nativeRealEndpoint = "unix:///var/run/docker.sock"
+	nativeBadEndpoint  = "unix:///tmp/echo.sock"
+)
+
+func TestNewTSLAPIClientUnixEndpoint(t *testing.T) {
+	srv, cleanup, err := newNativeServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("ok"))
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+	srv.Start()
+	defer srv.Close()
+	endpoint := nativeProtocol + "://" + srv.Listener.Addr().String()
+	client, err := newTLSClient(endpoint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if client.endpoint != endpoint {
+		t.Errorf("Expected endpoint %s. Got %s.", endpoint, client.endpoint)
+	}
+	rsp, err := client.do("GET", "/", doOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := ioutil.ReadAll(rsp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "ok" {
+		t.Fatalf("Expected response to be %q, got: %q", "ok", string(data))
+	}
+}
+
+func newNativeServer(handler http.Handler) (*httptest.Server, func(), error) {
+	tmpdir, err := ioutil.TempDir("", "socket")
+	if err != nil {
+		return nil, nil, err
+	}
+	socketPath := filepath.Join(tmpdir, "docker_test_stress.sock")
+	l, err := net.Listen("unix", socketPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	srv := httptest.NewUnstartedServer(handler)
+	srv.Listener = l
+	return srv, func() { os.RemoveAll(tmpdir) }, nil
+}

--- a/client_windows.go
+++ b/client_windows.go
@@ -1,0 +1,44 @@
+// +build windows
+// Copyright 2016 go-dockerclient authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package docker provides a client for the Docker remote API.
+//
+// See https://goo.gl/G3plxW for more details on the remote API.
+package docker
+
+import (
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/Microsoft/go-winio"
+	"github.com/hashicorp/go-cleanhttp"
+)
+
+const namedPipeConnectTimeout = 2 * time.Second
+
+type pipeDialer struct {
+	dialFunc func(network, addr string) (net.Conn, error)
+}
+
+func (p pipeDialer) Dial(network, address string) (net.Conn, error) {
+	return p.dialFunc(network, address)
+}
+
+// initializeNativeClient initializes the native Named Pipe client for Windows
+func (c *Client) initializeNativeClient() {
+	if c.endpointURL.Scheme != namedPipeProtocol {
+		return
+	}
+	namedPipePath := c.endpointURL.Path
+	dialFunc := func(network, addr string) (net.Conn, error) {
+		timeout := namedPipeConnectTimeout
+		return winio.DialPipe(namedPipePath, &timeout)
+	}
+	tr := cleanhttp.DefaultTransport()
+	tr.Dial = dialFunc
+	c.Dialer = &pipeDialer{dialFunc}
+	c.nativeHTTPClient = &http.Client{Transport: tr}
+}

--- a/client_windows_test.go
+++ b/client_windows_test.go
@@ -1,0 +1,43 @@
+// +build windows
+// Copyright 2016 go-dockerclient authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package docker
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+
+	"github.com/Microsoft/go-winio"
+)
+
+const (
+	nativeProtocol     = namedPipeProtocol
+	nativeRealEndpoint = "npipe:////./pipe/docker_engine"
+	nativeBadEndpoint  = "npipe:////./pipe/godockerclient_test_echo"
+)
+
+var (
+	// namedPipeCount is used to provide uniqueness in the named pipes generated
+	// by newNativeServer
+	namedPipeCount int
+	// namedPipesAllocateLock protects namedPipeCount
+	namedPipeAllocateLock sync.Mutex
+)
+
+func newNativeServer(handler http.Handler) (*httptest.Server, func(), error) {
+	namedPipeAllocateLock.Lock()
+	defer namedPipeAllocateLock.Unlock()
+	pipeName := fmt.Sprintf("//./pipe/godockerclient_test_%d", namedPipeCount)
+	namedPipeCount++
+	l, err := winio.ListenPipe(pipeName, &winio.PipeConfig{MessageMode: true})
+	if err != nil {
+		return nil, nil, err
+	}
+	srv := httptest.NewUnstartedServer(handler)
+	srv.Listener = l
+	return srv, func() {}, nil
+}

--- a/container_test.go
+++ b/container_test.go
@@ -15,14 +15,11 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
-	"path/filepath"
 	"reflect"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
-
-	"github.com/hashicorp/go-cleanhttp"
 )
 
 func TestStateString(t *testing.T) {
@@ -1717,37 +1714,6 @@ func TestExportContainer(t *testing.T) {
 	}
 }
 
-func TestExportContainerViaUnixSocket(t *testing.T) {
-	content := "exported container tar content"
-	var buf []byte
-	out := bytes.NewBuffer(buf)
-	tempSocket := tempfile("export_socket")
-	defer os.Remove(tempSocket)
-	endpoint := "unix://" + tempSocket
-	u, _ := parseEndpoint(endpoint, false)
-	client := Client{
-		HTTPClient:             cleanhttp.DefaultClient(),
-		Dialer:                 &net.Dialer{},
-		endpoint:               endpoint,
-		endpointURL:            u,
-		SkipServerVersionCheck: true,
-	}
-	listening := make(chan string)
-	done := make(chan int)
-	containerID := "4fa6e0f0c678"
-	go runStreamConnServer(t, "unix", tempSocket, listening, done, containerID)
-	<-listening // wait for server to start
-	opts := ExportContainerOptions{ID: containerID, OutputStream: out}
-	err := client.ExportContainer(opts)
-	<-done // make sure server stopped
-	if err != nil {
-		t.Errorf("ExportContainer: caugh error %#v while exporting container, expected nil", err.Error())
-	}
-	if out.String() != content {
-		t.Errorf("ExportContainer: wrong stdout. Want %#v. Got %#v.", content, out.String())
-	}
-}
-
 func runStreamConnServer(t *testing.T, network, laddr string, listening chan<- string, done chan<- int, containerID string) {
 	defer close(done)
 	l, err := net.Listen(network, laddr)
@@ -2016,63 +1982,6 @@ func TestTopContainerWithPsArgs(t *testing.T) {
 	expectedURI := "/containers/abef348/top?ps_args=aux"
 	if !strings.HasSuffix(fakeRT.requests[0].URL.String(), expectedURI) {
 		t.Errorf("TopContainer: Expected URI to have %q. Got %q.", expectedURI, fakeRT.requests[0].URL.String())
-	}
-}
-
-func TestStatsTimeout(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "socket")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpdir)
-	socketPath := filepath.Join(tmpdir, "docker_test.sock")
-	t.Logf("socketPath=%s", socketPath)
-	l, err := net.Listen("unix", socketPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	received := make(chan bool)
-	defer l.Close()
-	go func() {
-		conn, connErr := l.Accept()
-		if connErr != nil {
-			t.Logf("Failed to accept connection: %s", connErr)
-			return
-		}
-		breader := bufio.NewReader(conn)
-		req, connErr := http.ReadRequest(breader)
-		if connErr != nil {
-			t.Logf("Failed to read request: %s", connErr)
-			return
-		}
-		if req.URL.Path != "/containers/c/stats" {
-			t.Logf("Wrong URL path for stats: %q", req.URL.Path)
-			return
-		}
-		received <- true
-		time.Sleep(2 * time.Second)
-	}()
-	client, _ := NewClient("unix://" + socketPath)
-	client.SkipServerVersionCheck = true
-	errC := make(chan error, 1)
-	statsC := make(chan *Stats)
-	done := make(chan bool)
-	defer close(done)
-	go func() {
-		errC <- client.Stats(StatsOptions{ID: "c", Stats: statsC, Stream: true, Done: done, Timeout: time.Millisecond})
-		close(errC)
-	}()
-	err = <-errC
-	e, ok := err.(net.Error)
-	if !ok || !e.Timeout() {
-		t.Errorf("Failed to receive timeout error, got %#v", err)
-	}
-	recvTimeout := 2 * time.Second
-	select {
-	case <-received:
-		return
-	case <-time.After(recvTimeout):
-		t.Fatalf("Timeout waiting to receive message after %v", recvTimeout)
 	}
 }
 

--- a/container_test.go
+++ b/container_test.go
@@ -1466,7 +1466,6 @@ func TestAttachToContainerRawTerminalFalse(t *testing.T) {
 		conn.Write([]byte("hello!"))
 		conn.Close()
 	}))
-	defer server.Close()
 	client, _ := NewClient(server.URL)
 	client.SkipServerVersionCheck = true
 	var stdout, stderr bytes.Buffer
@@ -1489,6 +1488,7 @@ func TestAttachToContainerRawTerminalFalse(t *testing.T) {
 		"stream": {"1"},
 	}
 	got := map[string][]string(req.URL.Query())
+	server.Close()
 	if !reflect.DeepEqual(got, expected) {
 		t.Errorf("AttachToContainer: wrong query string. Want %#v. Got %#v.", expected, got)
 	}

--- a/container_unix_test.go
+++ b/container_unix_test.go
@@ -1,0 +1,108 @@
+// +build !windows
+// Copyright 2016 go-dockerclient authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package docker
+
+import (
+	"bufio"
+	"bytes"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-cleanhttp"
+)
+
+func TestExportContainerViaUnixSocket(t *testing.T) {
+	content := "exported container tar content"
+	var buf []byte
+	out := bytes.NewBuffer(buf)
+	tempSocket := tempfile("export_socket")
+	defer os.Remove(tempSocket)
+	endpoint := "unix://" + tempSocket
+	u, _ := parseEndpoint(endpoint, false)
+	client := Client{
+		HTTPClient:             cleanhttp.DefaultClient(),
+		Dialer:                 &net.Dialer{},
+		endpoint:               endpoint,
+		endpointURL:            u,
+		SkipServerVersionCheck: true,
+	}
+	listening := make(chan string)
+	done := make(chan int)
+	containerID := "4fa6e0f0c678"
+	go runStreamConnServer(t, "unix", tempSocket, listening, done, containerID)
+	<-listening // wait for server to start
+	opts := ExportContainerOptions{ID: containerID, OutputStream: out}
+	err := client.ExportContainer(opts)
+	<-done // make sure server stopped
+	if err != nil {
+		t.Errorf("ExportContainer: caugh error %#v while exporting container, expected nil", err.Error())
+	}
+	if out.String() != content {
+		t.Errorf("ExportContainer: wrong stdout. Want %#v. Got %#v.", content, out.String())
+	}
+}
+
+func TestStatsTimeoutUnixSocket(t *testing.T) {
+	tmpdir, err := ioutil.TempDir("", "socket")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpdir)
+	socketPath := filepath.Join(tmpdir, "docker_test.sock")
+	t.Logf("socketPath=%s", socketPath)
+	l, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	received := make(chan bool)
+	defer l.Close()
+	go func() {
+		conn, connErr := l.Accept()
+		if connErr != nil {
+			t.Logf("Failed to accept connection: %s", connErr)
+			return
+		}
+		breader := bufio.NewReader(conn)
+		req, connErr := http.ReadRequest(breader)
+		if connErr != nil {
+			t.Logf("Failed to read request: %s", connErr)
+			return
+		}
+		if req.URL.Path != "/containers/c/stats" {
+			t.Logf("Wrong URL path for stats: %q", req.URL.Path)
+			return
+		}
+		received <- true
+		time.Sleep(2 * time.Second)
+	}()
+	client, _ := NewClient("unix://" + socketPath)
+	client.SkipServerVersionCheck = true
+	errC := make(chan error, 1)
+	statsC := make(chan *Stats)
+	done := make(chan bool)
+	defer close(done)
+	go func() {
+		errC <- client.Stats(StatsOptions{ID: "c", Stats: statsC, Stream: true, Done: done, Timeout: time.Millisecond})
+		close(errC)
+	}()
+	err = <-errC
+	e, ok := err.(net.Error)
+	if !ok || !e.Timeout() {
+		t.Errorf("Failed to receive timeout error, got %#v", err)
+	}
+	recvTimeout := 2 * time.Second
+	select {
+	case <-received:
+		return
+	case <-time.After(recvTimeout):
+		t.Fatalf("Timeout waiting to receive message after %v", recvTimeout)
+	}
+}

--- a/event.go
+++ b/event.go
@@ -78,6 +78,10 @@ var (
 	// exists.
 	ErrListenerAlreadyExists = errors.New("listener already exists for docker events")
 
+	// ErrTLSNotSupported is the error returned when the client does not support
+	// TLS (this applies to the Windows named pipe client).
+	ErrTLSNotSupported = errors.New("tls not supported by this client")
+
 	// EOFEvent is sent when the event listener receives an EOF error.
 	EOFEvent = &APIEvents{
 		Type:   "EOF",
@@ -290,7 +294,7 @@ func (c *Client) eventHijack(startTime int64, eventChan chan *APIEvents, errChan
 	}
 	protocol := c.endpointURL.Scheme
 	address := c.endpointURL.Path
-	if protocol != "unix" {
+	if protocol != "unix" && protocol != "npipe" {
 		protocol = "tcp"
 		address = c.endpointURL.Host
 	}
@@ -299,7 +303,11 @@ func (c *Client) eventHijack(startTime int64, eventChan chan *APIEvents, errChan
 	if c.TLSConfig == nil {
 		dial, err = c.Dialer.Dial(protocol, address)
 	} else {
-		dial, err = tlsDialWithDialer(c.Dialer, protocol, address, c.TLSConfig)
+		netDialer, ok := c.Dialer.(*net.Dialer)
+		if !ok {
+			return ErrTLSNotSupported
+		}
+		dial, err = tlsDialWithDialer(netDialer, protocol, address, c.TLSConfig)
 	}
 	if err != nil {
 		return err


### PR DESCRIPTION
Fixes https://github.com/fsouza/go-dockerclient/issues/531

This series of commits adds support for communicating with Docker over a Windows named pipe.

There are a few things to note:
* I've only tested this with toy programs so far.
* All the unit/integ tests in this package are passing on both Linux and Windows.
* I haven't ported all the tests in `container_unix_test.go` to Windows; I started running into some issues with `Accept()` on a `net.Listener` for a named pipe and haven't spent time troubleshooting it yet.  If this is a blocker to accepting the pull request I can spend more time here.
* I did not add TLS support for named pipes.  I don't plan to do this since I don't expect to have a use-case for this.
* A few tests that were otherwise platform-independent made some assumptions about running on Linux that don't appear to always work on Windows; I've fixed them to ensure that they run on Linux and Windows.

All the commits here are contributed under the terms of the [BSD 2-clause license](https://github.com/fsouza/go-dockerclient/blob/01804de/LICENSE).

Let me know if you need anything else!