### PR TITLE
update ExecInspect to engine api v1.23

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -174,7 +174,9 @@ type ExecInspect struct {
 	OpenStderr    bool              `json:"OpenStderr,omitempty" yaml:"OpenStderr,omitempty" toml:"OpenStderr,omitempty"`
 	OpenStdout    bool              `json:"OpenStdout,omitempty" yaml:"OpenStdout,omitempty" toml:"OpenStdout,omitempty"`
 	ProcessConfig ExecProcessConfig `json:"ProcessConfig,omitempty" yaml:"ProcessConfig,omitempty" toml:"ProcessConfig,omitempty"`
-	Container     Container         `json:"Container,omitempty" yaml:"Container,omitempty" toml:"Container,omitempty"`
+	ContainerID   string            `json:"ContainerID,omitempty" yaml:"ContainerID,omitempty" toml:"ContainerID,omitempty"`
+	DetachKeys    string            `json:"DetachKeys,omitempty" yaml:"DetachKeys,omitempty" toml:"DetachKeys,omitempty"`
+	CanRemove     bool              `json:"CanRemove,omitempty" yaml:"CanRemove,omitempty" toml:"CanRemove,omitempty"`
 }
 
 // InspectExec returns low-level information about the exec command id.

--- a/exec_test.go
+++ b/exec_test.go
@@ -133,108 +133,25 @@ func TestExecResize(t *testing.T) {
 
 func TestExecInspect(t *testing.T) {
 	jsonExec := `{
-	  "ID": "32adfeeec34250f9530ce1dafd40c6233832315e065ea6b362d745e2f63cde0e",
-	  "Running": true,
-	  "ExitCode": 0,
-	  "ProcessConfig": {
-	    "privileged": false,
-	    "user": "",
-	    "tty": true,
-	    "entrypoint": "bash",
-	    "arguments": []
-	  },
-	  "OpenStdin": true,
+	  "CanRemove": false,
+	  "ContainerID": "b53ee82b53a40c7dca428523e34f741f3abc51d9f297a14ff874bf761b995126",
+	  "DetachKeys": "",
+	  "ExitCode": 2,
+	  "ID": "f33bbfb39f5b142420f4759b2348913bd4a8d1a6d7fd56499cb41a1bb91d7b3b",
 	  "OpenStderr": true,
+	  "OpenStdin": true,
 	  "OpenStdout": true,
-	  "Container": {
-	    "State": {
-	      "Running": true,
-	      "Paused": false,
-	      "Restarting": false,
-	      "OOMKilled": false,
-	      "Pid": 29392,
-	      "ExitCode": 0,
-	      "Error": "",
-	      "StartedAt": "2015-01-21T17:08:59.634662178Z",
-	      "FinishedAt": "0001-01-01T00:00:00Z"
-	    },
-	    "ID": "922cd0568714763dc725b24b7c9801016b2a3de68e2a1dc989bf5abf07740521",
-	    "Created": "2015-01-21T17:08:59.46407212Z",
-	    "Path": "/bin/bash",
-	    "Args": [
-	      "-lc",
-	      "tsuru_unit_agent http://192.168.50.4:8080 689b30e0ab3adce374346de2e72512138e0e8b75 gtest /var/lib/tsuru/start && tail -f /dev/null"
+	  "ProcessConfig": {
+	    "arguments": [
+	      "-c",
+	      "exit 2"
 	    ],
-	    "Config": {
-	      "Hostname": "922cd0568714",
-	      "Domainname": "",
-	      "User": "ubuntu",
-	      "Memory": 0,
-	      "MemorySwap": 0,
-	      "CpuShares": 100,
-	      "Cpuset": "",
-	      "AttachStdin": false,
-	      "AttachStdout": false,
-	      "AttachStderr": false,
-	      "PortSpecs": null,
-	      "ExposedPorts": {
-	        "8888/tcp": {}
-	      },
-	      "Tty": false,
-	      "OpenStdin": false,
-	      "StdinOnce": false,
-	      "Env": [
-	        "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-	      ],
-	      "Cmd": [
-	        "/bin/bash",
-	        "-lc",
-	        "tsuru_unit_agent http://192.168.50.4:8080 689b30e0ab3adce374346de2e72512138e0e8b75 gtest /var/lib/tsuru/start && tail -f /dev/null"
-	      ],
-	      "Image": "tsuru/app-gtest",
-	      "Volumes": null,
-	      "WorkingDir": "",
-	      "Entrypoint": null,
-	      "NetworkDisabled": false,
-	      "MacAddress": "",
-	      "OnBuild": null
-	    },
-	    "Image": "a88060b8b54fde0f7168c86742d0ce83b80f3f10925d85c98fdad9ed00bef544",
-	    "NetworkSettings": {
-	      "IPAddress": "172.17.0.8",
-	      "IPPrefixLen": 16,
-	      "MacAddress": "02:42:ac:11:00:08",
-	      "LinkLocalIPv6Address": "fe80::42:acff:fe11:8",
-	      "LinkLocalIPv6PrefixLen": 64,
-	      "GlobalIPv6Address": "",
-	      "GlobalIPv6PrefixLen": 0,
-	      "Gateway": "172.17.42.1",
-	      "IPv6Gateway": "",
-	      "Bridge": "docker0",
-	      "PortMapping": null,
-	      "Ports": {
-	        "8888/tcp": [
-	          {
-	            "HostIp": "0.0.0.0",
-	            "HostPort": "49156"
-	          }
-	        ]
-	      }
-	    },
-	    "ResolvConfPath": "/var/lib/docker/containers/922cd0568714763dc725b24b7c9801016b2a3de68e2a1dc989bf5abf07740521/resolv.conf",
-	    "HostnamePath": "/var/lib/docker/containers/922cd0568714763dc725b24b7c9801016b2a3de68e2a1dc989bf5abf07740521/hostname",
-	    "HostsPath": "/var/lib/docker/containers/922cd0568714763dc725b24b7c9801016b2a3de68e2a1dc989bf5abf07740521/hosts",
-	    "Name": "/c7e43b72288ee9d0270a",
-	    "Driver": "aufs",
-	    "ExecDriver": "native-0.2",
-	    "MountLabel": "",
-	    "ProcessLabel": "",
-	    "AppArmorProfile": "",
-	    "RestartCount": 0,
-	    "UpdateDns": false,
-	    "Volumes": {},
-	    "VolumesRW": {}
-	  }
+	    "entrypoint": "sh",
+	    "privileged": false,
+	    "tty": true,
+	    "user": "1000"
+	  },
+	  "Running": false
 	}`
 	var expected ExecInspect
 	err := json.Unmarshal([]byte(jsonExec), &expected)
@@ -243,7 +160,7 @@ func TestExecInspect(t *testing.T) {
 	}
 	fakeRT := &FakeRoundTripper{message: jsonExec, status: http.StatusOK}
 	client := newTestClient(fakeRT)
-	expectedID := "32adfeeec34250f9530ce1dafd40c6233832315e065ea6b362d745e2f63cde0e"
+	expectedID := "b53ee82b53a40c7dca428523e34f741f3abc51d9f297a14ff874bf761b995126"
 	execObj, err := client.InspectExec(expectedID)
 	if err != nil {
 		t.Fatal(err)

--- a/testing/server.go
+++ b/testing/server.go
@@ -1136,8 +1136,8 @@ func (s *DockerServer) createExecContainer(w http.ResponseWriter, r *http.Reques
 	container.ExecIDs = append(container.ExecIDs, execID)
 
 	exec := docker.ExecInspect{
-		ID:        execID,
-		Container: *container,
+		ID:          execID,
+		ContainerID: container.ID,
 	}
 
 	var params docker.CreateExecOptions

--- a/testing/server_test.go
+++ b/testing/server_test.go
@@ -1656,7 +1656,7 @@ func TestCreateExecContainer(t *testing.T) {
 			EntryPoint: "bash",
 			Arguments:  []string{"-c", "ls"},
 		},
-		Container: *server.containers[0],
+		ContainerID: server.containers[0].ID,
 	}
 
 	if !reflect.DeepEqual(*serverExec, expected) {
@@ -1698,14 +1698,8 @@ func TestInspectExecContainer(t *testing.T) {
 			EntryPoint: "bash",
 			Arguments:  []string{"-c", "ls"},
 		},
-		Container: *server.containers[0],
+		ContainerID: server.containers[0].ID,
 	}
-	got2.Container.State.StartedAt = expected.Container.State.StartedAt
-	got2.Container.State.FinishedAt = expected.Container.State.FinishedAt
-	got2.Container.Config = expected.Container.Config
-	got2.Container.Created = expected.Container.Created
-	got2.Container.NetworkSettings = expected.Container.NetworkSettings
-	got2.Container.ExecIDs = expected.Container.ExecIDs
 
 	if !reflect.DeepEqual(got2, expected) {
 		t.Errorf("InspectContainer: wrong value. Want:\n%#v\nGot:\n%#v\n", expected, got2)


### PR DESCRIPTION
Since v1.22, the exec inspect api returns only the container id rather than the complete contianer info. I changed `ExecInspect` to match the v1.23 [documentation](https://docs.docker.com/engine/api/v1.23)