### PR TITLE
Switch TaskSpec to use pointers for ContainerSpec so tests build successfully.

### DIFF
--- a/testing/swarm_test.go
+++ b/testing/swarm_test.go
@@ -190,7 +190,7 @@ func TestSwarmJoinWithService(t *testing.T) {
 	serviceCreateOpts := docker.CreateServiceOptions{
 		ServiceSpec: swarm.ServiceSpec{
 			TaskTemplate: swarm.TaskSpec{
-				ContainerSpec: swarm.ContainerSpec{
+				ContainerSpec: &swarm.ContainerSpec{
 					Image: "test/test",
 				},
 			},
@@ -341,7 +341,7 @@ func TestServiceCreate(t *testing.T) {
 				Name: "test",
 			},
 			TaskTemplate: swarm.TaskSpec{
-				ContainerSpec: swarm.ContainerSpec{
+				ContainerSpec: &swarm.ContainerSpec{
 					Image:   "test/test",
 					Command: []string{"sh"},
 					Args:    []string{"--test"},
@@ -437,7 +437,7 @@ func TestServiceCreateDynamicPort(t *testing.T) {
 				Name: "test",
 			},
 			TaskTemplate: swarm.TaskSpec{
-				ContainerSpec: swarm.ContainerSpec{
+				ContainerSpec: &swarm.ContainerSpec{
 					Image:   "test/test",
 					Command: []string{"sh"},
 					Args:    []string{"--test"},
@@ -993,7 +993,7 @@ func TestServiceUpdate(t *testing.T) {
 			Name: "test",
 		},
 		TaskTemplate: swarm.TaskSpec{
-			ContainerSpec: swarm.ContainerSpec{
+			ContainerSpec: &swarm.ContainerSpec{
 				Image: "test/test2",
 				Args:  []string{"--test2"},
 				Env:   []string{"ENV=2"},
@@ -1088,7 +1088,7 @@ func TestServiceUpdateMoreReplicas(t *testing.T) {
 			Name: "test",
 		},
 		TaskTemplate: swarm.TaskSpec{
-			ContainerSpec: swarm.ContainerSpec{
+			ContainerSpec: &swarm.ContainerSpec{
 				Image: "test/test2",
 				Args:  []string{"--test2"},
 				Env:   []string{"ENV=2"},
@@ -1133,7 +1133,7 @@ func TestServiceUpdateNotFound(t *testing.T) {
 			Name: "test",
 		},
 		TaskTemplate: swarm.TaskSpec{
-			ContainerSpec: swarm.ContainerSpec{
+			ContainerSpec: &swarm.ContainerSpec{
 				Image: "test/test2",
 				Args:  []string{"--test2"},
 				Env:   []string{"ENV=2"},
@@ -1297,7 +1297,7 @@ func addTestService(server *DockerServer) (*swarm.Service, error) {
 				},
 			},
 			TaskTemplate: swarm.TaskSpec{
-				ContainerSpec: swarm.ContainerSpec{
+				ContainerSpec: &swarm.ContainerSpec{
 					Image: "test/test",
 					Args:  []string{"--test"},
 					Env:   []string{"ENV=1"},


### PR DESCRIPTION
The build for tests has been failing since this PR was merged into the Moby repo. https://github.com/moby/moby/pull/33575.

This fixes the issue, however I'm still having a few tests failing to run locally.
```
--- FAIL: TestClientStreamInactivityTimeout (2.52s)
	client_test.go:511: expected request canceled error, got: %!s(<nil>)
--- FAIL: TestClientStreamContextDeadline (0.51s)
	client_test.go:545: expected context deadline exceeded, got: %!s(<nil>)
--- FAIL: TestClientStreamContextCancel (0.50s)
	client_test.go:582: expected context canceled, got: %!s(<nil>)
```

I'm looking into those next.