### PR TITLE
Plugin: fix the json tag for enabled

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -143,7 +143,7 @@ type PluginDetail struct {
 	ID       string         `json:"Id,omitempty" yaml:"Id,omitempty" toml:"Id,omitempty"`
 	Name     string         `json:"Name,omitempty" yaml:"Name,omitempty" toml:"Name,omitempty"`
 	Tag      string         `json:"Tag,omitempty" yaml:"Tag,omitempty" toml:"Tag,omitempty"`
-	Active   bool           `json:"Active,omitempty" yaml:"Active,omitempty" toml:"Active,omitempty"`
+	Active   bool           `json:"Enabled,omitempty" yaml:"Active,omitempty" toml:"Active,omitempty"`
 	Settings PluginSettings `json:"Settings,omitempty" yaml:"Settings,omitempty" toml:"Settings,omitempty"`
 	Config   PluginConfig   `json:"Config,omitempty" yaml:"Config,omitempty" toml:"Config,omitempty"`
 }

--- a/plugins_test.go
+++ b/plugins_test.go
@@ -66,7 +66,7 @@ const (
     "Id": "5724e2c8652da337ab2eedd19fc6fc0ec908e4bd907c7421bf6a8dfc70c4c078",
     "Name": "tiborvass/sample-volume-plugin",
     "Tag": "latest",
-    "Active": true,
+    "Enabled": true,
     "Settings": {
       "Env": [
         "DEBUG=0"


### PR DESCRIPTION
I was trying to read the listplugin output, but it can't unmarshal the `Enabled` field. Based on the [doc](https://docs.docker.com/engine/api/v1.37/#tag/Plugin) the enabled field should be "enabled", please let me know if I missed something.