### PR TITLE
testing: fix panic on service create without any containers

### DIFF
--- a/testing/swarm.go
+++ b/testing/swarm.go
@@ -255,6 +255,9 @@ func (s *DockerServer) setServiceEndpoint(service *swarm.Service) {
 }
 
 func (s *DockerServer) addTasks(service *swarm.Service, update bool) {
+	if service.Spec.TaskTemplate.ContainerSpec == nil {
+		return
+	}
 	containerCount := 1
 	if service.Spec.Mode.Global != nil {
 		containerCount = len(s.nodes)


### PR DESCRIPTION
When docker changed the ContainerSpec task attribute to be a pointer we started to panic if there was no ContainerSpec on api calls to the test server creating or updating services.