### PR TITLE
docker/docker -> moby/moby

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -61,6 +61,7 @@ Ed
 Elias G. Schneevoigt
 Erez Horev
 Eric Anderson
+Eric Barrett
 Eric J. Holmes
 Eric Mountain
 Erwin van Eyk

--- a/README.markdown
+++ b/README.markdown
@@ -120,6 +120,6 @@ The instructions below can be used to get a version of go-dockerclient that comp
 
 ```
 % git clone -b docker-1.9/go-1.4 https://github.com/fsouza/go-dockerclient.git $GOPATH/src/github.com/fsouza/go-dockerclient
-% git clone -b v1.9.1 https://github.com/docker/docker.git $GOPATH/src/github.com/docker/docker
+% git clone -b v1.9.1 https://github.com/moby/moby.git $GOPATH/src/github.com/moby/moby
 % go get github.com/fsouza/go-dockerclient
 ```

--- a/build_test.go
+++ b/build_test.go
@@ -14,7 +14,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/docker/docker/pkg/archive"
+	"github.com/moby/moby/pkg/archive"
 )
 
 func TestBuildImageMultipleContextsError(t *testing.T) {

--- a/client.go
+++ b/client.go
@@ -30,10 +30,10 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/docker/docker/opts"
-	"github.com/docker/docker/pkg/homedir"
-	"github.com/docker/docker/pkg/jsonmessage"
-	"github.com/docker/docker/pkg/stdcopy"
+	"github.com/moby/moby/opts"
+	"github.com/moby/moby/pkg/homedir"
+	"github.com/moby/moby/pkg/jsonmessage"
+	"github.com/moby/moby/pkg/stdcopy"
 	"golang.org/x/net/context"
 	"golang.org/x/net/context/ctxhttp"
 )
