### PR TITLE
Add Env and WorkingDir support, fix go vet for swarm tests

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -32,6 +32,8 @@ type CreateExecOptions struct {
 	Cmd          []string        `json:"Cmd,omitempty" yaml:"Cmd,omitempty"`
 	Container    string          `json:"Container,omitempty" yaml:"Container,omitempty"`
 	User         string          `json:"User,omitempty" yaml:"User,omitempty"`
+	Env          []string        `json:"Env,omitempty" yaml:"Env,omitempty"`
+	WorkingDir   string          `json:"WorkingDir,omitempty" yaml:"WorkingDir,omitempty"`
 	Context      context.Context `json:"-"`
 	Privileged   bool            `json:"Privileged,omitempty" yaml:"Privileged,omitempty"`
 }

--- a/exec_test.go
+++ b/exec_test.go
@@ -30,6 +30,8 @@ func TestExecCreate(t *testing.T) {
 		AttachStdout: true,
 		AttachStderr: false,
 		Tty:          false,
+		WorkingDir:   "/tmp",
+		Env:          []string{"FOO=BAR", "BAR=BAZ"},
 		Cmd:          []string{"touch", "/tmp/file"},
 		User:         "a-user",
 	}

--- a/testing/swarm_test.go
+++ b/testing/swarm_test.go
@@ -190,7 +190,7 @@ func TestSwarmJoinWithService(t *testing.T) {
 	serviceCreateOpts := docker.CreateServiceOptions{
 		ServiceSpec: swarm.ServiceSpec{
 			TaskTemplate: swarm.TaskSpec{
-				ContainerSpec: swarm.ContainerSpec{
+				ContainerSpec: &swarm.ContainerSpec{
 					Image: "test/test",
 				},
 			},
@@ -341,7 +341,7 @@ func TestServiceCreate(t *testing.T) {
 				Name: "test",
 			},
 			TaskTemplate: swarm.TaskSpec{
-				ContainerSpec: swarm.ContainerSpec{
+				ContainerSpec: &swarm.ContainerSpec{
 					Image:   "test/test",
 					Command: []string{"sh"},
 					Args:    []string{"--test"},
@@ -437,7 +437,7 @@ func TestServiceCreateDynamicPort(t *testing.T) {
 				Name: "test",
 			},
 			TaskTemplate: swarm.TaskSpec{
-				ContainerSpec: swarm.ContainerSpec{
+				ContainerSpec: &swarm.ContainerSpec{
 					Image:   "test/test",
 					Command: []string{"sh"},
 					Args:    []string{"--test"},
@@ -991,7 +991,7 @@ func TestServiceUpdate(t *testing.T) {
 			Name: "test",
 		},
 		TaskTemplate: swarm.TaskSpec{
-			ContainerSpec: swarm.ContainerSpec{
+			ContainerSpec: &swarm.ContainerSpec{
 				Image: "test/test2",
 				Args:  []string{"--test2"},
 				Env:   []string{"ENV=2"},
@@ -1086,7 +1086,7 @@ func TestServiceUpdateMoreReplicas(t *testing.T) {
 			Name: "test",
 		},
 		TaskTemplate: swarm.TaskSpec{
-			ContainerSpec: swarm.ContainerSpec{
+			ContainerSpec: &swarm.ContainerSpec{
 				Image: "test/test2",
 				Args:  []string{"--test2"},
 				Env:   []string{"ENV=2"},
@@ -1131,7 +1131,7 @@ func TestServiceUpdateNotFound(t *testing.T) {
 			Name: "test",
 		},
 		TaskTemplate: swarm.TaskSpec{
-			ContainerSpec: swarm.ContainerSpec{
+			ContainerSpec: &swarm.ContainerSpec{
 				Image: "test/test2",
 				Args:  []string{"--test2"},
 				Env:   []string{"ENV=2"},
@@ -1295,7 +1295,7 @@ func addTestService(server *DockerServer) (*swarm.Service, error) {
 				},
 			},
 			TaskTemplate: swarm.TaskSpec{
-				ContainerSpec: swarm.ContainerSpec{
+				ContainerSpec: &swarm.ContainerSpec{
 					Image: "test/test",
 					Args:  []string{"--test"},
 					Env:   []string{"ENV=1"},


### PR DESCRIPTION
In 2017.12 support was added for setting environment and working directory for execs.  This is super useful.  I've started to add support and it is working, but it doesn't test for if the version is new enough. I also saw that there were some problems with testing/swarm_test.go (had changed to accepting a pointer to the structure, but the tests weren't updated) so I fixed those too.  It might be nice to change the touch to not specify /tmp (because that's our workdir in the test now)