### PR TITLE
testing: improve how images and containers are stored in the testing server

### DIFF
--- a/testing/swarm_test.go
+++ b/testing/swarm_test.go
@@ -373,7 +373,7 @@ func TestServiceCreate(t *testing.T) {
 	if len(server.services) != 1 || len(server.tasks) != 1 || len(server.containers) != 1 {
 		t.Fatalf("ServiceCreate: wrong item count. Want 1. Got services: %d, tasks: %d, containers: %d.", len(server.services), len(server.tasks), len(server.containers))
 	}
-	cont := server.containers[0]
+	cont := getContainer(server)
 	expectedContainer := &docker.Container{
 		ID:      cont.ID,
 		Created: cont.Created,
@@ -1049,7 +1049,7 @@ func TestServiceUpdate(t *testing.T) {
 	if len(server.services) != 1 || len(server.tasks) != 1 || len(server.containers) != 1 {
 		t.Fatalf("ServiceUpdate: wrong item count. Want 1. Got services: %d, tasks: %d, containers: %d.", len(server.services), len(server.tasks), len(server.containers))
 	}
-	cont := server.containers[0]
+	cont := getContainer(server)
 	expectedContainer := &docker.Container{
 		ID:      cont.ID,
 		Created: cont.Created,


### PR DESCRIPTION
Now instead of using a slice for storing images and containers we store then in some maps. Images are indexed by ID and Repository name, and containers are indexed by ID and Name.

This change allows the test server to avoid iterating over all items when searching for a given container or image.

The motivation behind this change was that tsuru uses the go-dockerclient testing server to "simulate" a cluster and check whether a rebalance is needed or not during the node auto-scale process. After profiling some CPU spikes in production we found that the culprit was the testing server iterating over containers and images all the time.