### PR TITLE
fix error with unix socket not resolving on dial

### DIFF
--- a/client_unix.go
+++ b/client_unix.go
@@ -6,6 +6,7 @@
 package docker
 
 import (
+	"context"
 	"net"
 	"net/http"
 
@@ -20,7 +21,7 @@ func (c *Client) initializeNativeClient() {
 	}
 	socketPath := c.endpointURL.Path
 	tr := cleanhttp.DefaultTransport()
-	tr.Dial = func(network, addr string) (net.Conn, error) {
+	tr.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
 		return c.Dialer.Dial(unixProtocol, socketPath)
 	}
 	c.nativeHTTPClient = &http.Client{Transport: tr}


### PR DESCRIPTION
the first example of README fails with:

`panic: Get http://unix.sock/images/json?: dial tcp: lookup unix.sock on 127.0.1.1:53: no such host`

on a Ubuntu.

After investigations it appears the Dial attribute of the hashicorp cleanhttp.DefaultTransport() is deprecated. Using the new recommanded DialContext fixes the issue...