### PR TITLE
testing: add basic swarm support for multiple nodes

### DIFF
--- a/testing/server.go
+++ b/testing/server.go
@@ -8,6 +8,7 @@ package testing
 
 import (
 	"archive/tar"
+	"bytes"
 	"crypto/rand"
 	"crypto/tls"
 	"crypto/x509"
@@ -63,8 +64,40 @@ type DockerServer struct {
 	cChan          chan<- *docker.Container
 	volStore       map[string]*volumeCounter
 	volMut         sync.RWMutex
-	swarm          *swarm.Swarm
 	swarmMut       sync.RWMutex
+	swarm          *swarm.Swarm
+	swarmServer    *swarmServer
+	nodes          []swarm.Node
+	nodeId         string
+}
+
+type swarmServer struct {
+	srv      *DockerServer
+	mux      *mux.Router
+	listener net.Listener
+}
+
+func newSwarmServer(srv *DockerServer, bind string) (*swarmServer, error) {
+	listener, err := net.Listen("tcp", bind)
+	if err != nil {
+		return nil, err
+	}
+	router := mux.NewRouter()
+	router.Path("/internal/updatenodes").Methods("POST").HandlerFunc(srv.handlerWrapper(srv.internalUpdateNodes))
+	server := &swarmServer{
+		listener: listener,
+		mux:      router,
+		srv:      srv,
+	}
+	go http.Serve(listener, router)
+	return server, nil
+}
+
+func (s *swarmServer) URL() string {
+	if s.listener == nil {
+		return ""
+	}
+	return "http://" + s.listener.Addr().String() + "/"
 }
 
 type volumeCounter struct {
@@ -195,6 +228,10 @@ func (s *DockerServer) buildMuxer() {
 	s.mux.Path("/swarm").Methods("GET").HandlerFunc(s.handlerWrapper(s.swarmInspect))
 	s.mux.Path("/swarm/join").Methods("POST").HandlerFunc(s.handlerWrapper(s.swarmJoin))
 	s.mux.Path("/swarm/leave").Methods("POST").HandlerFunc(s.handlerWrapper(s.swarmLeave))
+	s.mux.Path("/nodes/{id:.+}/update").Methods("POST").HandlerFunc(s.handlerWrapper(s.nodeUpdate))
+	s.mux.Path("/nodes/{id:.+}").Methods("GET").HandlerFunc(s.handlerWrapper(s.nodeInspect))
+	s.mux.Path("/nodes/{id:.+}").Methods("DELETE").HandlerFunc(s.handlerWrapper(s.nodeDelete))
+	s.mux.Path("/nodes").Methods("GET").HandlerFunc(s.handlerWrapper(s.nodeList))
 	s.mux.Path("/services/create").Methods("POST").HandlerFunc(s.handlerWrapper(s.serviceCreate))
 	s.mux.Path("/networks/create").Methods("POST").HandlerFunc(s.handlerWrapper(s.networkCreate))
 }
@@ -290,6 +327,9 @@ func (s *DockerServer) MutateContainer(id string, state docker.State) error {
 func (s *DockerServer) Stop() {
 	if s.listener != nil {
 		s.listener.Close()
+	}
+	if s.swarmServer != nil {
+		s.swarmServer.listener.Close()
 	}
 }
 
@@ -1322,6 +1362,12 @@ func (s *DockerServer) infoDocker(w http.ResponseWriter, r *http.Request) {
 			paused++
 		}
 	}
+	var swarmInfo *swarm.Info
+	if s.swarm != nil {
+		swarmInfo = &swarm.Info{
+			NodeID: s.nodeId,
+		}
+	}
 	envs := map[string]interface{}{
 		"ID":                "AAAA:XXXX:0000:BBBB:AAAA:XXXX:0000:BBBB:AAAA:XXXX:0000:BBBB",
 		"Containers":        len(s.containers),
@@ -1384,6 +1430,7 @@ func (s *DockerServer) infoDocker(w http.ResponseWriter, r *http.Request) {
 		"ServerVersion":     "1.10.1",
 		"ClusterStore":      "",
 		"ClusterAdvertise":  "",
+		"Swarm":             swarmInfo,
 	}
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(envs)
@@ -1405,21 +1452,67 @@ func (s *DockerServer) versionDocker(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(envs)
 }
 
+func (s *DockerServer) initSwarmNode(listenAddr, advertiseAddr string) (swarm.Node, error) {
+	if listenAddr == "" {
+		listenAddr = "127.0.0.1:0"
+	}
+	var err error
+	s.swarmServer, err = newSwarmServer(s, listenAddr)
+	if err != nil {
+		return swarm.Node{}, err
+	}
+	if advertiseAddr == "" {
+		advertiseAddr = s.swarmServer.URL()
+	}
+	s.nodeId = s.generateID()
+	return swarm.Node{
+		ID: s.nodeId,
+		Status: swarm.NodeStatus{
+			State: swarm.NodeStateReady,
+		},
+		ManagerStatus: &swarm.ManagerStatus{
+			Addr: advertiseAddr,
+		},
+	}, nil
+}
+
 func (s *DockerServer) swarmInit(w http.ResponseWriter, r *http.Request) {
 	s.swarmMut.Lock()
 	defer s.swarmMut.Unlock()
-	if s.swarm == nil {
-		s.swarm = &swarm.Swarm{
-			JoinTokens: swarm.JoinTokens{
-				Manager: s.generateID(),
-				Worker:  s.generateID(),
-			},
-		}
-		w.WriteHeader(http.StatusOK)
-		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(`"teste"`))
-	} else {
+	if s.swarm != nil {
 		w.WriteHeader(http.StatusNotAcceptable)
+		return
+	}
+	var req swarm.InitRequest
+	err := json.NewDecoder(r.Body).Decode(&req)
+	if err != nil && err != io.EOF {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	node, err := s.initSwarmNode(req.ListenAddr, req.AdvertiseAddr)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	node.ManagerStatus.Leader = true
+	err = s.runNodeOperation(node.ManagerStatus.Addr, nodeOperation{
+		Op:   "add",
+		Node: node,
+	})
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	s.swarm = &swarm.Swarm{
+		JoinTokens: swarm.JoinTokens{
+			Manager: s.generateID(),
+			Worker:  s.generateID(),
+		},
+	}
+	w.Header().Set("Content-Type", "application/json")
+	err = json.NewEncoder(w).Encode(s.nodeId)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
 }
 
@@ -1438,17 +1531,40 @@ func (s *DockerServer) swarmInspect(w http.ResponseWriter, r *http.Request) {
 func (s *DockerServer) swarmJoin(w http.ResponseWriter, r *http.Request) {
 	s.swarmMut.Lock()
 	defer s.swarmMut.Unlock()
-	if s.swarm == nil {
-		s.swarm = &swarm.Swarm{
-			JoinTokens: swarm.JoinTokens{
-				Manager: s.generateID(),
-				Worker:  s.generateID(),
-			},
-		}
-		w.WriteHeader(http.StatusOK)
-	} else {
+	if s.swarm != nil {
 		w.WriteHeader(http.StatusNotAcceptable)
+		return
 	}
+	var req swarm.JoinRequest
+	err := json.NewDecoder(r.Body).Decode(&req)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if len(req.RemoteAddrs) == 0 {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	node, err := s.initSwarmNode(req.ListenAddr, req.AdvertiseAddr)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	err = s.runNodeOperation(req.RemoteAddrs[0], nodeOperation{
+		Op:   "add",
+		Node: node,
+	})
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	s.swarm = &swarm.Swarm{
+		JoinTokens: swarm.JoinTokens{
+			Manager: s.generateID(),
+			Worker:  s.generateID(),
+		},
+	}
+	w.WriteHeader(http.StatusOK)
 }
 
 func (s *DockerServer) swarmLeave(w http.ResponseWriter, r *http.Request) {
@@ -1457,7 +1573,11 @@ func (s *DockerServer) swarmLeave(w http.ResponseWriter, r *http.Request) {
 	if s.swarm == nil {
 		w.WriteHeader(http.StatusNotAcceptable)
 	} else {
+		s.swarmServer.listener.Close()
 		s.swarm = nil
+		s.nodes = nil
+		s.swarmServer = nil
+		s.nodeId = ""
 		w.WriteHeader(http.StatusOK)
 	}
 }
@@ -1524,4 +1644,169 @@ func (s *DockerServer) networkCreate(w http.ResponseWriter, r *http.Request) {
 		ID: s.generateID(),
 	}
 	json.NewEncoder(w).Encode(cnr)
+}
+
+func (s *DockerServer) nodeUpdate(w http.ResponseWriter, r *http.Request) {
+	s.swarmMut.Lock()
+	defer s.swarmMut.Unlock()
+	if s.swarm == nil {
+		w.WriteHeader(http.StatusNotAcceptable)
+		return
+	}
+	id := mux.Vars(r)["id"]
+	var n *swarm.Node
+	for i := range s.nodes {
+		if s.nodes[i].ID == id {
+			n = &s.nodes[i]
+			break
+		}
+	}
+	if n == nil {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+	var spec swarm.NodeSpec
+	err := json.NewDecoder(r.Body).Decode(&spec)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	n.Spec = spec
+	err = s.runNodeOperation(s.swarmServer.URL(), nodeOperation{
+		Op:   "update",
+		Node: *n,
+	})
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+}
+
+func (s *DockerServer) nodeDelete(w http.ResponseWriter, r *http.Request) {
+	s.swarmMut.Lock()
+	defer s.swarmMut.Unlock()
+	if s.swarm == nil {
+		w.WriteHeader(http.StatusNotAcceptable)
+		return
+	}
+	id := mux.Vars(r)["id"]
+	err := s.runNodeOperation(s.swarmServer.URL(), nodeOperation{
+		Op: "delete",
+		Node: swarm.Node{
+			ID: id,
+		},
+	})
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+}
+
+func (s *DockerServer) nodeInspect(w http.ResponseWriter, r *http.Request) {
+	s.swarmMut.Lock()
+	defer s.swarmMut.Unlock()
+	if s.swarm == nil {
+		w.WriteHeader(http.StatusNotAcceptable)
+		return
+	}
+	id := mux.Vars(r)["id"]
+	for _, n := range s.nodes {
+		if n.ID == id {
+			err := json.NewEncoder(w).Encode(n)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
+			return
+		}
+	}
+	w.WriteHeader(http.StatusNotFound)
+}
+
+func (s *DockerServer) nodeList(w http.ResponseWriter, r *http.Request) {
+	s.swarmMut.Lock()
+	defer s.swarmMut.Unlock()
+	if s.swarm == nil {
+		w.WriteHeader(http.StatusNotAcceptable)
+		return
+	}
+	err := json.NewEncoder(w).Encode(s.nodes)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+type nodeOperation struct {
+	Op   string
+	Node swarm.Node
+}
+
+func (s *DockerServer) runNodeOperation(dst string, nodeOp nodeOperation) error {
+	data, err := json.Marshal(nodeOp)
+	if err != nil {
+		return err
+	}
+	url := fmt.Sprintf("%s/internal/updatenodes", strings.TrimRight(dst, "/"))
+	rsp, err := http.Post(url, "application/json", bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
+	if rsp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status code in updatenodes: %d", rsp.StatusCode)
+	}
+	return json.NewDecoder(rsp.Body).Decode(&s.nodes)
+}
+
+func (s *DockerServer) internalUpdateNodes(w http.ResponseWriter, r *http.Request) {
+	propagate := r.URL.Query().Get("propagate") != "0"
+	if !propagate {
+		s.swarmMut.Lock()
+		defer s.swarmMut.Unlock()
+	}
+	data, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	var nodeOp nodeOperation
+	err = json.Unmarshal(data, &nodeOp)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if propagate {
+		for _, node := range s.nodes {
+			if s.swarmServer.URL() == node.ManagerStatus.Addr {
+				continue
+			}
+			url := fmt.Sprintf("%s/internal/updatenodes?propagate=0", strings.TrimRight(node.ManagerStatus.Addr, "/"))
+			_, err = http.Post(url, "application/json", bytes.NewReader(data))
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+		}
+	}
+	switch nodeOp.Op {
+	case "add":
+		s.nodes = append(s.nodes, nodeOp.Node)
+	case "update":
+		for i, n := range s.nodes {
+			if n.ID == nodeOp.Node.ID {
+				s.nodes[i] = nodeOp.Node
+				break
+			}
+		}
+	case "delete":
+		for i, n := range s.nodes {
+			if n.ID == nodeOp.Node.ID {
+				s.nodes = append(s.nodes[:i], s.nodes[i+1:]...)
+				break
+			}
+		}
+	}
+	w.Header().Set("Content-Type", "application/json")
+	err = json.NewEncoder(w).Encode(s.nodes)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
 }

--- a/testing/server_test.go
+++ b/testing/server_test.go
@@ -2246,7 +2246,7 @@ func TestSwarmInit(t *testing.T) {
 	server, _ := NewServer("127.0.0.1:0", nil, nil)
 	server.buildMuxer()
 	recorder := httptest.NewRecorder()
-	request, _ := http.NewRequest("POST", "/swarm/init", nil)
+	request, _ := http.NewRequest("POST", "/swarm/init", bytes.NewReader(nil))
 	server.ServeHTTP(recorder, request)
 	if recorder.Code != http.StatusOK {
 		t.Fatalf("SwarmInit: wrong status. Want %d. Got %d.", http.StatusOK, recorder.Code)
@@ -2262,6 +2262,15 @@ func TestSwarmInit(t *testing.T) {
 	if server.swarm == nil {
 		t.Fatalf("SwarmInit: expected swarm to be set.")
 	}
+	if len(server.nodes) != 1 {
+		t.Fatalf("SwarmInit: expected node len to be 1, got: %d", len(server.nodes))
+	}
+	if server.nodes[0].ManagerStatus.Addr != server.swarmServer.URL() {
+		t.Fatalf("SwarmInit: expected current node to have addr %q, got: %q", server.swarmServer.URL(), server.nodes[0].ManagerStatus.Addr)
+	}
+	if !server.nodes[0].ManagerStatus.Leader {
+		t.Fatalf("SwarmInit: expected current node to be leader")
+	}
 }
 
 func TestSwarmInitAlreadyInSwarm(t *testing.T) {
@@ -2276,17 +2285,62 @@ func TestSwarmInitAlreadyInSwarm(t *testing.T) {
 	}
 }
 
-func TestSwarmJoin(t *testing.T) {
+func TestSwarmJoinNoBody(t *testing.T) {
 	server, _ := NewServer("127.0.0.1:0", nil, nil)
 	server.buildMuxer()
 	recorder := httptest.NewRecorder()
-	request, _ := http.NewRequest("POST", "/swarm/join", nil)
+	request, _ := http.NewRequest("POST", "/swarm/join", bytes.NewReader(nil))
 	server.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusInternalServerError {
+		t.Fatalf("SwarmJoin: wrong status. Want %d. Got %d.", http.StatusInternalServerError, recorder.Code)
+	}
+	if server.swarm != nil {
+		t.Fatalf("SwarmJoin: expected swarm not to be set.")
+	}
+}
+
+func TestSwarmJoin(t *testing.T) {
+	server1, _ := NewServer("127.0.0.1:0", nil, nil)
+	server2, _ := NewServer("127.0.0.1:0", nil, nil)
+	data, err := json.Marshal(swarm.InitRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	recorder := httptest.NewRecorder()
+	request, _ := http.NewRequest("POST", "/swarm/init", bytes.NewReader(data))
+	server1.ServeHTTP(recorder, request)
 	if recorder.Code != http.StatusOK {
 		t.Fatalf("SwarmJoin: wrong status. Want %d. Got %d.", http.StatusOK, recorder.Code)
 	}
-	if server.swarm == nil {
+	data, err = json.Marshal(swarm.JoinRequest{
+		RemoteAddrs: []string{server1.swarmServer.URL()},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	recorder = httptest.NewRecorder()
+	request, _ = http.NewRequest("POST", "/swarm/join", bytes.NewReader(data))
+	server2.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("SwarmJoin: wrong status. Want %d. Got %d.", http.StatusOK, recorder.Code)
+	}
+	if server1.swarm == nil || server2.swarm == nil {
 		t.Fatalf("SwarmJoin: expected swarm to be set.")
+	}
+	if len(server1.nodes) != 2 {
+		t.Fatalf("SwarmJoin: expected node len to be 2, got: %d", len(server1.nodes))
+	}
+	if server1.nodes[0].ManagerStatus.Addr != server1.swarmServer.URL() {
+		t.Fatalf("SwarmJoin: expected nodes[0] to have addr %q, got: %q", server1.swarmServer.URL(), server1.nodes[0].ManagerStatus.Addr)
+	}
+	if server1.nodes[1].ManagerStatus.Leader {
+		t.Fatalf("SwarmInit: expected nodes[1] not to be leader")
+	}
+	if server1.nodes[1].ManagerStatus.Addr != server2.swarmServer.URL() {
+		t.Fatalf("SwarmJoin: expected nodes[1] to have addr %q, got: %q", server2.swarmServer.URL(), server1.nodes[1].ManagerStatus.Addr)
+	}
+	if !reflect.DeepEqual(server1.nodes, server2.nodes) {
+		t.Fatalf("SwarmJoin: expected nodes to be equal in server1 and server2, got:\n%#v\n%#v", server1.nodes, server2.nodes)
 	}
 }
 
@@ -2306,6 +2360,7 @@ func TestSwarmLeave(t *testing.T) {
 	server, _ := NewServer("127.0.0.1:0", nil, nil)
 	server.buildMuxer()
 	server.swarm = &swarm.Swarm{}
+	server.swarmServer, _ = newSwarmServer(server, "127.0.0.1:0")
 	recorder := httptest.NewRecorder()
 	request, _ := http.NewRequest("POST", "/swarm/leave", nil)
 	server.ServeHTTP(recorder, request)
@@ -2459,4 +2514,128 @@ func TestNetworkCreate(t *testing.T) {
 	if resp["ID"] == "" {
 		t.Fatal("NetworkCreate: network id can't be empty.")
 	}
+}
+
+func TestNodeList(t *testing.T) {
+	srv1, srv2, err := setUpSwarm()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, srv := range []*DockerServer{srv1, srv2} {
+		recorder := httptest.NewRecorder()
+		request, _ := http.NewRequest("GET", "/nodes", nil)
+		srv.ServeHTTP(recorder, request)
+		if recorder.Code != http.StatusOK {
+			t.Fatalf("invalid status code: %d", recorder.Code)
+		}
+		var nodes []swarm.Node
+		err = json.NewDecoder(recorder.Body).Decode(&nodes)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(nodes, srv1.nodes) {
+			t.Fatalf("expected nodes to equal %#v, got: %#v", srv1.nodes, nodes)
+		}
+		if !reflect.DeepEqual(nodes, srv2.nodes) {
+			t.Fatalf("expected nodes to equal %#v, got: %#v", srv2.nodes, nodes)
+		}
+	}
+}
+
+func TestNodeInfo(t *testing.T) {
+	srv1, srv2, err := setUpSwarm()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, srv := range []*DockerServer{srv1, srv2} {
+		recorder := httptest.NewRecorder()
+		request, _ := http.NewRequest("GET", "/nodes/"+srv.nodes[0].ID, nil)
+		srv.ServeHTTP(recorder, request)
+		if recorder.Code != http.StatusOK {
+			t.Fatalf("invalid status code: %d", recorder.Code)
+		}
+		var node swarm.Node
+		err = json.NewDecoder(recorder.Body).Decode(&node)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(node, srv1.nodes[0]) {
+			t.Fatalf("expected node to equal %#v, got: %#v", srv1.nodes[0], node)
+		}
+		if !reflect.DeepEqual(node, srv2.nodes[0]) {
+			t.Fatalf("expected node to equal %#v, got: %#v", srv2.nodes[0], node)
+		}
+	}
+}
+
+func TestNodeUpdate(t *testing.T) {
+	srv1, srv2, err := setUpSwarm()
+	if err != nil {
+		t.Fatal(err)
+	}
+	recorder := httptest.NewRecorder()
+	for i, srv := range []*DockerServer{srv1, srv2} {
+		key := fmt.Sprintf("l%d", i)
+		data, err := json.Marshal(swarm.NodeSpec{
+			Annotations: swarm.Annotations{Labels: map[string]string{key: "value"}},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		body := bytes.NewReader(data)
+		request, _ := http.NewRequest("POST", "/nodes/"+srv.nodes[0].ID+"/update", body)
+		srv.ServeHTTP(recorder, request)
+		if recorder.Code != http.StatusOK {
+			t.Fatalf("invalid status code: %d", recorder.Code)
+		}
+		if srv1.nodes[0].Spec.Annotations.Labels[key] != "value" {
+			t.Fatalf("expected node to have label %s", key)
+		}
+		if srv2.nodes[0].Spec.Annotations.Labels[key] != "value" {
+			t.Fatalf("expected node to have label %s", key)
+		}
+	}
+}
+
+func TestNodeDelete(t *testing.T) {
+	srv1, srv2, err := setUpSwarm()
+	if err != nil {
+		t.Fatal(err)
+	}
+	recorder := httptest.NewRecorder()
+	request, _ := http.NewRequest("DELETE", "/nodes/"+srv1.nodes[0].ID, nil)
+	srv1.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("invalid status code: %d", recorder.Code)
+	}
+	if len(srv1.nodes) != 1 {
+		t.Fatalf("expected len(nodes) to be 1, got %d", len(srv1.nodes))
+	}
+	if len(srv2.nodes) != 1 {
+		t.Fatalf("expected len(nodes) to be 1, got %d", len(srv2.nodes))
+	}
+}
+
+func setUpSwarm() (*DockerServer, *DockerServer, error) {
+	server1, _ := NewServer("127.0.0.1:0", nil, nil)
+	server2, _ := NewServer("127.0.0.1:0", nil, nil)
+	recorder := httptest.NewRecorder()
+	request, _ := http.NewRequest("POST", "/swarm/init", bytes.NewReader(nil))
+	server1.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusOK {
+		return nil, nil, fmt.Errorf("invalid status code %d", recorder.Code)
+	}
+	data, err := json.Marshal(swarm.JoinRequest{
+		RemoteAddrs: []string{server1.swarmServer.URL()},
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	recorder = httptest.NewRecorder()
+	request, _ = http.NewRequest("POST", "/swarm/join", bytes.NewReader(data))
+	server2.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusOK {
+		return nil, nil, fmt.Errorf("invalid status code %d", recorder.Code)
+	}
+	return server1, server2, nil
 }


### PR DESCRIPTION
This pull request add support to multiple swarm nodes in the testing client.

A new server is started after running `/swarm/init` or `/swarm/join` respecting the ListenAddr parameter or choosing a new random localhost address.

After the cluster is started all nodes joining it are exposed for listing and manipulation using the `/nodes*` routes. Information about new nodes and updates to existing nodes are propagated to all members of the cluster using an internal route in the started swarm server.

This implementation mirrors basic functionality exposed by docker swarm mode, there are probably some corner and error cases that do not completely reflect docker behavior. However, I think it's a good enough start point to enable accepting further contributions and improve from here.