### PR TITLE
Parse the error response as JSON if possible

### DIFF
--- a/client.go
+++ b/client.go
@@ -946,12 +946,20 @@ type Error struct {
 }
 
 func newError(resp *http.Response) *Error {
+	type ErrMsg struct {
+		Message string `json:"message"`
+	}
 	defer resp.Body.Close()
 	data, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return &Error{Status: resp.StatusCode, Message: fmt.Sprintf("cannot read body, err: %v", err)}
 	}
-	return &Error{Status: resp.StatusCode, Message: string(data)}
+	var emsg ErrMsg
+	err = json.Unmarshal(data, &emsg)
+	if err != nil {
+		return &Error{Status: resp.StatusCode, Message: string(data)}
+	}
+	return &Error{Status: resp.StatusCode, Message: emsg.Message}
 }
 
 func (e *Error) Error() string {


### PR DESCRIPTION
I fetched the logs of a removed container, and the API returns an error like:
```go
*docker.Error {
	Status: 404,
	Message: "{\"message\":\"No such container: syncing-archlinux\"}\n"
}
```
so I think it is reasonable to parse the error if possible.