### PR TITLE
fix CreateNetwork error handling

### DIFF
--- a/network.go
+++ b/network.go
@@ -153,9 +153,6 @@ func (c *Client) CreateNetwork(opts CreateNetworkOptions) (*Network, error) {
 		},
 	)
 	if err != nil {
-		if e, ok := err.(*Error); ok && e.Status == http.StatusConflict {
-			return nil, ErrNetworkAlreadyExists
-		}
 		return nil, err
 	}
 	defer resp.Body.Close()


### PR DESCRIPTION
fixes #605

---

I'm not totally sure this is the right thing to do but it does address #605. with this change, `ErrNetworkAlreadyExists` is not used but I did not remove it since it is part of exported api.