### PR TITLE
Add ability to use registry token authentication

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -26,6 +26,7 @@ type AuthConfiguration struct {
 	Username      string `json:"username,omitempty"`
 	Password      string `json:"password,omitempty"`
 	Email         string `json:"email,omitempty"`
+	RegistryToken string `json:"registrytoken,omitempty"`
 	ServerAddress string `json:"serveraddress,omitempty"`
 }
 


### PR DESCRIPTION
Adds RegistryToken to AuthConfiguration struct to match docker/api/types.AuthConfig
Reference: https://godoc.org/github.com/docker/docker/api/types#AuthConfig 

This is useful when token authentication is configured on a private registry and want to connect using go-dockerclient.  Usage below:
```go
t := "jwt token"
err := docker.PushImage(docker.PushImageOptions{
  ...}, 
  docker.AuthConfiguration{RegistryToken: t}
);
```