### PR TITLE
Fix idtools types to follow the changes in docker library

### DIFF
--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -71,7 +71,7 @@ type TarOptions struct {
 	NoLchown         bool
 	UIDMaps          []idtools.IDMap
 	GIDMaps          []idtools.IDMap
-	ChownOpts        *idtools.IDPair
+	ChownOpts        *idtools.Identity
 	IncludeSourceDir bool
 	// WhiteoutFormat is the expected on disk format for whiteout files.
 	// This format will be converted to the standard format on pack
@@ -292,9 +292,9 @@ type tarAppender struct {
 	Buffer    *bufio.Writer
 
 	// for hardlink mapping
-	SeenFiles  map[uint64]string
-	IDMappings *idtools.IDMappings
-	ChownOpts  *idtools.IDPair
+	SeenFiles       map[uint64]string
+	IdentityMapping *idtools.IdentityMapping
+	ChownOpts       *idtools.Identity
 
 	// For packing and unpacking whiteout files in the
 	// non standard format. The whiteout files defined
@@ -303,13 +303,13 @@ type tarAppender struct {
 	WhiteoutConverter tarWhiteoutConverter
 }
 
-func newTarAppender(idMapping *idtools.IDMappings, writer io.Writer, chownOpts *idtools.IDPair) *tarAppender {
+func newTarAppender(idMapping *idtools.IdentityMapping, writer io.Writer, chownOpts *idtools.Identity) *tarAppender {
 	return &tarAppender{
-		SeenFiles:  make(map[uint64]string),
-		TarWriter:  tar.NewWriter(writer),
-		Buffer:     pools.BufioWriter32KPool.Get(nil),
-		IDMappings: idMapping,
-		ChownOpts:  chownOpts,
+		SeenFiles:       make(map[uint64]string),
+		TarWriter:       tar.NewWriter(writer),
+		Buffer:          pools.BufioWriter32KPool.Get(nil),
+		IdentityMapping: idMapping,
+		ChownOpts:       chownOpts,
 	}
 }
 
@@ -364,12 +364,12 @@ func (ta *tarAppender) addTarFile(path, name string) error {
 	//by the kernel and already have proper ownership relative to the host
 	if !isOverlayWhiteout &&
 		!strings.HasPrefix(filepath.Base(hdr.Name), WhiteoutPrefix) &&
-		!ta.IDMappings.Empty() {
-		fileIDPair, err := getFileUIDGID(fi.Sys())
+		!ta.IdentityMapping.Empty() {
+		fileIdentity, err := getFileUIDGID(fi.Sys())
 		if err != nil {
 			return err
 		}
-		hdr.Uid, hdr.Gid, err = ta.IDMappings.ToContainer(fileIDPair)
+		hdr.Uid, hdr.Gid, err = ta.IdentityMapping.ToContainer(fileIdentity)
 		if err != nil {
 			return err
 		}

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -365,7 +365,7 @@ func (ta *tarAppender) addTarFile(path, name string) error {
 	if !isOverlayWhiteout &&
 		!strings.HasPrefix(filepath.Base(hdr.Name), WhiteoutPrefix) &&
 		!ta.IdentityMapping.Empty() {
-		fileIdentity, err := getFileUIDGID(fi.Sys())
+		fileIdentity, err := getFileIdentity(fi.Sys())
 		if err != nil {
 			return err
 		}

--- a/internal/archive/archive_unix.go
+++ b/internal/archive/archive_unix.go
@@ -48,7 +48,7 @@ func getInodeFromStat(stat interface{}) (inode uint64, err error) {
 	return
 }
 
-func getFileUIDGID(stat interface{}) (idtools.Identity, error) {
+func getFileIdentity(stat interface{}) (idtools.Identity, error) {
 	s, ok := stat.(*syscall.Stat_t)
 
 	if !ok {

--- a/internal/archive/archive_unix.go
+++ b/internal/archive/archive_unix.go
@@ -48,13 +48,13 @@ func getInodeFromStat(stat interface{}) (inode uint64, err error) {
 	return
 }
 
-func getFileUIDGID(stat interface{}) (idtools.IDPair, error) {
+func getFileUIDGID(stat interface{}) (idtools.Identity, error) {
 	s, ok := stat.(*syscall.Stat_t)
 
 	if !ok {
-		return idtools.IDPair{}, errors.New("cannot convert stat value to syscall.Stat_t")
+		return idtools.Identity{}, errors.New("cannot convert stat value to syscall.Stat_t")
 	}
-	return idtools.IDPair{UID: int(s.Uid), GID: int(s.Gid)}, nil
+	return idtools.Identity{UID: int(s.Uid), GID: int(s.Gid)}, nil
 }
 
 func chmodTarEntry(perm os.FileMode) os.FileMode {

--- a/internal/archive/archive_windows.go
+++ b/internal/archive/archive_windows.go
@@ -47,7 +47,7 @@ func getInodeFromStat(stat interface{}) (inode uint64, err error) {
 	return
 }
 
-func getFileUIDGID(stat interface{}) (idtools.Identity, error) {
+func getFileIdentity(stat interface{}) (idtools.Identity, error) {
 	// no notion of file ownership mapping yet on Windows
 	return idtools.Identity{}, nil
 }

--- a/internal/archive/archive_windows.go
+++ b/internal/archive/archive_windows.go
@@ -47,9 +47,9 @@ func getInodeFromStat(stat interface{}) (inode uint64, err error) {
 	return
 }
 
-func getFileUIDGID(stat interface{}) (idtools.IDPair, error) {
+func getFileUIDGID(stat interface{}) (idtools.Identity, error) {
 	// no notion of file ownership mapping yet on Windows
-	return idtools.IDPair{0, 0}, nil
+	return idtools.Identity{}, nil
 }
 
 // chmodTarEntry is used to adjust the file permissions used in tar header based


### PR DESCRIPTION
This pull request fixes the following compile error, related to the changes in the docker library https://github.com/moby/moby/commit/b3e9f7b13b0f0c414fa6253e1f17a86b2cff68b5. The library added another field `SID` to `IDPair` and now it's not a pair so renamed to `Identity`. I confirmed that `make` passes.
```
# github.com/fsouza/go-dockerclient/internal/archive
internal/archive/archive.go:74:20: undefined: idtools.IDPair
```