### PR TITLE
Allow TLS without client credentials

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -159,9 +159,40 @@ func TestNewTLSVersionedClient(t *testing.T) {
 	}
 }
 
+func TestNewTLSVersionedClientNoClientCert(t *testing.T) {
+	certPath := "testing/data/cert_doesnotexist.pem"
+	keyPath := "testing/data/key_doesnotexist.pem"
+	caPath := "testing/data/ca.pem"
+	endpoint := "https://localhost:4243"
+	client, err := NewVersionedTLSClient(endpoint, certPath, keyPath, caPath, "1.14")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if client.endpoint != endpoint {
+		t.Errorf("Expected endpoint %s. Got %s.", endpoint, client.endpoint)
+	}
+	if reqVersion := client.requestedAPIVersion.String(); reqVersion != "1.14" {
+		t.Errorf("Wrong requestAPIVersion. Want %q. Got %q.", "1.14", reqVersion)
+	}
+	if client.SkipServerVersionCheck {
+		t.Error("Expected SkipServerVersionCheck to be false, got true")
+	}
+}
+
 func TestNewTLSVersionedClientInvalidCA(t *testing.T) {
 	certPath := "testing/data/cert.pem"
 	keyPath := "testing/data/key.pem"
+	caPath := "testing/data/key.pem"
+	endpoint := "https://localhost:4243"
+	_, err := NewVersionedTLSClient(endpoint, certPath, keyPath, caPath, "1.14")
+	if err == nil {
+		t.Errorf("Expected invalid ca at %s", caPath)
+	}
+}
+
+func TestNewTLSVersionedClientInvalidCANoClientCert(t *testing.T) {
+	certPath := "testing/data/cert_doesnotexist.pem"
+	keyPath := "testing/data/key_doesnotexist.pem"
 	caPath := "testing/data/key.pem"
 	endpoint := "https://localhost:4243"
 	_, err := NewVersionedTLSClient(endpoint, certPath, keyPath, caPath, "1.14")


### PR DESCRIPTION
This patch allows TLS to work in the absence of client credentials (certificate and key), same as the Docker client.

[Docker documentation](https://docs.docker.com/engine/security/https/#client-modes) allows use of TLS without the server/daemon authenticating the client.

We've come across this situation in our use of the go-dockerclient API, so here's a proposed patch...
