### PR TITLE
support authentication when updating swarm mode service from private …

### DIFF
--- a/service.go
+++ b/service.go
@@ -91,6 +91,7 @@ func (c *Client) RemoveService(opts RemoveServiceOptions) error {
 //
 // See https://goo.gl/wu3MmS for more details.
 type UpdateServiceOptions struct {
+	Auth AuthConfiguration `qs:"-"`
 	swarm.ServiceSpec
 	Context context.Context
 	Version uint64
@@ -100,9 +101,14 @@ type UpdateServiceOptions struct {
 //
 // See https://goo.gl/wu3MmS for more details.
 func (c *Client) UpdateService(id string, opts UpdateServiceOptions) error {
+	headers, err := headersWithAuth(opts.Auth)
+	if err != nil {
+		return err
+	}
 	params := make(url.Values)
 	params.Set("version", strconv.FormatUint(opts.Version, 10))
 	resp, err := c.do("POST", "/services/"+id+"/update?"+params.Encode(), doOptions{
+		headers:   headers,
 		data:      opts.ServiceSpec,
 		forceJSON: true,
 		context:   opts.Context,

--- a/service_test.go
+++ b/service_test.go
@@ -173,6 +173,54 @@ func TestUpdateService(t *testing.T) {
 	}
 }
 
+func TestUpdateServiceWithAuthentication(t *testing.T) {
+	fakeRT := &FakeRoundTripper{message: "", status: http.StatusOK}
+	client := newTestClient(fakeRT)
+	id := "4fa6e0f0c6786287e131c3852c58a2e01cc697a68231826813597e4994f1d6e2"
+	update := UpdateServiceOptions{Version: 23}
+	update.Auth = AuthConfiguration{
+		Username: "gopher",
+		Password: "gopher123",
+		Email:    "gopher@tsuru.io",
+	}
+
+	err := client.UpdateService(id, update)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := fakeRT.requests[0]
+	if req.Method != "POST" {
+		t.Errorf("UpdateService: wrong HTTP method. Want %q. Got %q.", "POST", req.Method)
+	}
+	expectedURL, _ := url.Parse(client.getURL("/services/" + id + "/update?version=23"))
+	if gotURI := req.URL.RequestURI(); gotURI != expectedURL.RequestURI() {
+		t.Errorf("UpdateService: Wrong path in request. Want %q. Got %q.", expectedURL.RequestURI(), gotURI)
+	}
+	expectedContentType := "application/json"
+	if contentType := req.Header.Get("Content-Type"); contentType != expectedContentType {
+		t.Errorf("UpdateService: Wrong content-type in request. Want %q. Got %q.", expectedContentType, contentType)
+	}
+	var out UpdateServiceOptions
+	if err := json.NewDecoder(req.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+	var updateAuth AuthConfiguration
+
+	auth, err := base64.URLEncoding.DecodeString(req.Header.Get("X-Registry-Auth"))
+	if err != nil {
+		t.Errorf("UpdateService: caught error decoding auth. %#v", err.Error())
+	}
+
+	err = json.Unmarshal(auth, &updateAuth)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(updateAuth, update.Auth) {
+		t.Errorf("UpdateService: wrong auth configuration. Want %#v. Got %#v", update.Auth, updateAuth)
+	}
+}
+
 func TestUpdateServiceNotFound(t *testing.T) {
 	client := newTestClient(&FakeRoundTripper{message: "no such service", status: http.StatusNotFound})
 	update := UpdateServiceOptions{}


### PR DESCRIPTION
…registries.

We need to support registry authentication in service update, too, otherwise pulling images from a private registry during an update won't work.