### PR TITLE
Add workaround for ContainerCreate conflict error with Docker 17.09

### DIFF
--- a/container.go
+++ b/container.go
@@ -630,6 +630,11 @@ func (c *Client) CreateContainer(opts CreateContainerOptions) (*Container, error
 		if e.Status == http.StatusConflict {
 			return nil, ErrContainerAlreadyExists
 		}
+		// Workaround for 17.09 bug returning 400 instead of 409.
+		// See https://github.com/moby/moby/issues/35021
+		if e.Status == http.StatusBadRequest && strings.Contains(e.Message, "Conflict.") {
+			return nil, ErrContainerAlreadyExists
+		}
 	}
 
 	if err != nil {

--- a/container_test.go
+++ b/container_test.go
@@ -921,6 +921,21 @@ func TestCreateContainerDuplicateName(t *testing.T) {
 	}
 }
 
+// Workaround for 17.09 bug returning 400 instead of 409.
+// See https://github.com/moby/moby/issues/35021
+func TestCreateContainerDuplicateNameWorkaroundDocker17_09(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(&FakeRoundTripper{message: `{"message":"Conflict. The container name \"/c1\" is already in use by container \"2ce137e165dfca5e087f247b5d05a2311f91ef3da4bb7772168446a1a47e2f68\". You have to remove (or rename) that container to be able to reuse that name."}`, status: http.StatusBadRequest})
+	config := Config{AttachStdout: true, AttachStdin: true}
+	container, err := client.CreateContainer(CreateContainerOptions{Config: &config})
+	if container != nil {
+		t.Errorf("CreateContainer: expected <nil> container, got %#v.", container)
+	}
+	if err != ErrContainerAlreadyExists {
+		t.Errorf("CreateContainer: Wrong error type. Want %#v. Got %#v.", ErrContainerAlreadyExists, err)
+	}
+}
+
 func TestCreateContainerWithHostConfig(t *testing.T) {
 	t.Parallel()
 	fakeRT := &FakeRoundTripper{message: "{}", status: http.StatusOK}


### PR DESCRIPTION
Due to moby/moby#35021 this workaround searches for the "Conflict." message in the response body for a `/containers/create` request with 400 response. If the string is found we assume this is a ErrContainerAlreadyExists error.