### PR TITLE
Surface io.Writer errors in jsonmessage

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -805,16 +805,11 @@ func TestClientStreamTimeoutNativeClient(t *testing.T) {
 	}
 }
 
-func TestClientStreamFailingOutputWriter(t *testing.T) {
+func TestClientStreamJSONDecoderFailingOutputWriter(t *testing.T) {
 	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		for i := 0; i < 5; i++ {
-			fmt.Fprintf(w, "%d\n", i)
-			if f, ok := w.(http.Flusher); ok {
-				f.Flush()
-			}
-			time.Sleep(500 * time.Millisecond)
-		}
+		fmt.Fprint(w, "{}")
+		time.Sleep(500 * time.Millisecond)
 	}))
 	client, err := NewClient(srv.URL)
 	if err != nil {
@@ -823,6 +818,7 @@ func TestClientStreamFailingOutputWriter(t *testing.T) {
 	var w eofWriter
 	err = client.stream("POST", "/image/create", streamOptions{
 		setRawTerminal: true,
+		useJSONDecoder: true,
 		stdout:         &w,
 	})
 	if err != io.EOF {


### PR DESCRIPTION
Errors returned from an `io.Writer` presented as output to `(*Client).BuildImage(...)` aren't being bubbled up when `RawJSONStream` is set to `false`. After doing a bit of digging, I found the `jsonmessage` package—[delegated to when handling a stream's HTTP response](https://github.com/fsouza/go-dockerclient/blob/623c4c4b51ec7507502197470dbfbcf77ae877b3/client.go#L649)—isn't surfacing errors that occur when writing.

In our situation, we have a writer that's entering a bad state and returning an error. However, because none of these errors are seen by the client, the client continues to attempt writes against the failing `io.Writer`—leading to some odd behavior.

This change adds some minor error handling so the client can deal with those errors.