### PR TITLE
adding in online_cpus as of docker v17.05 stats update

### DIFF
--- a/container.go
+++ b/container.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/docker/go-units"
+	units "github.com/docker/go-units"
 	"golang.org/x/net/context"
 )
 
@@ -547,7 +547,7 @@ func (c *Client) InspectContainer(id string) (*Container, error) {
 // The context object can be used to cancel the inspect request.
 //
 // See https://goo.gl/FaI5JT for more details.
-func (c *Client) InspectContainerWithContext(id string, ctx context.Context) (*Container, error) {
+func (c *Client) InspectContainerWithContext(ctx context.Context, id string) (*Container, error) {
 	return c.inspectContainer(id, doOptions{context: ctx})
 }
 
@@ -817,7 +817,7 @@ func (c *Client) StartContainer(id string, hostConfig *HostConfig) error {
 // API 1.24 or greater.
 //
 // See https://goo.gl/fbOSZy for more details.
-func (c *Client) StartContainerWithContext(id string, hostConfig *HostConfig, ctx context.Context) error {
+func (c *Client) StartContainerWithContext(ctx context.Context, id string, hostConfig *HostConfig) error {
 	return c.startContainer(id, hostConfig, doOptions{context: ctx})
 }
 
@@ -857,7 +857,7 @@ func (c *Client) StopContainer(id string, timeout uint) error {
 // container request.
 //
 // See https://goo.gl/R9dZcV for more details.
-func (c *Client) StopContainerWithContext(id string, timeout uint, ctx context.Context) error {
+func (c *Client) StopContainerWithContext(ctx context.Context, id string, timeout uint) error {
 	return c.stopContainer(id, timeout, doOptions{context: ctx})
 }
 
@@ -1052,6 +1052,7 @@ type CPUStats struct {
 		UsageInKernelmode uint64   `json:"usage_in_kernelmode,omitempty" yaml:"usage_in_kernelmode,omitempty" toml:"usage_in_kernelmode,omitempty"`
 	} `json:"cpu_usage,omitempty" yaml:"cpu_usage,omitempty" toml:"cpu_usage,omitempty"`
 	SystemCPUUsage uint64 `json:"system_cpu_usage,omitempty" yaml:"system_cpu_usage,omitempty" toml:"system_cpu_usage,omitempty"`
+	OnlineCPUs     uint64 `json:"online_cpus,omitempty" yaml:"online_cpus,omitempty" toml:"online_cpus,omitempty"`
 	ThrottlingData struct {
 		Periods          uint64 `json:"periods,omitempty"`
 		ThrottledPeriods uint64 `json:"throttled_periods,omitempty"`

--- a/container.go
+++ b/container.go
@@ -547,7 +547,7 @@ func (c *Client) InspectContainer(id string) (*Container, error) {
 // The context object can be used to cancel the inspect request.
 //
 // See https://goo.gl/FaI5JT for more details.
-func (c *Client) InspectContainerWithContext(ctx context.Context, id string) (*Container, error) {
+func (c *Client) InspectContainerWithContext(id string, ctx context.Context) (*Container, error) {
 	return c.inspectContainer(id, doOptions{context: ctx})
 }
 
@@ -817,7 +817,7 @@ func (c *Client) StartContainer(id string, hostConfig *HostConfig) error {
 // API 1.24 or greater.
 //
 // See https://goo.gl/fbOSZy for more details.
-func (c *Client) StartContainerWithContext(ctx context.Context, id string, hostConfig *HostConfig) error {
+func (c *Client) StartContainerWithContext(id string, hostConfig *HostConfig, ctx context.Context) error {
 	return c.startContainer(id, hostConfig, doOptions{context: ctx})
 }
 
@@ -857,7 +857,7 @@ func (c *Client) StopContainer(id string, timeout uint) error {
 // container request.
 //
 // See https://goo.gl/R9dZcV for more details.
-func (c *Client) StopContainerWithContext(ctx context.Context, id string, timeout uint) error {
+func (c *Client) StopContainerWithContext(id string, timeout uint, ctx context.Context) error {
 	return c.stopContainer(id, timeout, doOptions{context: ctx})
 }
 

--- a/container_test.go
+++ b/container_test.go
@@ -1079,7 +1079,7 @@ func TestStartContainerWithContext(t *testing.T) {
 
 	startError := make(chan error)
 	go func() {
-		startError <- client.StartContainerWithContext(ctx, id, &HostConfig{})
+		startError <- client.StartContainerWithContext(id, &HostConfig{}, ctx)
 	}()
 	select {
 	case err := <-startError:
@@ -1154,7 +1154,7 @@ func TestStopContainerWithContext(t *testing.T) {
 
 	stopError := make(chan error)
 	go func() {
-		stopError <- client.StopContainerWithContext(ctx, id, 10)
+		stopError <- client.StopContainerWithContext(id, 10, ctx)
 	}()
 	select {
 	case err := <-stopError:
@@ -2729,7 +2729,7 @@ func TestInspectContainerWhenContextTimesOut(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.TODO(), 100*time.Millisecond)
 	defer cancel()
 
-	_, err := client.InspectContainerWithContext(ctx, "id")
+	_, err := client.InspectContainerWithContext("id", ctx)
 	if err != context.DeadlineExceeded {
 		t.Errorf("Expected 'DeadlineExceededError', got: %v", err)
 	}
@@ -2744,7 +2744,7 @@ func TestStartContainerWhenContextTimesOut(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.TODO(), 100*time.Millisecond)
 	defer cancel()
 
-	err := client.StartContainerWithContext(ctx, "id", nil)
+	err := client.StartContainerWithContext("id", nil, ctx)
 	if err != context.DeadlineExceeded {
 		t.Errorf("Expected 'DeadlineExceededError', got: %v", err)
 	}
@@ -2759,7 +2759,7 @@ func TestStopContainerWhenContextTimesOut(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.TODO(), 50*time.Millisecond)
 	defer cancel()
 
-	err := client.StopContainerWithContext(ctx, "id", 10)
+	err := client.StopContainerWithContext("id", 10, ctx)
 	if err != context.DeadlineExceeded {
 		t.Errorf("Expected 'DeadlineExceededError', got: %v", err)
 	}

--- a/container_test.go
+++ b/container_test.go
@@ -1079,7 +1079,7 @@ func TestStartContainerWithContext(t *testing.T) {
 
 	startError := make(chan error)
 	go func() {
-		startError <- client.StartContainerWithContext(id, &HostConfig{}, ctx)
+		startError <- client.StartContainerWithContext(ctx, id, &HostConfig{})
 	}()
 	select {
 	case err := <-startError:
@@ -1154,7 +1154,7 @@ func TestStopContainerWithContext(t *testing.T) {
 
 	stopError := make(chan error)
 	go func() {
-		stopError <- client.StopContainerWithContext(id, 10, ctx)
+		stopError <- client.StopContainerWithContext(ctx, id, 10)
 	}()
 	select {
 	case err := <-stopError:
@@ -2473,7 +2473,8 @@ func TestStats(t *testing.T) {
              "total_usage" : 36488948,
              "usage_in_kernelmode" : 20000000
           },
-          "system_cpu_usage" : 20091722000000000
+          "system_cpu_usage" : 20091722000000000,
+		  "online_cpus": 4
        },
        "precpu_stats" : {
           "cpu_usage" : {
@@ -2487,7 +2488,8 @@ func TestStats(t *testing.T) {
              "total_usage" : 36488948,
              "usage_in_kernelmode" : 20000000
           },
-          "system_cpu_usage" : 20091722000000000
+          "system_cpu_usage" : 20091722000000000,
+		  "online_cpus": 4
        }
     }`
 	// 1 second later, cache is 100
@@ -2591,7 +2593,8 @@ func TestStats(t *testing.T) {
              "total_usage" : 36488948,
              "usage_in_kernelmode" : 20000000
           },
-          "system_cpu_usage" : 20091722000000000
+          "system_cpu_usage" : 20091722000000000,
+		  "online_cpus": 4
        },
        "precpu_stats" : {
           "cpu_usage" : {
@@ -2605,7 +2608,8 @@ func TestStats(t *testing.T) {
              "total_usage" : 36488948,
              "usage_in_kernelmode" : 20000000
           },
-          "system_cpu_usage" : 20091722000000000
+          "system_cpu_usage" : 20091722000000000,
+		  "online_cpus": 4
        }
     }`
 	var expected1 Stats
@@ -2725,7 +2729,7 @@ func TestInspectContainerWhenContextTimesOut(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.TODO(), 100*time.Millisecond)
 	defer cancel()
 
-	_, err := client.InspectContainerWithContext("id", ctx)
+	_, err := client.InspectContainerWithContext(ctx, "id")
 	if err != context.DeadlineExceeded {
 		t.Errorf("Expected 'DeadlineExceededError', got: %v", err)
 	}
@@ -2740,7 +2744,7 @@ func TestStartContainerWhenContextTimesOut(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.TODO(), 100*time.Millisecond)
 	defer cancel()
 
-	err := client.StartContainerWithContext("id", nil, ctx)
+	err := client.StartContainerWithContext(ctx, "id", nil)
 	if err != context.DeadlineExceeded {
 		t.Errorf("Expected 'DeadlineExceededError', got: %v", err)
 	}
@@ -2755,7 +2759,7 @@ func TestStopContainerWhenContextTimesOut(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.TODO(), 50*time.Millisecond)
 	defer cancel()
 
-	err := client.StopContainerWithContext("id", 10, ctx)
+	err := client.StopContainerWithContext(ctx, "id", 10)
 	if err != context.DeadlineExceeded {
 		t.Errorf("Expected 'DeadlineExceededError', got: %v", err)
 	}

--- a/testing/swarm.go
+++ b/testing/swarm.go
@@ -280,7 +280,7 @@ func (s *DockerServer) addTasks(service *swarm.Service, update bool) {
 			NodeID:    chosenNode.ID,
 			Status: swarm.TaskStatus{
 				State: swarm.TaskStateReady,
-				ContainerStatus: swarm.ContainerStatus{
+				ContainerStatus: &swarm.ContainerStatus{
 					ContainerID: container.ID,
 				},
 			},

--- a/testing/swarm_test.go
+++ b/testing/swarm_test.go
@@ -414,7 +414,7 @@ func TestServiceCreate(t *testing.T) {
 		NodeID:    server.nodes[0].ID,
 		Status: swarm.TaskStatus{
 			State: swarm.TaskStateReady,
-			ContainerStatus: swarm.ContainerStatus{
+			ContainerStatus: &swarm.ContainerStatus{
 				ContainerID: cont.ID,
 			},
 		},
@@ -1094,7 +1094,7 @@ func TestServiceUpdate(t *testing.T) {
 		NodeID:    server.nodes[1].ID,
 		Status: swarm.TaskStatus{
 			State: swarm.TaskStateReady,
-			ContainerStatus: swarm.ContainerStatus{
+			ContainerStatus: &swarm.ContainerStatus{
 				ContainerID: cont.ID,
 			},
 		},


### PR DESCRIPTION
The `CPUStats` section now includes an `online_cpus` component which is roughly (usually?) the `len(cpu_usage.percpu_usage)` list within the same struct. I'm not 100% certain this appeared as of v17.05, but it's definitely now there and part of the `cpuPercent` calculation in the docker stats api.

JSON output example -- https://pastebin.com/uhmgxHiF
moby code -- https://github.com/moby/moby/blob/17.05.x/cli/command/container/stats_helpers.go#L174