### PR TITLE
reorder config files

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -93,12 +93,12 @@ func NewAuthConfigurationsFromFile(path string) (*AuthConfigurations, error) {
 func cfgPaths(dockerConfigEnv string, homeEnv string) []string {
 	var paths []string
 	if dockerConfigEnv != "" {
-		paths = append(paths, path.Join(dockerConfigEnv, "config.json"))
 		paths = append(paths, path.Join(dockerConfigEnv, "plaintext-passwords.json"))
+		paths = append(paths, path.Join(dockerConfigEnv, "config.json"))
 	}
 	if homeEnv != "" {
-		paths = append(paths, path.Join(homeEnv, ".docker", "config.json"))
 		paths = append(paths, path.Join(homeEnv, ".docker", "plaintext-passwords.json"))
+		paths = append(paths, path.Join(homeEnv, ".docker", "config.json"))
 		paths = append(paths, path.Join(homeEnv, ".dockercfg"))
 	}
 	return paths

--- a/auth_test.go
+++ b/auth_test.go
@@ -23,9 +23,9 @@ func TestAuthConfigurationSearchPath(t *testing.T) {
 		expectedPaths   []string
 	}{
 		{"", "", []string{}},
-		{"", "home", []string{path.Join("home", ".docker", "config.json"), path.Join("home", ".docker", "plaintext-passwords.json"), path.Join("home", ".dockercfg")}},
-		{"docker_config", "", []string{path.Join("docker_config", "config.json"), path.Join("docker_config", "plaintext-passwords.json")}},
-		{"a", "b", []string{path.Join("a", "config.json"),path.Join("a", "plaintext-passwords.json"), path.Join("b", ".docker", "config.json"),path.Join("b", ".docker", "plaintext-passwords.json"), path.Join("b", ".dockercfg")}},
+		{"", "home", []string{path.Join("home", ".docker", "plaintext-passwords.json"), path.Join("home", ".docker", "config.json"), path.Join("home", ".dockercfg")}},
+		{"docker_config", "", []string{path.Join("docker_config", "plaintext-passwords.json"),path.Join("docker_config", "config.json") }},
+		{"a", "b", []string{path.Join("a", "plaintext-passwords.json"),path.Join("a", "config.json"),path.Join("b", ".docker", "plaintext-passwords.json"), path.Join("b", ".docker", "config.json"), path.Join("b", ".dockercfg")}},
 	}
 	for _, tt := range testData {
 		tt := tt


### PR DESCRIPTION
**rationale** there's still an empty `auths` json block in `$HOME/.docker/config.json` in the newest docker version therefore `plaintext-passwords.json` needs to be parsed first otherwise it returns an empty auth.