### PR TITLE
Fix .Map panic on environment variable missing value

### DIFF
--- a/env.go
+++ b/env.go
@@ -162,7 +162,11 @@ func (env *Env) Map() map[string]string {
 	m := make(map[string]string)
 	for _, kv := range *env {
 		parts := strings.SplitN(kv, "=", 2)
-		m[parts[0]] = parts[1]
+		if len(parts) == 1 {
+			m[parts[0]] = ""
+		} else {
+			m[parts[0]] = parts[1]
+		}
 	}
 	return m
 }

--- a/env_test.go
+++ b/env_test.go
@@ -351,6 +351,7 @@ func TestMap(t *testing.T) {
 		expected map[string]string
 	}{
 		{[]string{"PATH=/usr/bin:/bin", "PYTHONPATH=/usr/local"}, map[string]string{"PATH": "/usr/bin:/bin", "PYTHONPATH": "/usr/local"}},
+		{[]string{"ENABLE_LOGGING", "PYTHONPATH=/usr/local"}, map[string]string{"ENABLE_LOGGING": "", "PYTHONPATH": "/usr/local"}},
 		{nil, nil},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
### Problem

Recently attempted to use https://github.com/swipely/iam-docker which has your library as a dep. We use `docker-cloud` for scheduling and provisioning out containers and one of the `weave` containers has an env var that has no value:

`WEAVE_HTTP_ADDR`

This ends up causing a panic in the current `.Map` implementation as it's always expecting and env var to be in the format `NAME=VALUE`.

### Solution

* Check the length of the exploded parts, if there's only one then just set the maps value for that key to an empty string.