### PR TITLE
Don't panic when env is nil

### DIFF
--- a/env.go
+++ b/env.go
@@ -156,7 +156,7 @@ func (env *Env) SetAuto(key string, value interface{}) {
 
 // Map returns the map representation of the env.
 func (env *Env) Map() map[string]string {
-	if len(*env) == 0 {
+	if env == nil || len(*env) == 0 {
 		return nil
 	}
 	m := make(map[string]string)


### PR DESCRIPTION
Recently we moved docker-gen to be included as a service in our base AMIs. There seems to be a timing issue with things coming up and going down, and that is definitely something to handle on our end and possibly some changes needed in docker-gen.

The one thing I noticed was the panic happening in `env.go`, and simply wanted to offer up a PR for making it a little more graceful.