### PR TITLE
Get rid of nativeHTTPClient

### DIFF
--- a/client_unix.go
+++ b/client_unix.go
@@ -9,7 +9,6 @@ package docker
 import (
 	"context"
 	"net"
-	"net/http"
 )
 
 // initializeNativeClient initializes the native Unix domain socket client on
@@ -26,5 +25,5 @@ func (c *Client) initializeNativeClient() {
 	tr.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
 		return c.Dialer.Dial(unixProtocol, socketPath)
 	}
-	c.nativeHTTPClient = &http.Client{Transport: tr}
+	c.HTTPClient.Transport = tr
 }

--- a/client_windows.go
+++ b/client_windows.go
@@ -1,15 +1,14 @@
-// +build windows
-
 // Copyright 2016 go-dockerclient authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
+
+// +build windows
 
 package docker
 
 import (
 	"context"
 	"net"
-	"net/http"
 	"time"
 
 	"github.com/Microsoft/go-winio"
@@ -41,5 +40,5 @@ func (c *Client) initializeNativeClient() {
 		return dialFunc(network, addr)
 	}
 	c.Dialer = &pipeDialer{dialFunc}
-	c.nativeHTTPClient = &http.Client{Transport: tr}
+	c.HTTPClient.Transport = tr
 }


### PR DESCRIPTION
While reviewing #671, I noticed that we don't really need two instances
of the http client, as an instance of the docker client can only talk to
one Docker remote API.