### PR TITLE
Adding list plugins API with filter

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -166,6 +166,33 @@ func (c *Client) ListPlugins(ctx context.Context) ([]PluginDetail, error) {
 	return pluginDetails, nil
 }
 
+// ListFilteredPluginsOptions specify parameters to the ListFilteredPlugins function.
+//
+// See https://goo.gl/C4t7Tz for more details.
+type ListFilteredPluginsOptions struct {
+	Filters map[string][]string
+	Context context.Context
+}
+
+// ListFilteredPlugins returns pluginDetails or an error.
+//
+// See https://goo.gl/rmdmWg for more details.
+func (c *Client) ListFilteredPlugins(opts ListFilteredPluginsOptions) ([]PluginDetail, error) {
+	path := "/plugins/json?" + queryString(opts)
+	resp, err := c.do("GET", path, doOptions{
+		context: opts.Context,
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	pluginDetails := make([]PluginDetail, 0)
+	if err := json.NewDecoder(resp.Body).Decode(&pluginDetails); err != nil {
+		return nil, err
+	}
+	return pluginDetails, nil
+}
+
 // GetPluginPrivileges returns pulginPrivileges or an error.
 //
 // See https://goo.gl/C4t7Tz for more details.


### PR DESCRIPTION
Summary
This change adds list plugins API with filter, under a new function ListFilteredPlugins. This was added in docker api v1.28 (https://goo.gl/rmdmWg). 
Also see https://docs.docker.com/engine/reference/commandline/plugin_ls/#filtering for more detail. 

Ideally, ListPlugins would accept the input param containing optional filters and context, but I did not want to make backward incompatible change that might break other users. I am not too clear on how docker API version is managed in this client, but If updating existing ListPlugins function to handle filters is ok, please let me know and I can update this PR. 

➜  go-dockerclient git:(plugin-ls-filter)  make lint vet fmtcheck
[ -z "$(golint . | grep -v 'type name will be used as docker.DockerInfo' | grep -v 'context.Context should be the first' | tee /dev/stderr)" ]
go vet ./...
[ -z "$(gofmt -s -d *.go ./testing | tee /dev/stderr)" ]
➜  go-dockerclient git:(plugin-ls-filter) make gotest
go test -race ./...
ok      github.com/go-dockerclient      (cached)
ok      github.com/go-dockerclient/testing      (cached)
