### PR TITLE
container: add Init to HostConfig struct

### DIFF
--- a/container.go
+++ b/container.go
@@ -778,6 +778,7 @@ type HostConfig struct {
 	IOMaximumBandwidth   int64                  `json:"IOMaximumBandwidth,omitempty" yaml:"IOMaximumBandwidth,omitempty"`
 	IOMaximumIOps        int64                  `json:"IOMaximumIOps,omitempty" yaml:"IOMaximumIOps,omitempty"`
 	Mounts               []HostMount            `json:"Mounts,omitempty" yaml:"Mounts,omitempty" toml:"Mounts,omitempty"`
+	Init                 bool                   `json:",omitempty" yaml:",omitempty"`
 }
 
 // NetworkingConfig represents the container's networking configuration for each of its interfaces


### PR DESCRIPTION
### Summary
* add Init to HostConfig struct

### Testing Done
- [X] `make test` passed 
```
$ make test 
go get -d -t ./...
[ -z "$(golint . | grep -v 'type name will be used as docker.DockerInfo' | grep -v 'context.Context should be the first' | tee /dev/stderr)" ]
go vet ./...
[ -z "$(gofmt -s -d . | tee /dev/stderr)" ]
go test  ./...
ok      github.com/fsouza/go-dockerclient       2.553s
ok      github.com/fsouza/go-dockerclient/testing       0.776s
```
- [X] Manual Test: Started a container with `Init=true` and verified that docker started an `init` process for the same. Example code:
```go
package main

import (
	"fmt"

	docker "github.com/fsouza/go-dockerclient"
)

func main() {
	endpoint := "unix:///var/run/docker.sock"
	client, err := docker.NewClient(endpoint)
	if err != nil {
		panic(err)
	}

	createContConf := docker.Config{
		Image: "busybox",
		Cmd:   []string{"sh", "-c", "sleep 300"},
	}

	createContHostConfig := docker.HostConfig{
		Privileged: false,
		Init: true,
	}

	createContOps := docker.CreateContainerOptions{
		Name:       "busybox",
		Config:     &createContConf,
		HostConfig: &createContHostConfig,
	}

	fmt.Printf("\nops = %v\n", createContOps)

	cont, err := client.CreateContainer(createContOps)
	if err != nil {
		fmt.Printf("create error = %v\n", err)
	}
	fmt.Printf("container = %v\n", cont)

	err = client.StartContainer(cont.ID, nil)
	if err != nil {
		fmt.Printf("start error = %v\n", err)
	}
	fmt.Printf("start = %v\n", err)
}
```
Output:
```
$  docker inspect --format '{{json .HostConfig.Init}}'  busybox
true
```