### PR TITLE
add securityopt arg support

### DIFF
--- a/image.go
+++ b/image.go
@@ -473,6 +473,7 @@ type BuildImageOptions struct {
 	NetworkMode         string             `qs:"networkmode"`
 	InactivityTimeout   time.Duration      `qs:"-"`
 	CgroupParent        string             `qs:"cgroupparent"`
+	SecurityOpt         []string           `qs:"securityopt"`
 	Context             context.Context
 }
 

--- a/image_test.go
+++ b/image_test.go
@@ -801,6 +801,7 @@ func TestBuildImageParameters(t *testing.T) {
 		Labels:              map[string]string{"k": "v"},
 		NetworkMode:         "host",
 		CgroupParent:        "cgparent",
+		SecurityOpt:         []string{"securityoptions"},
 	}
 	err := client.BuildImage(opts)
 	if err != nil && !strings.Contains(err.Error(), "build image fail") {
@@ -825,10 +826,11 @@ func TestBuildImageParameters(t *testing.T) {
 		"buildargs":    {`{"SOME_VAR":"some_value"}`},
 		"networkmode":  {"host"},
 		"cgroupparent": {"cgparent"},
+		"securityopt":  {"securityoptions"},
 	}
 	got := map[string][]string(req.URL.Query())
 	if !reflect.DeepEqual(got, expected) {
-		t.Errorf("BuildImage: wrong query string. Want %#v. Got %#v.", expected, got)
+		t.Errorf("BuildImage: wrong query string. Want %#v.\n Got %#v.", expected, got)
 	}
 }
 


### PR DESCRIPTION
this arg is supported as seen here:
https://github.com/moby/moby/blob/dfc2d62632d32f9d38166ea477f0ca033a5c91c2/api/server/router/build/build_routes.go#L68