### PR TITLE
Add golang/dep support

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,0 +1,24 @@
+
+[[constraint]]
+  name = "github.com/Microsoft/go-winio"
+  branch = "master"
+
+[[constraint]]
+  name = "github.com/docker/docker"
+  branch = "master"
+
+[[constraint]]
+  name = "github.com/docker/go-units"
+  branch = "master"
+
+[[constraint]]
+  name = "github.com/google/go-cmp"
+  branch = "master"
+
+[[constraint]]
+  name = "github.com/gorilla/mux"
+  branch = "master"
+
+[[constraint]]
+  name = "golang.org/x/net"
+  branch = "master"

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ lint:
 	[ -z "$$(golint . | grep -v 'type name will be used as docker.DockerInfo' | grep -v 'context.Context should be the first' | tee /dev/stderr)" ]
 
 vet:
-	go vet ./...
+	go vet $(go list ./... | grep -v vendor)
 
 fmt:
 	gofmt -s -w .
@@ -30,7 +30,9 @@ testdeps:
 pretest: testdeps lint vet fmtcheck
 
 gotest:
-	go test $(GO_TEST_FLAGS) ./...
+	go get -u github.com/golang/dep/cmd/dep
+	dep ensure -v
+	go test -race $(go list ./... | grep -v vendor)
 
 test: pretest gotest
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,8 +13,9 @@ install:
   - appveyor DownloadFile https://storage.googleapis.com/golang/go%GOVERSION%.windows-amd64.zip
   - 7z x go%GOVERSION%.windows-amd64.zip -y -oC:\ > NUL
 build_script:
-  - go get -race -d -t ./...
+  - go get -u github.com/golang/dep/cmd/dep
+  - dep ensure -v
 test_script:
-  - go test -race ./...
+  - for /f "" %%G in ('go list ./... ^| find /i /v "/vendor/"') do ( go test %%G & IF ERRORLEVEL == 1 EXIT 1)
 matrix:
   fast_finish: true


### PR DESCRIPTION
The project constraints are all set to master branch of the dependencies, which is the same as `go get`-ting them. I would recommend doing semver releases in the future with properly defined constraints.

fixes #683 