### PR TITLE
Add runtimes to info struct

### DIFF
--- a/misc.go
+++ b/misc.go
@@ -85,12 +85,21 @@ type DockerInfo struct {
 	Labels             []string
 	ServerVersion      string
 	ClusterStore       string
+	Runtimes           map[string]Runtime
 	ClusterAdvertise   string
 	Isolation          string
 	InitBinary         string
 	DefaultRuntime     string
 	LiveRestoreEnabled bool
 	Swarm              swarm.Info
+}
+
+// Runtime describes an OCI runtime
+//
+// for more information, see: https://dockr.ly/2NKM8qq
+type Runtime struct {
+	Path string
+	Args []string `json:"runtimeArgs"`
 }
 
 // PluginsInfo is a struct with the plugins registered with the docker daemon

--- a/misc_test.go
+++ b/misc_test.go
@@ -95,7 +95,19 @@ func TestInfo(t *testing.T) {
      	"name=apparmor",
      	"name=seccomp",
      	"profile=default"
-     ]
+     ],
+	 "Runtimes": {
+		"runc": {
+		  "path": "docker-runc"
+		},
+		"custom": {
+		  "path": "/usr/local/bin/my-oci-runtime",
+		  "runtimeArgs": [
+		    "--debug",
+		    "--systemd-cgroup=false"
+		    ]
+		  }
+	  }
 }`
 	fakeRT := FakeRoundTripper{message: body, status: http.StatusOK}
 	client := newTestClient(&fakeRT)
@@ -126,6 +138,18 @@ func TestInfo(t *testing.T) {
 			"name=apparmor",
 			"name=seccomp",
 			"profile=default",
+		},
+		Runtimes: map[string]Runtime{
+			"runc": {
+				Path: "docker-runc",
+			},
+			"custom": {
+				Path: "/usr/local/bin/my-oci-runtime",
+				Args: []string{
+					"--debug",
+					"--systemd-cgroup=false",
+				},
+			},
 		},
 	}
 	info, err := client.Info()


### PR DESCRIPTION
Adding runtimes from https://docs.docker.com/engine/api/v1.37/#operation/SystemInfo.

I generated the shortened URL using https://bitly.com as it looks like the google URL shortener service is being shuttered.