### PR TITLE
Support IdentityToken in AuthConfiguration

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -146,25 +146,23 @@ func authConfigs(confs map[string]dockerConfig) (*AuthConfigurations, error) {
 
 		userpass := strings.SplitN(string(data), ":", 2)
 		if len(userpass) != 2 {
-			if conf.IdentityToken == "" {
-				return nil, ErrCannotParseDockercfg
-			}
-
-			// docker config contains username and identitytoken
-			c.Configs[reg] = AuthConfiguration{
-				Username:      string(data),
-				IdentityToken: conf.IdentityToken,
-			}
-
-			continue
+			return nil, ErrCannotParseDockercfg
 		}
 
-		c.Configs[reg] = AuthConfiguration{
+		authConfig := AuthConfiguration{
 			Email:         conf.Email,
 			Username:      userpass[0],
 			Password:      userpass[1],
 			ServerAddress: reg,
 		}
+
+		// if identitytoken provided then zero the password and set it
+		if conf.IdentityToken != "" {
+			authConfig.Password = ""
+			authConfig.IdentityToken = conf.IdentityToken
+		}
+
+		c.Configs[reg] = authConfig
 	}
 
 	return c, nil

--- a/auth.go
+++ b/auth.go
@@ -152,6 +152,7 @@ func authConfigs(confs map[string]dockerConfig) (*AuthConfigurations, error) {
 
 			// docker config contains username and identitytoken
 			c.Configs[reg] = AuthConfiguration{
+				Username:      string(data),
 				IdentityToken: conf.IdentityToken,
 			}
 

--- a/auth.go
+++ b/auth.go
@@ -152,7 +152,6 @@ func authConfigs(confs map[string]dockerConfig) (*AuthConfigurations, error) {
 
 			// docker config contains username and identitytoken
 			c.Configs[reg] = AuthConfiguration{
-				Username:      string(data),
 				IdentityToken: conf.IdentityToken,
 			}
 

--- a/auth_test.go
+++ b/auth_test.go
@@ -148,6 +148,7 @@ func TestAuthAndOtherFields(t *testing.T) {
 		t.Errorf(`AuthConfigurations.Configs["docker.io"].ServerAddress: wrong result. Want %q. Got %q`, want, got)
 	}
 }
+
 func TestAuthConfig(t *testing.T) {
 	t.Parallel()
 	auth := base64.StdEncoding.EncodeToString([]byte("user:pass"))
@@ -171,6 +172,26 @@ func TestAuthConfig(t *testing.T) {
 	}
 	if got, want := c.ServerAddress, "docker.io"; got != want {
 		t.Errorf(`AuthConfigurations.Configs["docker.io"].ServerAddress: wrong result. Want %q. Got %q`, want, got)
+	}
+}
+
+func TestAuthConfigIdentityToken(t *testing.T) {
+	t.Parallel()
+	auth := base64.StdEncoding.EncodeToString([]byte("someuser"))
+	read := strings.NewReader(fmt.Sprintf(`{"auths":{"docker.io":{"auth":"%s","identitytoken":"sometoken"}}}`, auth))
+	ac, err := NewAuthConfigurations(read)
+	if err != nil {
+		t.Error(err)
+	}
+	c, ok := ac.Configs["docker.io"]
+	if !ok {
+		t.Error("NewAuthConfigurations: Expected Configs to contain docker.io")
+	}
+	if got, want := c.Username, "someuser"; got != want {
+		t.Errorf(`AuthConfigurations.Configs["docker.io"].IdentityToken: wrong result. Want %q. Got %q`, want, got)
+	}
+	if got, want := c.IdentityToken, "sometoken"; got != want {
+		t.Errorf(`AuthConfigurations.Configs["docker.io"].IdentityToken: wrong result. Want %q. Got %q`, want, got)
 	}
 }
 

--- a/auth_test.go
+++ b/auth_test.go
@@ -187,9 +187,6 @@ func TestAuthConfigIdentityToken(t *testing.T) {
 	if !ok {
 		t.Error("NewAuthConfigurations: Expected Configs to contain docker.io")
 	}
-	if got, want := c.Username, "someuser"; got != want {
-		t.Errorf(`AuthConfigurations.Configs["docker.io"].IdentityToken: wrong result. Want %q. Got %q`, want, got)
-	}
 	if got, want := c.IdentityToken, "sometoken"; got != want {
 		t.Errorf(`AuthConfigurations.Configs["docker.io"].IdentityToken: wrong result. Want %q. Got %q`, want, got)
 	}

--- a/auth_test.go
+++ b/auth_test.go
@@ -177,18 +177,19 @@ func TestAuthConfig(t *testing.T) {
 
 func TestAuthConfigIdentityToken(t *testing.T) {
 	t.Parallel()
-	auth := base64.StdEncoding.EncodeToString([]byte("someuser"))
+	auth := base64.StdEncoding.EncodeToString([]byte("someuser:"))
 	read := strings.NewReader(fmt.Sprintf(`{"auths":{"docker.io":{"auth":"%s","identitytoken":"sometoken"}}}`, auth))
 	ac, err := NewAuthConfigurations(read)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
+
 	c, ok := ac.Configs["docker.io"]
 	if !ok {
 		t.Error("NewAuthConfigurations: Expected Configs to contain docker.io")
 	}
 	if got, want := c.Username, "someuser"; got != want {
-		t.Errorf(`AuthConfigurations.Configs["docker.io"].IdentityToken: wrong result. Want %q. Got %q`, want, got)
+		t.Errorf(`AuthConfigurations.Configs["docker.io"].Username: wrong result. Want %q. Got %q`, want, got)
 	}
 	if got, want := c.IdentityToken, "sometoken"; got != want {
 		t.Errorf(`AuthConfigurations.Configs["docker.io"].IdentityToken: wrong result. Want %q. Got %q`, want, got)

--- a/auth_test.go
+++ b/auth_test.go
@@ -187,6 +187,9 @@ func TestAuthConfigIdentityToken(t *testing.T) {
 	if !ok {
 		t.Error("NewAuthConfigurations: Expected Configs to contain docker.io")
 	}
+	if got, want := c.Username, "someuser"; got != want {
+		t.Errorf(`AuthConfigurations.Configs["docker.io"].IdentityToken: wrong result. Want %q. Got %q`, want, got)
+	}
 	if got, want := c.IdentityToken, "sometoken"; got != want {
 		t.Errorf(`AuthConfigurations.Configs["docker.io"].IdentityToken: wrong result. Want %q. Got %q`, want, got)
 	}


### PR DESCRIPTION
This change adds support for the sending and parsing of an
IdentityToken in an AuthConfiguration. IdentityToken's are retrieved via the /auth call (see
AuthCheck) and can then be used in place of the password. After a
successful `docker login` a users `.dockercfg` can contain an identity
token in place of the original username and password in the auth field.

See: https://docs.docker.com/engine/api/v1.25/#section/Authentication

Also see official docker types https://godoc.org/github.com/docker/docker/api/types#AuthConfig