### PR TITLE
add support for cgroup parent on image build

### DIFF
--- a/image.go
+++ b/image.go
@@ -462,6 +462,7 @@ type BuildImageOptions struct {
 	BuildArgs           []BuildArg         `qs:"-"`
 	NetworkMode         string             `qs:"networkmode"`
 	InactivityTimeout   time.Duration      `qs:"-"`
+	CgroupParent        string             `qs:"cgroupparent"`
 	Context             context.Context
 }
 

--- a/image_test.go
+++ b/image_test.go
@@ -704,6 +704,7 @@ func TestBuildImageParameters(t *testing.T) {
 		OutputStream:        &buf,
 		Labels:              map[string]string{"k": "v"},
 		NetworkMode:         "host",
+		CgroupParent:        "cgparent",
 	}
 	err := client.BuildImage(opts)
 	if err != nil && !strings.Contains(err.Error(), "build image fail") {
@@ -711,22 +712,23 @@ func TestBuildImageParameters(t *testing.T) {
 	}
 	req := fakeRT.requests[0]
 	expected := map[string][]string{
-		"t":           {opts.Name},
-		"nocache":     {"1"},
-		"q":           {"1"},
-		"pull":        {"1"},
-		"rm":          {"1"},
-		"forcerm":     {"1"},
-		"memory":      {"1024"},
-		"memswap":     {"2048"},
-		"cpushares":   {"10"},
-		"cpuquota":    {"7500"},
-		"cpuperiod":   {"100000"},
-		"cpusetcpus":  {"0-3"},
-		"labels":      {`{"k":"v"}`},
-		"ulimits":     {`[{"Name":"nofile","Soft":100,"Hard":200}]`},
-		"buildargs":   {`{"SOME_VAR":"some_value"}`},
-		"networkmode": {"host"},
+		"t":            {opts.Name},
+		"nocache":      {"1"},
+		"q":            {"1"},
+		"pull":         {"1"},
+		"rm":           {"1"},
+		"forcerm":      {"1"},
+		"memory":       {"1024"},
+		"memswap":      {"2048"},
+		"cpushares":    {"10"},
+		"cpuquota":     {"7500"},
+		"cpuperiod":    {"100000"},
+		"cpusetcpus":   {"0-3"},
+		"labels":       {`{"k":"v"}`},
+		"ulimits":      {`[{"Name":"nofile","Soft":100,"Hard":200}]`},
+		"buildargs":    {`{"SOME_VAR":"some_value"}`},
+		"networkmode":  {"host"},
+		"cgroupparent": {"cgparent"},
 	}
 	got := map[string][]string(req.URL.Query())
 	if !reflect.DeepEqual(got, expected) {


### PR DESCRIPTION
the api does not appear to be documented but it's implemented here:
https://github.com/docker/docker/blob/master/api/server/router/build/build_routes.go#L53

and the docker-build cli tool leverages it.