### PR TITLE
Update import paths for docker dependencies

### DIFF
--- a/misc.go
+++ b/misc.go
@@ -8,7 +8,7 @@ import (
 	"encoding/json"
 	"strings"
 
-	"github.com/docker/engine-api/types/swarm"
+	"github.com/docker/docker/api/types/swarm"
 )
 
 // Version returns version information about the docker server.

--- a/node.go
+++ b/node.go
@@ -10,7 +10,7 @@ import (
 	"net/url"
 	"strconv"
 
-	"github.com/docker/engine-api/types/swarm"
+	"github.com/docker/docker/api/types/swarm"
 	"golang.org/x/net/context"
 )
 

--- a/node_test.go
+++ b/node_test.go
@@ -11,7 +11,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/docker/engine-api/types/swarm"
+	"github.com/docker/docker/api/types/swarm"
 )
 
 func TestListNodes(t *testing.T) {

--- a/service.go
+++ b/service.go
@@ -10,7 +10,7 @@ import (
 	"net/url"
 	"strconv"
 
-	"github.com/docker/engine-api/types/swarm"
+	"github.com/docker/docker/api/types/swarm"
 	"golang.org/x/net/context"
 )
 

--- a/service_test.go
+++ b/service_test.go
@@ -11,7 +11,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/docker/engine-api/types/swarm"
+	"github.com/docker/docker/api/types/swarm"
 )
 
 func TestCreateService(t *testing.T) {

--- a/swarm.go
+++ b/swarm.go
@@ -11,7 +11,7 @@ import (
 	"net/url"
 	"strconv"
 
-	"github.com/docker/engine-api/types/swarm"
+	"github.com/docker/docker/api/types/swarm"
 	"golang.org/x/net/context"
 )
 

--- a/swarm_test.go
+++ b/swarm_test.go
@@ -10,7 +10,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/docker/engine-api/types/swarm"
+	"github.com/docker/docker/api/types/swarm"
 )
 
 func TestInitSwarm(t *testing.T) {

--- a/task.go
+++ b/task.go
@@ -8,7 +8,7 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/docker/engine-api/types/swarm"
+	"github.com/docker/docker/api/types/swarm"
 	"golang.org/x/net/context"
 )
 

--- a/task_test.go
+++ b/task_test.go
@@ -11,7 +11,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/docker/engine-api/types/swarm"
+	"github.com/docker/docker/api/types/swarm"
 )
 
 func TestListTasks(t *testing.T) {

--- a/testing/server.go
+++ b/testing/server.go
@@ -25,8 +25,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/pkg/stdcopy"
-	"github.com/docker/engine-api/types/swarm"
 	"github.com/fsouza/go-dockerclient"
 	"github.com/gorilla/mux"
 )

--- a/testing/server_test.go
+++ b/testing/server_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/engine-api/types/swarm"
+	"github.com/docker/docker/api/types/swarm"
 	"github.com/fsouza/go-dockerclient"
 )
 

--- a/testing/swarm.go
+++ b/testing/swarm.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/docker/engine-api/types/swarm"
+	"github.com/docker/docker/api/types/swarm"
 	"github.com/fsouza/go-dockerclient"
 	"github.com/gorilla/mux"
 )

--- a/testing/swarm_test.go
+++ b/testing/swarm_test.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/engine-api/types/swarm"
+	"github.com/docker/docker/api/types/swarm"
 	"github.com/fsouza/go-dockerclient"
 )
 


### PR DESCRIPTION
The github.com/docker/engine-api package has been deprecated now all import paths should move to github.com/docker/docker/{api,client}