### PR TITLE
base64 string without padding on docker for mac

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -170,9 +170,14 @@ func authConfigs(confs map[string]dockerConfig) (*AuthConfigurations, error) {
 		if conf.Auth == "" {
 			continue
 		}
+
+		// support both padded and unpadded encoding
 		data, err := base64.StdEncoding.DecodeString(conf.Auth)
 		if err != nil {
-			return nil, err
+			data, err = base64.StdEncoding.WithPadding(base64.NoPadding).DecodeString(conf.Auth)
+		}
+		if err != nil {
+			return nil, errors.New("error decoding plaintext credentials")
 		}
 
 		userpass := strings.SplitN(string(data), ":", 2)


### PR DESCRIPTION
**rationale** On docker for mac, the base64 string stored in `plaintext-passwords.json` has no padding. plus adds a clearer error when base64 decoding fails