### PR TITLE
auth: add AuthCheckWithContext method

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -6,6 +6,7 @@ package docker
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -262,11 +263,21 @@ type AuthStatus struct {
 //
 // See https://goo.gl/6nsZkH for more details.
 func (c *Client) AuthCheck(conf *AuthConfiguration) (AuthStatus, error) {
+	return c.AuthCheckWithContext(conf, context.TODO())
+}
+
+// AuthCheckWithContext validates the given credentials. It returns nil if successful. The context object
+// can be used to cancel the request.
+//
+// For Docker API versions >= 1.23, the AuthStatus struct will be populated, otherwise it will be empty.
+//
+// See https://goo.gl/6nsZkH for more details.
+func (c *Client) AuthCheckWithContext(conf *AuthConfiguration, ctx context.Context) (AuthStatus, error) {
 	var authStatus AuthStatus
 	if conf == nil {
 		return authStatus, errors.New("conf is nil")
 	}
-	resp, err := c.do(http.MethodPost, "/auth", doOptions{data: conf})
+	resp, err := c.do(http.MethodPost, "/auth", doOptions{data: conf, context: ctx})
 	if err != nil {
 		return authStatus, err
 	}


### PR DESCRIPTION
This PR closes https://github.com/fsouza/go-dockerclient/issues/887 by adding an `AuthCheckWithContext` method and adjusts the existing `AuthCheck` method to use it.