### PR TITLE
Added registry token support for docker registry

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -32,6 +32,9 @@ type AuthConfiguration struct {
 	// see https://godoc.org/github.com/docker/docker/api/types#AuthConfig
 	// It can be used in place of password not in conjunction with it
 	IdentityToken string `json:"identitytoken,omitempty"`
+
+	// RegistryToken can be supplied with the registrytoken
+	RegistryToken string `json:"registrytoken,omitempty"`
 }
 
 // AuthConfigurations represents authentication options to use for the
@@ -50,6 +53,7 @@ type dockerConfig struct {
 	Auth          string `json:"auth"`
 	Email         string `json:"email"`
 	IdentityToken string `json:"identitytoken"`
+	RegistryToken string `json:"registrytoken"`
 }
 
 // NewAuthConfigurationsFromFile returns AuthConfigurations from a path containing JSON
@@ -162,6 +166,11 @@ func authConfigs(confs map[string]dockerConfig) (*AuthConfigurations, error) {
 			authConfig.IdentityToken = conf.IdentityToken
 		}
 
+		// if registrytoken provided then zero the password and set it
+		if conf.RegistryToken != "" {
+			authConfig.Password = ""
+			authConfig.RegistryToken = conf.RegistryToken
+		}
 		c.Configs[reg] = authConfig
 	}
 

--- a/auth_test.go
+++ b/auth_test.go
@@ -196,6 +196,27 @@ func TestAuthConfigIdentityToken(t *testing.T) {
 	}
 }
 
+func TestAuthConfigRegistryToken(t *testing.T) {
+	t.Parallel()
+	auth := base64.StdEncoding.EncodeToString([]byte("someuser:"))
+	read := strings.NewReader(fmt.Sprintf(`{"auths":{"docker.io":{"auth":"%s","registrytoken":"sometoken"}}}`, auth))
+	ac, err := NewAuthConfigurations(read)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c, ok := ac.Configs["docker.io"]
+	if !ok {
+		t.Error("NewAuthConfigurations: Expected Configs to contain docker.io")
+	}
+	if got, want := c.Username, "someuser"; got != want {
+		t.Errorf(`AuthConfigurations.Configs["docker.io"].Username: wrong result. Want %q. Got %q`, want, got)
+	}
+	if got, want := c.RegistryToken, "sometoken"; got != want {
+		t.Errorf(`AuthConfigurations.Configs["docker.io"].RegistryToken: wrong result. Want %q. Got %q`, want, got)
+	}
+}
+
 func TestAuthCheck(t *testing.T) {
 	t.Parallel()
 	fakeRT := &FakeRoundTripper{status: http.StatusOK}


### PR DESCRIPTION
Added RegistryToken field in the AuthConfiguration to use the bearer token based push/pull
https://github.com/moby/moby/blob/8e610b2b55bfd1bfa9436ab110d311f5e8a74dcb/api/types/auth.go