### PR TITLE
add DriverOpts to EndpointConfig

### DIFF
--- a/network.go
+++ b/network.go
@@ -225,6 +225,7 @@ type EndpointConfig struct {
 	GlobalIPv6Address   string              `json:"GlobalIPv6Address,omitempty" yaml:"GlobalIPv6Address,omitempty" toml:"GlobalIPv6Address,omitempty"`
 	GlobalIPv6PrefixLen int                 `json:"GlobalIPv6PrefixLen,omitempty" yaml:"GlobalIPv6PrefixLen,omitempty" toml:"GlobalIPv6PrefixLen,omitempty"`
 	MacAddress          string              `json:"MacAddress,omitempty" yaml:"MacAddress,omitempty" toml:"MacAddress,omitempty"`
+	DriverOpts          map[string]string   `json:"DriverOpts,omitempty" yaml:"DriverOpts,omitempty" toml:"DriverOpts,omitempty"`
 }
 
 // EndpointIPAMConfig represents IPAM configurations for an


### PR DESCRIPTION
Docker API v 1.32 introduced `DriverOpts` to `EndpointConfig`, which is defined as:

>DriverOpts is a mapping of driver options and values. These options are passed directly to the driver and are driver specific.

see https://docs.docker.com/engine/api/v1.32/#operation/ContainerCreate

This PR adds `DriverOpts` field to `EndpointConfig` struct.