### PR TITLE
allow memory swappiness to be set to 0

### DIFF
--- a/container.go
+++ b/container.go
@@ -754,7 +754,7 @@ type HostConfig struct {
 	MemoryReservation    int64                  `json:"MemoryReservation,omitempty" yaml:"MemoryReservation,omitempty" toml:"MemoryReservation,omitempty"`
 	KernelMemory         int64                  `json:"KernelMemory,omitempty" yaml:"KernelMemory,omitempty" toml:"KernelMemory,omitempty"`
 	MemorySwap           int64                  `json:"MemorySwap,omitempty" yaml:"MemorySwap,omitempty" toml:"MemorySwap,omitempty"`
-	MemorySwappiness     int64                  `json:"MemorySwappiness,omitempty" yaml:"MemorySwappiness,omitempty" toml:"MemorySwappiness,omitempty"`
+	MemorySwappiness     *int64                 `json:"MemorySwappiness,omitempty" yaml:"MemorySwappiness,omitempty" toml:"MemorySwappiness,omitempty"`
 	CPUShares            int64                  `json:"CpuShares,omitempty" yaml:"CpuShares,omitempty" toml:"CpuShares,omitempty"`
 	CPUSet               string                 `json:"Cpuset,omitempty" yaml:"Cpuset,omitempty" toml:"Cpuset,omitempty"`
 	CPUSetCPUs           string                 `json:"CpusetCpus,omitempty" yaml:"CpusetCpus,omitempty" toml:"CpusetCpus,omitempty"`


### PR DESCRIPTION
per: https://docs.docker.com/config/containers/resource_constraints/#--memory-swappiness-details

found when trying to set this value to 0, these bindings at present do not
allow it. the default behavior of this setting is to inherit the setting from
the host. in order to keep the default behavior of not sending in this value,
we need to allow sending in 'null' as well as 0, this is a fabled go issue and
omitempty with null is the way to accomplish this. this seems preferable to
not having an API change, removing omitempty and defaulting to turning this
off for everyone, as this is not the intended default. however, this is an API
change, though I suspect nobody tried to set it to 0 yet ;)

I've tested and this fixes the issue for me.

thank you!