@@ -257,8 +257,8 @@ func NewVersionedTLSClient(endpoint string, cert, key, ca, apiVersionString stri
 // NewClientFromEnv returns a Client instance ready for communication created from
 // Docker's default logic for the environment variables DOCKER_HOST, DOCKER_TLS_VERIFY, and DOCKER_CERT_PATH.
 //
-// See https://github.com/docker/docker/blob/1f963af697e8df3a78217f6fdbf67b8123a7db94/docker/docker.go#L68.
-// See https://github.com/docker/compose/blob/81707ef1ad94403789166d2fe042c8a718a4c748/compose/cli/docker_client.py#L7.
+// See https://github.com/moby/moby/blob/1f963af697e8df3a78217f6fdbf67b8123a7db94/docker/docker.go#L68.
+// See https://github.com/moby/moby/blob/81707ef1ad94403789166d2fe042c8a718a4c748/compose/cli/docker_client.py#L7.
 func NewClientFromEnv() (*Client, error) {
 	client, err := NewVersionedClientFromEnv("")
 	if err != nil {
@@ -272,7 +272,7 @@ func NewClientFromEnv() (*Client, error) {
 // Docker's default logic for the environment variables DOCKER_HOST, DOCKER_TLS_VERIFY, and DOCKER_CERT_PATH,
 // and using a specific remote API version.
 //
-// See https://github.com/docker/docker/blob/1f963af697e8df3a78217f6fdbf67b8123a7db94/docker/docker.go#L68.
+// See https://github.com/moby/moby/blob/1f963af697e8df3a78217f6fdbf67b8123a7db94/docker/docker.go#L68.
 // See https://github.com/docker/compose/blob/81707ef1ad94403789166d2fe042c8a718a4c748/compose/cli/docker_client.py#L7.
 func NewVersionedClientFromEnv(apiVersionString string) (*Client, error) {
 	dockerEnv, err := getDockerEnv()

--- a/distribution.go
+++ b/distribution.go
@@ -7,7 +7,7 @@ package docker
 import (
 	"encoding/json"
 
-	"github.com/docker/docker/api/types/registry"
+	"github.com/moby/moby/api/types/registry"
 )
 
 // InspectDistribution returns image digest and platform information by contacting the registry

--- a/distribution_test.go
+++ b/distribution_test.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/docker/docker/api/types/registry"
+	"github.com/moby/moby/api/types/registry"
 )
 
 func TestInspectDistribution(t *testing.T) {

--- a/misc.go
+++ b/misc.go
@@ -9,7 +9,7 @@ import (
 	"net"
 	"strings"
 
-	"github.com/docker/docker/api/types/swarm"
+	"github.com/moby/moby/api/types/swarm"
 )
 
 // Version returns version information about the docker server.

--- a/node.go
+++ b/node.go
@@ -10,7 +10,7 @@ import (
 	"net/url"
 	"strconv"
 
-	"github.com/docker/docker/api/types/swarm"
+	"github.com/moby/moby/api/types/swarm"
 	"golang.org/x/net/context"
 )
 

--- a/node_test.go
+++ b/node_test.go
@@ -11,7 +11,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/docker/docker/api/types/swarm"
+	"github.com/moby/moby/api/types/swarm"
 )
 
 func TestListNodes(t *testing.T) {

--- a/service.go
+++ b/service.go
@@ -12,7 +12,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/docker/docker/api/types/swarm"
+	"github.com/moby/moby/api/types/swarm"
 	"golang.org/x/net/context"
 )
 

--- a/service_test.go
+++ b/service_test.go
@@ -16,7 +16,7 @@ import (
 	"encoding/base64"
 	"strings"
 
-	"github.com/docker/docker/api/types/swarm"
+	"github.com/moby/moby/api/types/swarm"
 )
 
 func TestCreateService(t *testing.T) {

--- a/swarm.go
+++ b/swarm.go
@@ -11,7 +11,7 @@ import (
 	"net/url"
 	"strconv"
 
-	"github.com/docker/docker/api/types/swarm"
+	"github.com/moby/moby/api/types/swarm"
 	"golang.org/x/net/context"
 )
 

--- a/swarm_test.go
+++ b/swarm_test.go
@@ -10,7 +10,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/docker/docker/api/types/swarm"
+	"github.com/moby/moby/api/types/swarm"
 )
 
 func TestInitSwarm(t *testing.T) {

--- a/tar.go
+++ b/tar.go
@@ -13,8 +13,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/docker/docker/pkg/archive"
-	"github.com/docker/docker/pkg/fileutils"
+	"github.com/moby/moby/pkg/archive"
+	"github.com/moby/moby/pkg/fileutils"
 )
 
 func createTarStream(srcPath, dockerfilePath string) (io.ReadCloser, error) {
@@ -32,7 +32,7 @@ func createTarStream(srcPath, dockerfilePath string) (io.ReadCloser, error) {
 	// removed.  The deamon will remove them for us, if needed, after it
 	// parses the Dockerfile.
 	//
-	// https://github.com/docker/docker/issues/8330
+	// https://github.com/moby/moby/issues/8330
 	//
 	forceIncludeFiles := []string{".dockerignore", dockerfilePath}
 

--- a/task.go
+++ b/task.go
@@ -8,7 +8,7 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/docker/docker/api/types/swarm"
+	"github.com/moby/moby/api/types/swarm"
 	"golang.org/x/net/context"
 )
 

--- a/task_test.go
+++ b/task_test.go
@@ -11,7 +11,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/docker/docker/api/types/swarm"
+	"github.com/moby/moby/api/types/swarm"
 )
 
 func TestListTasks(t *testing.T) {

--- a/testing/server.go
+++ b/testing/server.go
@@ -26,10 +26,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/docker/docker/api/types/swarm"
-	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/fsouza/go-dockerclient"
 	"github.com/gorilla/mux"
+	"github.com/moby/moby/api/types/swarm"
+	"github.com/moby/moby/pkg/stdcopy"
 )
 
 var nameRegexp = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_.-]+$`)

--- a/testing/server_test.go
+++ b/testing/server_test.go
@@ -22,8 +22,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/docker/api/types/swarm"
 	"github.com/fsouza/go-dockerclient"
+	"github.com/moby/moby/api/types/swarm"
 )
 
 func TestNewServer(t *testing.T) {

--- a/testing/swarm.go
+++ b/testing/swarm.go
@@ -17,9 +17,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/docker/docker/api/types/swarm"
 	"github.com/fsouza/go-dockerclient"
 	"github.com/gorilla/mux"
+	"github.com/moby/moby/api/types/swarm"
 )
 
 type swarmServer struct {

--- a/testing/swarm_test.go
+++ b/testing/swarm_test.go
@@ -16,8 +16,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/docker/api/types/swarm"
 	"github.com/fsouza/go-dockerclient"
+	"github.com/moby/moby/api/types/swarm"
 )
 
 func TestSwarmInit(t *testing.T) {


### PR DESCRIPTION
Rename github.com/docker/docker to github.com/moby/moby throughout the project.  All changed comment URLs have been tested.

Motivated to fix this because github.com/golang/dep was breaking on Docker's (Moby's?) April name change.