### PR TITLE
add configpath in auth

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -94,9 +94,11 @@ func cfgPaths(dockerConfigEnv string, homeEnv string) []string {
 	var paths []string
 	if dockerConfigEnv != "" {
 		paths = append(paths, path.Join(dockerConfigEnv, "config.json"))
+		paths = append(paths, path.Join(dockerConfigEnv, "plaintext-passwords.json"))
 	}
 	if homeEnv != "" {
 		paths = append(paths, path.Join(homeEnv, ".docker", "config.json"))
+		paths = append(paths, path.Join(homeEnv, ".docker", "plaintext-passwords.json"))
 		paths = append(paths, path.Join(homeEnv, ".dockercfg"))
 	}
 	return paths

--- a/auth_test.go
+++ b/auth_test.go
@@ -23,9 +23,9 @@ func TestAuthConfigurationSearchPath(t *testing.T) {
 		expectedPaths   []string
 	}{
 		{"", "", []string{}},
-		{"", "home", []string{path.Join("home", ".docker", "config.json"), path.Join("home", ".dockercfg")}},
+		{"", "home", []string{path.Join("home", ".docker", "config.json"), path.Join("home", ".docker", "plaintext-passwords.json"), path.Join("home", ".dockercfg")}},
 		{"docker_config", "", []string{path.Join("docker_config", "config.json")}},
-		{"a", "b", []string{path.Join("a", "config.json"), path.Join("b", ".docker", "config.json"), path.Join("b", ".dockercfg")}},
+		{"a", "b", []string{path.Join("a", "config.json"), path.Join("b", ".docker", "config.json"), path.Join("b", ".docker", "plaintext-passwords.json"), path.Join("b", ".dockercfg")}},
 	}
 	for _, tt := range testData {
 		tt := tt


### PR DESCRIPTION
**rationale** latest docker for mac release `2.1.X` introduced a breaking change in the way they store credentials in ~/.docker/, credentials are now stored in a different file named `plaintext-passwords.json`