### PR TITLE
Go 1.15 is out, let's use that in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,8 +14,8 @@ jobs:
     strategy:
       matrix:
         go_version:
-          - 1.13
           - 1.14
+          - 1.15
         os:
           - macos
           - ubuntu

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,10 +40,6 @@ jobs:
 
       - run: go mod download
 
-      - run: make lint
-        env:
-          GOFLAGS: -mod=readonly
-
       - run: make gotest
         env:
           GOARCH: ${{ matrix.goarch }}
@@ -53,3 +49,8 @@ jobs:
         if: matrix.os != 'macos' && matrix.goarch == 'amd64'
         env:
           GOFLAGS: -mod=readonly
+
+  lint:
+    - uses: actions/checkout@v2.3.1
+
+    - uses: golangci/golangci-lint-action@v2.2.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,6 +51,9 @@ jobs:
           GOFLAGS: -mod=readonly
 
   lint:
-    - uses: actions/checkout@v2.3.1
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.1
 
-    - uses: golangci/golangci-lint-action@v2.2.0
+      - uses: golangci/golangci-lint-action@v2.2.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fsouza/go-dockerclient
 
-go 1.13
+go 1.14
 
 require (
 	github.com/Microsoft/go-winio v0.4.15-0.20200113171025-3fe6c5262873


### PR DESCRIPTION
Also mark minimal version of go.mod as Go 1.14 since Go 1.13 is gone.