### PR TITLE
Include on Docker Inspect: Container network aliases

### DIFF
--- a/container.go
+++ b/container.go
@@ -214,15 +214,16 @@ type PortMapping map[string]string
 
 // ContainerNetwork represents the networking settings of a container per network.
 type ContainerNetwork struct {
-	MacAddress          string `json:"MacAddress,omitempty" yaml:"MacAddress,omitempty" toml:"MacAddress,omitempty"`
-	GlobalIPv6PrefixLen int    `json:"GlobalIPv6PrefixLen,omitempty" yaml:"GlobalIPv6PrefixLen,omitempty" toml:"GlobalIPv6PrefixLen,omitempty"`
-	GlobalIPv6Address   string `json:"GlobalIPv6Address,omitempty" yaml:"GlobalIPv6Address,omitempty" toml:"GlobalIPv6Address,omitempty"`
-	IPv6Gateway         string `json:"IPv6Gateway,omitempty" yaml:"IPv6Gateway,omitempty" toml:"IPv6Gateway,omitempty"`
-	IPPrefixLen         int    `json:"IPPrefixLen,omitempty" yaml:"IPPrefixLen,omitempty" toml:"IPPrefixLen,omitempty"`
-	IPAddress           string `json:"IPAddress,omitempty" yaml:"IPAddress,omitempty" toml:"IPAddress,omitempty"`
-	Gateway             string `json:"Gateway,omitempty" yaml:"Gateway,omitempty" toml:"Gateway,omitempty"`
-	EndpointID          string `json:"EndpointID,omitempty" yaml:"EndpointID,omitempty" toml:"EndpointID,omitempty"`
-	NetworkID           string `json:"NetworkID,omitempty" yaml:"NetworkID,omitempty" toml:"NetworkID,omitempty"`
+	Aliases             []string `json:"Aliases,omitempty" yaml:"Aliases,omitempty" toml:"Aliases,omitempty"`
+	MacAddress          string   `json:"MacAddress,omitempty" yaml:"MacAddress,omitempty" toml:"MacAddress,omitempty"`
+	GlobalIPv6PrefixLen int      `json:"GlobalIPv6PrefixLen,omitempty" yaml:"GlobalIPv6PrefixLen,omitempty" toml:"GlobalIPv6PrefixLen,omitempty"`
+	GlobalIPv6Address   string   `json:"GlobalIPv6Address,omitempty" yaml:"GlobalIPv6Address,omitempty" toml:"GlobalIPv6Address,omitempty"`
+	IPv6Gateway         string   `json:"IPv6Gateway,omitempty" yaml:"IPv6Gateway,omitempty" toml:"IPv6Gateway,omitempty"`
+	IPPrefixLen         int      `json:"IPPrefixLen,omitempty" yaml:"IPPrefixLen,omitempty" toml:"IPPrefixLen,omitempty"`
+	IPAddress           string   `json:"IPAddress,omitempty" yaml:"IPAddress,omitempty" toml:"IPAddress,omitempty"`
+	Gateway             string   `json:"Gateway,omitempty" yaml:"Gateway,omitempty" toml:"Gateway,omitempty"`
+	EndpointID          string   `json:"EndpointID,omitempty" yaml:"EndpointID,omitempty" toml:"EndpointID,omitempty"`
+	NetworkID           string   `json:"NetworkID,omitempty" yaml:"NetworkID,omitempty" toml:"NetworkID,omitempty"`
 }
 
 // NetworkSettings contains network-related information about a container

