### PR TITLE
Implement NetworkConnect endpoint for DockerServer in testing

### DIFF
--- a/testing/server.go
+++ b/testing/server.go
@@ -196,6 +196,7 @@ func (s *DockerServer) buildMuxer() {
 	s.mux.Path("/networks/{id:.*}").Methods("GET").HandlerFunc(s.handlerWrapper(s.networkInfo))
 	s.mux.Path("/networks/{id:.*}").Methods("DELETE").HandlerFunc(s.handlerWrapper(s.removeNetwork))
 	s.mux.Path("/networks/create").Methods("POST").HandlerFunc(s.handlerWrapper(s.createNetwork))
+	s.mux.Path("/networks/{id:.*}/connect").Methods("POST").HandlerFunc(s.handlerWrapper(s.networksConnect))
 	s.mux.Path("/volumes").Methods("GET").HandlerFunc(s.handlerWrapper(s.listVolumes))
 	s.mux.Path("/volumes/create").Methods("POST").HandlerFunc(s.handlerWrapper(s.createVolume))
 	s.mux.Path("/volumes/{name:.*}").Methods("GET").HandlerFunc(s.handlerWrapper(s.inspectVolume))
@@ -1293,9 +1294,10 @@ func (s *DockerServer) createNetwork(w http.ResponseWriter, r *http.Request) {
 
 	generatedID := s.generateID()
 	network := docker.Network{
-		Name:   config.Name,
-		ID:     generatedID,
-		Driver: config.Driver,
+		Name:       config.Name,
+		ID:         generatedID,
+		Driver:     config.Driver,
+		Containers: map[string]docker.Endpoint{},
 	}
 	s.netMut.Lock()
 	s.networks = append(s.networks, &network)
@@ -1317,6 +1319,35 @@ func (s *DockerServer) removeNetwork(w http.ResponseWriter, r *http.Request) {
 	s.networks[index] = s.networks[len(s.networks)-1]
 	s.networks = s.networks[:len(s.networks)-1]
 	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *DockerServer) networksConnect(w http.ResponseWriter, r *http.Request) {
+	id := mux.Vars(r)["id"]
+	var config *docker.NetworkConnectionOptions
+	defer r.Body.Close()
+	err := json.NewDecoder(r.Body).Decode(&config)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	network, index, _ := s.findNetwork(id)
+	container, _, _ := s.findContainer(config.Container)
+	if network == nil || container == nil {
+		http.Error(w, "network or container not found", http.StatusNotFound)
+		return
+	}
+
+	if _, found := network.Containers[container.ID]; found == true {
+		http.Error(w, "endpoint already exists in network", http.StatusBadRequest)
+		return
+	}
+
+	s.netMut.Lock()
+	s.networks[index].Containers[config.Container] = docker.Endpoint{}
+	s.netMut.Unlock()
+
+	w.WriteHeader(http.StatusOK)
 }
 
 func (s *DockerServer) listVolumes(w http.ResponseWriter, r *http.Request) {

--- a/testing/server_test.go
+++ b/testing/server_test.go
@@ -2168,6 +2168,25 @@ func TestRemoveNetwork(t *testing.T) {
 	}
 }
 
+func TestNetworkConnect(t *testing.T) {
+	t.Parallel()
+	server := DockerServer{}
+	server.buildMuxer()
+	addNetworks(&server, 1)
+	server.networks[0].ID = fmt.Sprintf("%x", rand.Int()%10000)
+	server.imgIDs = map[string]string{"base": "a1234"}
+	addContainers(&server, 1)
+	server.containers[0].ID = fmt.Sprintf("%x", rand.Int()%10000)
+
+	recorder := httptest.NewRecorder()
+	body := fmt.Sprintf(`{"Container": "%s" }`, server.containers[0].ID)
+	request, _ := http.NewRequest("POST", fmt.Sprintf("/networks/%s/connect", server.networks[0].ID), strings.NewReader(body))
+	server.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusOK {
+		t.Errorf("NetworkConnect: wrong status. Want %d. Got %d.", http.StatusOK, recorder.Code)
+	}
+}
+
 func TestListVolumes(t *testing.T) {
 	t.Parallel()
 	server := DockerServer{}


### PR DESCRIPTION
Because I needed this test case in another project, I found that the NetworkConnect API (see https://docs.docker.com/engine/api/v1.31/#operation/NetworkConnect) is missing in  `testing/DockerServer`. 

This PR should fix this.