### PR TITLE
export NativeHTTPClient on docker.Client struct

### DIFF
--- a/client.go
+++ b/client.go
@@ -151,7 +151,7 @@ type Client struct {
 	requestedAPIVersion APIVersion
 	serverAPIVersion    APIVersion
 	expectedAPIVersion  APIVersion
-	nativeHTTPClient    *http.Client
+	NativeHTTPClient    *http.Client
 }
 
 // Dialer is an interface that allows network connections to be dialed
@@ -345,14 +345,14 @@ func NewVersionedTLSClientFromBytes(endpoint string, certPEMBlock, keyPEMBlock, 
 }
 
 // SetTimeout takes a timeout and applies it to both the HTTPClient and
-// nativeHTTPClient. It should not be called concurrently with any other Client
+// NativeHTTPClient. It should not be called concurrently with any other Client
 // methods.
 func (c *Client) SetTimeout(t time.Duration) {
 	if c.HTTPClient != nil {
 		c.HTTPClient.Timeout = t
 	}
-	if c.nativeHTTPClient != nil {
-		c.nativeHTTPClient.Timeout = t
+	if c.NativeHTTPClient != nil {
+		c.NativeHTTPClient.Timeout = t
 	}
 }
 
@@ -450,7 +450,7 @@ func (c *Client) do(method, path string, doOptions doOptions) (*http.Response, e
 	var u string
 	switch protocol {
 	case unixProtocol, namedPipeProtocol:
-		httpClient = c.nativeHTTPClient
+		httpClient = c.NativeHTTPClient
 		u = c.getFakeNativeURL(path)
 	default:
 		u = c.getURL(path)

--- a/client_unix.go
+++ b/client_unix.go
@@ -26,5 +26,5 @@ func (c *Client) initializeNativeClient() {
 	tr.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
 		return c.Dialer.Dial(unixProtocol, socketPath)
 	}
-	c.nativeHTTPClient = &http.Client{Transport: tr}
+	c.NativeHTTPClient = &http.Client{Transport: tr}
 }

--- a/client_windows.go
+++ b/client_windows.go
@@ -41,5 +41,5 @@ func (c *Client) initializeNativeClient() {
 		return dialFunc(network, addr)
 	}
 	c.Dialer = &pipeDialer{dialFunc}
-	c.nativeHTTPClient = &http.Client{Transport: tr}
+	c.NativeHTTPClient = &http.Client{Transport: tr}
 }


### PR DESCRIPTION
Use-case
===

I want to trace calls made to the docker unix socket or http/tcp endpoint.
Thus I plan on overwriting the [Roundtripper](https://golang.org/pkg/net/http/#RoundTripper) on the Transport of the http.Client of the docker client. While I can do this for the exported "HTTPClient" already, I can not do this on the unexported "nativeHTTPClient" used for Unix socket connections.

I don't see another way of passing a different HTTP Transport on the nativeHTTPClient in right now, other than having the one initialized exported and accessible from the outside. I am open to any ideas here.

Tests pass
---
```
~/go/src/github.com/fsouza/go-dockerclient (master) system  ᕕ( ᐛ )ᕗ   make test
go get -d -t ./...
[ -z "$(golint . | grep -v 'type name will be used as docker.DockerInfo' | grep -v 'context.Context should be the first' | tee /dev/stderr)" ]
go vet ./...
[ -z "$(gofmt -s -d . | tee /dev/stderr)" ]
go test  ./...
ok  	github.com/fsouza/go-dockerclient	2.749s
ok  	github.com/fsouza/go-dockerclient/testing	1.346s
```
