### PR TITLE
Args type for filters

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -366,6 +366,9 @@ func TestQueryString(t *testing.T) {
 	v := float32(2.4)
 	f32QueryString := fmt.Sprintf("w=%s&x=10&y=10.35", strconv.FormatFloat(float64(v), 'f', -1, 64))
 	jsonPerson := url.QueryEscape(`{"Name":"gopher","age":4}`)
+	filters := NewArgs()
+	filters.Add("status", "paused")
+	filters.Add("status", "running")
 	tests := []struct {
 		input   interface{}
 		want    string
@@ -375,7 +378,7 @@ func TestQueryString(t *testing.T) {
 		{ListContainersOptions{All: true}, "all=1", nil},
 		{ListContainersOptions{Before: "something"}, "before=something", nil},
 		{ListContainersOptions{Before: "something", Since: "other"}, "before=something&since=other", nil},
-		{ListContainersOptions{Filters: map[string][]string{"status": {"paused", "running"}}}, "filters=%7B%22status%22%3A%5B%22paused%22%2C%22running%22%5D%7D", nil},
+		{ListContainersOptions{Filters: filters}, "filters=%7B%22status%22%3A%5B%22paused%22%2C%22running%22%5D%7D", nil},
 		{dumb{X: 10, Y: 10.35000}, "x=10&y=10.35", apiVersion119},
 		{dumb{W: v, X: 10, Y: 10.35000}, f32QueryString, apiVersion124},
 		{dumb{X: 10, Y: 10.35000, Z: 10}, "x=10&y=10.35&zee=10", apiVersion119},

--- a/container_list.go
+++ b/container_list.go
@@ -15,7 +15,7 @@ type ListContainersOptions struct {
 	Limit   int
 	Since   string
 	Before  string
-	Filters map[string][]string
+	Filters Args
 	Context context.Context
 }
 

--- a/container_list_test.go
+++ b/container_list_test.go
@@ -73,12 +73,12 @@ func TestListContainersParams(t *testing.T) {
 			map[string][]string{"all": {"1"}, "limit": {"10"}, "since": {"adf9983"}, "before": {"abdeef"}},
 		},
 		{
-			ListContainersOptions{Filters: map[string][]string{"status": {"paused", "running"}}},
-			map[string][]string{"filters": {"{\"status\":[\"paused\",\"running\"]}"}},
+			ListContainersOptions{Filters: Args{"status": {"paused", "running"}}},
+			Args{"filters": {"{\"status\":[\"paused\",\"running\"]}"}},
 		},
 		{
-			ListContainersOptions{All: true, Filters: map[string][]string{"exited": {"0"}, "status": {"exited"}}},
-			map[string][]string{"all": {"1"}, "filters": {"{\"exited\":[\"0\"],\"status\":[\"exited\"]}"}},
+			ListContainersOptions{All: true, Filters: Args{"exited": {"0"}, "status": {"exited"}}},
+			Args{"all": {"1"}, "filters": {"{\"exited\":[\"0\"],\"status\":[\"exited\"]}"}},
 		},
 	}
 	const expectedPath = "/containers/json"

--- a/container_prune.go
+++ b/container_prune.go
@@ -10,7 +10,7 @@ import (
 //
 // See https://goo.gl/wnkgDT for more details.
 type PruneContainersOptions struct {
-	Filters map[string][]string
+	Filters Args
 	Context context.Context
 }
 

--- a/filters.go
+++ b/filters.go
@@ -1,0 +1,16 @@
+package docker
+
+// Filter Arguments
+// Use NewArgs() and Add(key, val) to populate
+type Args map[string][]string
+
+// NewArgs returns a new Args populated with the initial args
+func NewArgs() Args {
+	args := Args{}
+	return args
+}
+
+func (args Args) Add(key, value string) {
+	vals := args[key]
+	args[key] = append(vals, value)
+}

--- a/filters.go
+++ b/filters.go
@@ -1,5 +1,7 @@
 package docker
 
+import "encoding/json"
+
 // Filter Arguments
 // Use NewArgs() and Add(key, val) to populate
 type Args map[string][]string
@@ -13,4 +15,17 @@ func NewArgs() Args {
 func (args Args) Add(key, value string) {
 	vals := args[key]
 	args[key] = append(vals, value)
+}
+
+func (args Args) Len() int {
+	return len(args)
+}
+
+// ToJSON returns the Args as a JSON encoded string
+func (args Args) ToJSON() string {
+	if args.Len() == 0 {
+		return ""
+	}
+	buf, _ := json.Marshal(args)
+	return string(buf)
 }

--- a/filters_test.go
+++ b/filters_test.go
@@ -1,0 +1,29 @@
+// Copyright 2020 go-dockerclient authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package docker
+
+import (
+	"testing"
+)
+
+func TestArgs(t *testing.T) {
+	t.Parallel()
+	filters := NewArgs()
+	serialized := filters.ToJSON()
+	if serialized != "" {
+		t.Errorf("Incorrectly serialized %s", serialized)
+	}
+	filters.Add("status", "paused")
+	filters.Add("status", "running")
+	length := filters.Len()
+	if length != 1 {
+		t.Errorf("Incorrect length %d", length)
+	}
+
+	serialized = filters.ToJSON()
+	if serialized != "{\"status\":[\"paused\",\"running\"]}" {
+		t.Errorf("Incorrectly serialized %s", serialized)
+	}
+}

--- a/image.go
+++ b/image.go
@@ -731,7 +731,7 @@ func (c *Client) SearchImagesEx(term string, auth AuthConfiguration) ([]APIImage
 //
 // See https://goo.gl/qfZlbZ for more details.
 type PruneImagesOptions struct {
-	Filters map[string][]string
+	Filters Args
 	Context context.Context
 }
 

--- a/image_test.go
+++ b/image_test.go
@@ -129,7 +129,7 @@ func TestListImagesParameters(t *testing.T) {
 		t.Errorf("ListImages({All: true}): Wrong parameter. Want all=1. Got all=%s", all)
 	}
 	fakeRT.Reset()
-	_, err = client.ListImages(ListImagesOptions{Filters: map[string][]string{
+	_, err = client.ListImages(ListImagesOptions{Filters: Args{
 		"dangling": {"true"},
 	}})
 	if err != nil {
@@ -137,7 +137,7 @@ func TestListImagesParameters(t *testing.T) {
 	}
 	req = fakeRT.requests[0]
 	body := req.URL.Query().Get("filters")
-	var filters map[string][]string
+	var filters Args
 	err = json.Unmarshal([]byte(body), &filters)
 	if err != nil {
 		t.Fatal(err)

--- a/network.go
+++ b/network.go
@@ -291,7 +291,7 @@ func (c *Client) DisconnectNetwork(id string, opts NetworkConnectionOptions) err
 //
 // See https://goo.gl/kX0S9h for more details.
 type PruneNetworksOptions struct {
-	Filters map[string][]string
+	Filters Args
 	Context context.Context
 }
 

--- a/plugin.go
+++ b/plugin.go
@@ -182,7 +182,7 @@ func (c *Client) ListPlugins(ctx context.Context) ([]PluginDetail, error) {
 //
 // See https://goo.gl/C4t7Tz for more details.
 type ListFilteredPluginsOptions struct {
-	Filters map[string][]string
+	Filters Args
 	Context context.Context
 }
 

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -141,7 +141,7 @@ func TestListFilteredPlugins(t *testing.T) {
 
 	pluginDetails, err := client.ListFilteredPlugins(
 		ListFilteredPluginsOptions{
-			Filters: map[string][]string{
+			Filters: Args{
 				"capability": {"volumedriver"},
 				"enabled":    {"true"},
 			},

--- a/swarm_configs.go
+++ b/swarm_configs.go
@@ -153,7 +153,7 @@ func (c *Client) InspectConfig(id string) (*swarm.Config, error) {
 //
 // See https://goo.gl/DwvNMd for more details.
 type ListConfigsOptions struct {
-	Filters map[string][]string
+	Filters Args
 	Context context.Context
 }
 

--- a/swarm_node.go
+++ b/swarm_node.go
@@ -32,7 +32,7 @@ func (err *NoSuchNode) Error() string {
 //
 // See http://goo.gl/3K4GwU for more details.
 type ListNodesOptions struct {
-	Filters map[string][]string
+	Filters Args
 	Context context.Context
 }
 

--- a/swarm_secrets.go
+++ b/swarm_secrets.go
@@ -153,7 +153,7 @@ func (c *Client) InspectSecret(id string) (*swarm.Secret, error) {
 //
 // See https://goo.gl/DwvNMd for more details.
 type ListSecretsOptions struct {
-	Filters map[string][]string
+	Filters Args
 	Context context.Context
 }
 

--- a/swarm_service.go
+++ b/swarm_service.go
@@ -150,7 +150,7 @@ func (c *Client) InspectService(id string) (*swarm.Service, error) {
 //
 // See https://goo.gl/DwvNMd for more details.
 type ListServicesOptions struct {
-	Filters map[string][]string
+	Filters Args
 	Status  bool
 	Context context.Context
 }

--- a/swarm_task.go
+++ b/swarm_task.go
@@ -30,7 +30,7 @@ func (err *NoSuchTask) Error() string {
 //
 // See http://goo.gl/rByLzw for more details.
 type ListTasksOptions struct {
-	Filters map[string][]string
+	Filters Args
 	Context context.Context
 }
 

--- a/volume.go
+++ b/volume.go
@@ -36,7 +36,7 @@ type Volume struct {
 //
 // See https://goo.gl/3wgTsd for more details.
 type ListVolumesOptions struct {
-	Filters map[string][]string
+	Filters Args
 	Context context.Context
 }
 
@@ -164,7 +164,7 @@ func (c *Client) RemoveVolumeWithOptions(opts RemoveVolumeOptions) error {
 //
 // See https://goo.gl/f9XDem for more details.
 type PruneVolumesOptions struct {
-	Filters map[string][]string
+	Filters Args
 	Context context.Context
 }
 


### PR DESCRIPTION
The Args type is similar to [filters.Args](https://github.com/moby/moby/blob/c9b2a3cff51a6403f4eac319af5a794b0dbdeba4/api/types/filters/parse.go) type from official Docker client.
It also provides constructor NewArgs() and method Add().
This can make migration to official docker client easier and reuse familiar concept
