### PR TITLE
testing: properly remove volume from map

### DIFF
--- a/testing/server.go
+++ b/testing/server.go
@@ -1411,7 +1411,7 @@ func (s *DockerServer) removeVolume(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "volume in use and cannot be removed", http.StatusConflict)
 		return
 	}
-	s.volStore[vol.volume.Name] = nil
+	delete(s.volStore, vol.volume.Name)
 	w.WriteHeader(http.StatusNoContent)
 }
 


### PR DESCRIPTION
Listing the volumes after removing a volume would result in the following panic:

```
2017/07/26 15:33:42 http: panic serving 127.0.0.1:64777: runtime error: invalid memory address or nil pointer dereference
goroutine 5463 [running]:
net/http.(*conn).serve.func1(0xc422b4e5a0)
	/usr/local/Cellar/go/1.8.3/libexec/src/net/http/server.go:1721 +0xd0
panic(0x164f0c0, 0x1a0d0d0)
	/usr/local/Cellar/go/1.8.3/libexec/src/runtime/panic.go:489 +0x2cf
github.com/tsuru/tsuru/vendor/github.com/fsouza/go-dockerclient/testing.(*DockerServer).listVolumes(0xc423131400, 0x19e42e0, 0xc4200ae700, 0xc422802600)
	/Users/andre.carvalho/projects/src/github.com/tsuru/tsuru/vendor/github.com/fsouza/go-dockerclient/testing/server.go:1326 +0x135
github.com/tsuru/tsuru/vendor/github.com/fsouza/go-dockerclient/testing.(*DockerServer).(github.com/tsuru/tsuru/vendor/github.com/fsouza/go-dockerclient/testing.listVolumes)-fm(0x19e42e0, 0xc4200ae700, 0xc422802600)
	/Users/andre.carvalho/projects/src/github.com/tsuru/tsuru/vendor/github.com/fsouza/go-dockerclient/testing/server.go:199 +0x48
github.com/tsuru/tsuru/vendor/github.com/fsouza/go-dockerclient/testing.(*DockerServer).handlerWrapper.func1(0x19e42e0, 0xc4200ae700, 0xc422802600)
	/Users/andre.carvalho/projects/src/github.com/tsuru/tsuru/vendor/github.com/fsouza/go-dockerclient/testing/server.go:378 +0x252
net/http.HandlerFunc.ServeHTTP(0xc423082cc0, 0x19e42e0, 0xc4200ae700, 0xc422802600)
	/usr/local/Cellar/go/1.8.3/libexec/src/net/http/server.go:1942 +0x44
github.com/tsuru/tsuru/vendor/github.com/gorilla/mux.(*Router).ServeHTTP(0xc420819e50, 0x19e42e0, 0xc4200ae700, 0xc422802600)
	/Users/andre.carvalho/projects/src/github.com/tsuru/tsuru/vendor/github.com/gorilla/mux/mux.go:114 +0x10c
github.com/tsuru/tsuru/vendor/github.com/fsouza/go-dockerclient/testing.(*DockerServer).ServeHTTP(0xc423131400, 0x19e42e0, 0xc4200ae700, 0xc422802100)
	/Users/andre.carvalho/projects/src/github.com/tsuru/tsuru/vendor/github.com/fsouza/go-dockerclient/testing/server.go:339 +0x186
net/http.serverHandler.ServeHTTP(0xc423eeebb0, 0x19e42e0, 0xc4200ae700, 0xc422802100)
	/usr/local/Cellar/go/1.8.3/libexec/src/net/http/server.go:2568 +0x92
net/http.(*conn).serve(0xc422b4e5a0, 0x19e4de0, 0xc422f8b500)
	/usr/local/Cellar/go/1.8.3/libexec/src/net/http/server.go:1825 +0x612
created by net/http.(*Server).Serve
	/usr/local/Cellar/go/1.8.3/libexec/src/net/http/server.go:2668 +0x2ce
```

This prevents this by removing the entry from the map instead of assigning it to nil.