--- a/container_test.go
+++ b/container_test.go
@@ -629,8 +629,8 @@ func TestInspectContainerNetwork(t *testing.T) {
 	id := "81e1bbe20b55"
 	expIP := "10.0.0.3"
 	expNetworkID := "7ea29fc1412292a2d7bba362f9253545fecdfa8ce9a6e37dd10ba8bee7129812"
-	expAlias0 = "testalias"
-	expAlias1 = "81e1bbe20b55"
+	expAlias0 := "testalias"
+	expAlias1 := "81e1bbe20b55"
 
 	container, err := client.InspectContainer(id)
 	if err != nil {

--- a/container_test.go
+++ b/container_test.go
@@ -629,8 +629,7 @@ func TestInspectContainerNetwork(t *testing.T) {
 	id := "81e1bbe20b55"
 	expIP := "10.0.0.3"
 	expNetworkID := "7ea29fc1412292a2d7bba362f9253545fecdfa8ce9a6e37dd10ba8bee7129812"
-	expAlias0 := "testalias"
-	expAlias1 := "81e1bbe20b55"
+	expectedAliases := []string{"testalias", "81e1bbe20b55"}
 
 	container, err := client.InspectContainer(id)
 	if err != nil {
@@ -665,8 +664,8 @@ func TestInspectContainerNetwork(t *testing.T) {
 				aliases = networks.MapIndex(net).FieldByName("Aliases").Interface().([]string)
 			}
 		}
-		if aliases[0] != expAlias0 || aliases[1] != expAlias1 {
-			t.Errorf("InspectContainerNetworks(%q): Expected Alias0 %s. Got %s, Alias1 %s. Got %s", id, expAlias0, aliases[0], expAlias1, aliases[1])
+		if !reflect.DeepEqual(aliases, expectedAliases) {
+			t.Errorf("InspectContainerNetworks(%q): Expected Aliases %#v. Got %#v.", id, expectedAliases, aliases)
 		}
 
 		if networkID != expNetworkID {

--- a/container_test.go
+++ b/container_test.go
@@ -606,6 +606,10 @@ func TestInspectContainerNetwork(t *testing.T) {
                 "MacAddress": "",
                 "Networks": {
                     "swl-net": {
+						"Aliases": [
+							"testalias",
+							"81e1bbe20b55"
+						],
                         "NetworkID": "7ea29fc1412292a2d7bba362f9253545fecdfa8ce9a6e37dd10ba8bee7129812",
                         "EndpointID": "683e3092275782a53c3b0968cc7e3a10f23264022ded9cb20490902f96fc5981",
                         "Gateway": "",
@@ -625,6 +629,8 @@ func TestInspectContainerNetwork(t *testing.T) {
 	id := "81e1bbe20b55"
 	expIP := "10.0.0.3"
 	expNetworkID := "7ea29fc1412292a2d7bba362f9253545fecdfa8ce9a6e37dd10ba8bee7129812"
+	expAlias0 = "testalias"
+	expAlias1 = "81e1bbe20b55"
 
 	container, err := client.InspectContainer(id)
 	if err != nil {
@@ -652,6 +658,17 @@ func TestInspectContainerNetwork(t *testing.T) {
 				t.Logf("%s %v", net, networkID)
 			}
 		}
+
+		var aliases []string
+		for _, net := range networks.MapKeys() {
+			if net.Interface().(string) == container.HostConfig.NetworkMode {
+				aliases = networks.MapIndex(net).FieldByName("Aliases").Interface().([]string)
+			}
+		}
+		if aliases[0] != expAlias0 || aliases[1] != expAlias1 {
+			t.Errorf("InspectContainerNetworks(%q): Expected Alias0 %s. Got %s, Alias1 %s. Got %s", id, expAlias0, aliases[0], expAlias1, aliases[1])
+		}
+
 		if networkID != expNetworkID {
 			t.Errorf("InspectContainerNetworks(%q): Expected %#v. Got %#v.", id, expNetworkID, networkID)
 		}


### PR DESCRIPTION
When doing docker inspect, there is a Aliases information on NetworkSettings.Networks, this is a valueable information that can be used. This should be supported for API 1.23 above.

Example output JSON from Docker inspect:

```
"someusernetwork": {
     "IPAMConfig": null,
     "Links": null,
     "Aliases": [
         "web01",
         "dfcfa712b3a9"
     ],
     "NetworkID": "751d96e988b498284bd1ddf940295787691afdcc73dc8c63bbbca5dda2a31752",
     "EndpointID": "4610d818cf63b73237d411e43a8d4a79ca9df8f1dae9a271daf0623c4f3c78e7",
     "Gateway": "172.18.0.1",
     "IPAddress": "172.18.0.2",
     "IPPrefixLen": 16,
     "IPv6Gateway": "",
     "GlobalIPv6Address": "",
     "GlobalIPv6PrefixLen": 0,
     "MacAddress": "02:42:ac:12:00:02"
 }
```