### PR TITLE
Allow CreateNetworkOptions.IPAMOptions to be empty

### DIFF
--- a/network.go
+++ b/network.go
@@ -112,7 +112,7 @@ func (c *Client) NetworkInfo(id string) (*Network, error) {
 type CreateNetworkOptions struct {
 	Name           string                 `json:"Name" yaml:"Name" toml:"Name"`
 	Driver         string                 `json:"Driver" yaml:"Driver" toml:"Driver"`
-	IPAM           IPAMOptions            `json:"IPAM" yaml:"IPAM" toml:"IPAM"`
+	IPAM           *IPAMOptions           `json:"IPAM,omitempty" yaml:"IPAM" toml:"IPAM"`
 	Options        map[string]interface{} `json:"Options" yaml:"Options" toml:"Options"`
 	Labels         map[string]string      `json:"Labels" yaml:"Labels" toml:"Labels"`
 	CheckDuplicate bool                   `json:"CheckDuplicate" yaml:"CheckDuplicate" toml:"CheckDuplicate"`


### PR DESCRIPTION
If you do not do this and you just want default IPAM behavior, docker
daemon takes precisely 15 seconds to create you a network. It would seem
that some kind of discovery on a timeout is happening in the docker
daemon when you specify empty IPAM options. If you actually omit the
IPAM configuration (which is what docker/client does) then you get a
result immediately.

Steps to reproduce:
```go
package main

import (
	"log"
	"time"

	docker "github.com/fsouza/go-dockerclient"
)

func main() {
	cli, err := docker.NewClientFromEnv()
	if err != nil {
		panic(err)
	}

	start := time.Now()
	defer func() {
		log.Println("duration", time.Now().Sub(start))
	}()

	cli.CreateNetwork(docker.CreateNetworkOptions{Name: "foo"})
}
```

When I run this:
```shell
➜  slow-network go run main.go
2017/11/21 12:39:54 duration 15.24755523s
```

This change just makes the IPAMOptions a pointer and allows it to be omitted. This change makes the return immediately.