### PR TITLE
Supports cachefrom build option from api 1.25

### DIFF
--- a/build_test.go
+++ b/build_test.go
@@ -24,6 +24,7 @@ func TestBuildImageMultipleContextsError(t *testing.T) {
 	opts := BuildImageOptions{
 		Name:                "testImage",
 		NoCache:             true,
+		CacheFrom:           []string{"a", "b", "c"},
 		SuppressOutput:      true,
 		RmTmpContainer:      true,
 		ForceRmTmpContainer: true,
@@ -55,6 +56,7 @@ func TestBuildImageContextDirDockerignoreParsing(t *testing.T) {
 	opts := BuildImageOptions{
 		Name:                "testImage",
 		NoCache:             true,
+		CacheFrom:           []string{"a", "b", "c"},
 		SuppressOutput:      true,
 		RmTmpContainer:      true,
 		ForceRmTmpContainer: true,

--- a/client.go
+++ b/client.go
@@ -58,6 +58,7 @@ var (
 	apiVersion112, _ = NewAPIVersion("1.12")
 	apiVersion119, _ = NewAPIVersion("1.19")
 	apiVersion124, _ = NewAPIVersion("1.24")
+	apiVersion125, _ = NewAPIVersion("1.25")
 )
 
 // APIVersion is an internal representation of a version of the Remote API.

--- a/image.go
+++ b/image.go
@@ -440,7 +440,7 @@ type BuildImageOptions struct {
 	Name                string             `qs:"t"`
 	Dockerfile          string             `qs:"dockerfile"`
 	NoCache             bool               `qs:"nocache"`
-	CacheFrom           []string           `qs:"cachefrom"`
+	CacheFrom           []string           `qs:"-"`
 	SuppressOutput      bool               `qs:"q"`
 	Pull                bool               `qs:"pull"`
 	RmTmpContainer      bool               `qs:"rm"`
@@ -507,12 +507,10 @@ func (c *Client) BuildImage(opts BuildImageOptions) error {
 			return err
 		}
 	}
-	cacheFrom := opts.CacheFrom
-	opts.CacheFrom = nil
 	qs := queryString(&opts)
 
-	if c.serverAPIVersion.GreaterThanOrEqualTo(apiVersion125) && len(cacheFrom) > 0 {
-		if b, err := json.Marshal(cacheFrom); err == nil {
+	if c.serverAPIVersion.GreaterThanOrEqualTo(apiVersion125) && len(opts.CacheFrom) > 0 {
+		if b, err := json.Marshal(opts.CacheFrom); err == nil {
 			item := url.Values(map[string][]string{})
 			item.Add("cachefrom", string(b))
 			qs = fmt.Sprintf("%s&%s", qs, item.Encode())

--- a/image.go
+++ b/image.go
@@ -537,7 +537,6 @@ func (c *Client) BuildImage(opts BuildImageOptions) error {
 		}
 	}
 
-	fmt.Println(qs)
 	return c.stream("POST", fmt.Sprintf("/build?%s", qs), streamOptions{
 		setRawTerminal:    true,
 		rawJSONStream:     opts.RawJSONStream,

--- a/image_test.go
+++ b/image_test.go
@@ -688,6 +688,7 @@ func TestBuildImageParameters(t *testing.T) {
 	opts := BuildImageOptions{
 		Name:                "testImage",
 		NoCache:             true,
+		CacheFrom:           []string{"test1", "test2"},
 		SuppressOutput:      true,
 		Pull:                true,
 		RmTmpContainer:      true,


### PR DESCRIPTION
cachefrom support. See https://docs.docker.com/engine/api/v1.25/

Usefull if you want to use cache on a docker that is not persisting cache on local FS (i.e a docker running in a container)