### PR TITLE
misc: add VersionWithContext method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: go
 sudo: required
 go:
-  - 1.9.x
   - 1.10.x
   - tip
 os:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 sudo: required
 go:
+  - 1.9.x
   - 1.10.x
-  - tip
 os:
   - linux
   - osx

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,7 @@ clone_folder: c:\gopath\src\github.com\fsouza\go-dockerclient
 environment:
   GOPATH: c:\gopath
   matrix:
+    - GOVERSION: 1.9.5
     - GOVERSION: 1.10.1
 install:
   - set PATH=%GOPATH%\bin;c:\go\bin;%PATH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,6 @@ clone_folder: c:\gopath\src\github.com\fsouza\go-dockerclient
 environment:
   GOPATH: c:\gopath
   matrix:
-    - GOVERSION: 1.9.5
     - GOVERSION: 1.10.1
 install:
   - set PATH=%GOPATH%\bin;c:\go\bin;%PATH%

--- a/misc.go
+++ b/misc.go
@@ -5,6 +5,7 @@
 package docker
 
 import (
+	"context"
 	"encoding/json"
 	"net"
 	"strings"
@@ -16,7 +17,12 @@ import (
 //
 // See https://goo.gl/mU7yje for more details.
 func (c *Client) Version() (*Env, error) {
-	resp, err := c.do("GET", "/version", doOptions{})
+	return c.VersionWithContext(nil)
+}
+
+// VersionWithContext returns version information about the docker server.
+func (c *Client) VersionWithContext(ctx context.Context) (*Env, error) {
+	resp, err := c.do("GET", "/version", doOptions{context: ctx})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
In rare cases, Docker's "/version" API might take a long time to
respond. Wrapping this with a context gives clients more control
over handling this scenario.