### PR TITLE
Add the SHELL command to container Config

### DIFF
--- a/container.go
+++ b/container.go
@@ -303,6 +303,7 @@ type Config struct {
 	StopTimeout       int                 `json:"StopTimeout,omitempty" yaml:"StopTimeout,omitempty" toml:"StopTimeout,omitempty"`
 	Env               []string            `json:"Env,omitempty" yaml:"Env,omitempty" toml:"Env,omitempty"`
 	Cmd               []string            `json:"Cmd" yaml:"Cmd" toml:"Cmd"`
+	Shell             []string            `json:"Shell,omitempty" yaml:"Shell,omitempty" toml:"Shell,omitempty"`
 	Healthcheck       *HealthConfig       `json:"Healthcheck,omitempty" yaml:"Healthcheck,omitempty" toml:"Healthcheck,omitempty"`
 	DNS               []string            `json:"Dns,omitempty" yaml:"Dns,omitempty" toml:"Dns,omitempty"` // For Docker API v1.9 and below only
 	Image             string              `json:"Image,omitempty" yaml:"Image,omitempty" toml:"Image,omitempty"`

--- a/container_test.go
+++ b/container_test.go
@@ -216,7 +216,10 @@ func TestInspectContainer(t *testing.T) {
                       ],
                       "Ulimits": [
                           { "Name": "nofile", "Soft": 1024, "Hard": 2048 }
-                      ]
+											],
+											"Shell": [
+                         "/bin/sh", "-c"
+											]
              },
              "State": {
                      "Running": false,


### PR DESCRIPTION
Part of Docker engine API 1.30, allows clients to set the default shell
for RUN / ENTRYPOINT / CMD for cross platform support.