### PR TITLE
Add support for security options in docker system information

### DIFF
--- a/misc.go
+++ b/misc.go
@@ -68,6 +68,7 @@ type DockerInfo struct {
 	Architecture       string
 	IndexServerAddress string
 	RegistryConfig     *ServiceConfig
+	SecurityOptions    []string
 	NCPU               int
 	MemTotal           int64
 	DockerRootDir      string

--- a/misc_test.go
+++ b/misc_test.go
@@ -90,7 +90,12 @@ func TestInfo(t *testing.T) {
          }
        },
        "Mirrors":null
-     }
+     },
+     "SecurityOptions": [
+     	"name=apparmor",
+     	"name=seccomp",
+     	"profile=default"
+     ]
 }`
 	fakeRT := FakeRoundTripper{message: body, status: http.StatusOK}
 	client := newTestClient(&fakeRT)
@@ -116,6 +121,11 @@ func TestInfo(t *testing.T) {
 					Official: true,
 				},
 			},
+		},
+		SecurityOptions: []string{
+			"name=apparmor",
+			"name=seccomp",
+			"profile=default",
 		},
 	}
 	info, err := client.Info()


### PR DESCRIPTION
In order to use security options in the docker system information, I've
added the `SecurityOptions` entry to `DockerInfo` struct.

Added UT respectively.