### PR TITLE
Env create exec option

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -6,6 +6,7 @@ package docker
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -42,6 +43,9 @@ type CreateExecOptions struct {
 //
 // See https://goo.gl/60TeBP for more details
 func (c *Client) CreateExec(opts CreateExecOptions) (*Exec, error) {
+	if len(opts.Env) > 0 && c.serverAPIVersion.LessThan(apiVersion125) {
+		return nil, errors.New("exec configuration Env is only supported in API#1.25 and above")
+	}
 	path := fmt.Sprintf("/containers/%s/exec", opts.Container)
 	resp, err := c.do("POST", path, doOptions{data: opts, context: opts.Context})
 	if err != nil {

--- a/exec.go
+++ b/exec.go
@@ -29,6 +29,7 @@ type CreateExecOptions struct {
 	AttachStdout bool            `json:"AttachStdout,omitempty" yaml:"AttachStdout,omitempty" toml:"AttachStdout,omitempty"`
 	AttachStderr bool            `json:"AttachStderr,omitempty" yaml:"AttachStderr,omitempty" toml:"AttachStderr,omitempty"`
 	Tty          bool            `json:"Tty,omitempty" yaml:"Tty,omitempty" toml:"Tty,omitempty"`
+	Env          []string        `json:"Env,omitempty" yaml:"Env,omitempty" toml:"Env,omitempty"`
 	Cmd          []string        `json:"Cmd,omitempty" yaml:"Cmd,omitempty" toml:"Cmd,omitempty"`
 	Container    string          `json:"Container,omitempty" yaml:"Container,omitempty" toml:"Container,omitempty"`
 	User         string          `json:"User,omitempty" yaml:"User,omitempty" toml:"User,omitempty"`


### PR DESCRIPTION
Currently CreateExecOption doesn't support adding environmental variables that is supported in api ver 1.25. This pull request is to add support for the Env configuration for Exec. Error handling has been added to notify <1.25 api users that Env is not supported for CreateExecOption.