### PR TITLE
Add missing Target to BuildImageOptions

### DIFF
--- a/image.go
+++ b/image.go
@@ -473,6 +473,7 @@ type BuildImageOptions struct {
 	InactivityTimeout   time.Duration      `qs:"-"`
 	CgroupParent        string             `qs:"cgroupparent"`
 	SecurityOpt         []string           `qs:"securityopt"`
+	Target              string             `gs:"target"`
 	Context             context.Context
 }
 


### PR DESCRIPTION
This field was added a long time ago (I think around Docker 17.06), but wasn't in the API docs. I opened a PR to add it to the API docs as well (https://github.com/moby/moby/pull/36724).