### PR TITLE
ServerAPIVersion needs to be set in Client.CreateExec()

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -44,6 +44,9 @@ type CreateExecOptions struct {
 //
 // See https://goo.gl/60TeBP for more details
 func (c *Client) CreateExec(opts CreateExecOptions) (*Exec, error) {
+	if c.serverAPIVersion == nil {
+		c.checkAPIVersion()
+	}
 	if len(opts.Env) > 0 && c.serverAPIVersion.LessThan(apiVersion125) {
 		return nil, errors.New("exec configuration Env is only supported in API#1.25 and above")
 	}


### PR DESCRIPTION
`c.checkAPIVersion()` may not have been called before the client is used in CreateExec(), and thus there's no ServerApiVersion, so the version checks go all wrong.
