### PR TITLE
Adding driver options to Volume, to reflect docker volume inspect output

### DIFF
--- a/volume.go
+++ b/volume.go
@@ -27,6 +27,7 @@ type Volume struct {
 	Driver     string            `json:"Driver,omitempty" yaml:"Driver,omitempty" toml:"Driver,omitempty"`
 	Mountpoint string            `json:"Mountpoint,omitempty" yaml:"Mountpoint,omitempty" toml:"Mountpoint,omitempty"`
 	Labels     map[string]string `json:"Labels,omitempty" yaml:"Labels,omitempty" toml:"Labels,omitempty"`
+	Options    map[string]string `json:"Options,omitempty" yaml:"Options,omitempty" toml:"Options,omitempty"`
 }
 
 // ListVolumesOptions specify parameters to the ListVolumes function.

--- a/volume_test.go
+++ b/volume_test.go
@@ -85,7 +85,10 @@ func TestInspectVolume(t *testing.T) {
 	body := `{
 		"Name": "tardis",
 		"Driver": "local",
-		"Mountpoint": "/var/lib/docker/volumes/tardis"
+		"Mountpoint": "/var/lib/docker/volumes/tardis",
+		"Options": {
+			"foo": "bar"
+		}
 	}`
 	var expected Volume
 	if err := json.Unmarshal([]byte(body), &expected); err != nil {


### PR DESCRIPTION
**Summary**
This change adds Options field missing in Volume struct, to reflect the output of docker volume inspect.

**Test**
% make lint vet fmtcheck 
[ -z "$(golint . | grep -v 'type name will be used as docker.DockerInfo' | grep -v 'context.Context should be the first' | tee /dev/stderr)" ]
go vet ./...
[ -z "$(gofmt -s -d *.go ./testing | tee /dev/stderr)" ]

% make gotest 
go test -race ./...
ok  	github.com/go-dockerclient	7.243s
ok  	github.com/go-dockerclient/testing	3.478s
