### PR TITLE
Use Go 1.20 in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3.5.0
         with:
-          go-version: 1.19
+          go-version: "1.20"
 
       - uses: actions/checkout@v3.3.0
 
@@ -36,8 +36,8 @@ jobs:
     strategy:
       matrix:
         go_version:
-          - 1.18
           - 1.19
+          - "1.20"
         os:
           - macos
           - ubuntu
@@ -62,7 +62,7 @@ jobs:
       - run: go mod download
 
       - run: make staticcheck
-        if: matrix.go_version == '1.19'
+        if: matrix.go_version == '1.20'
 
       - run: make gotest
         env:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fsouza/go-dockerclient
 
-go 1.18
+go 1.19
 
 require (
 	github.com/Microsoft/go-winio v0.6.0


### PR DESCRIPTION
Also set the minimum version in go.mod to Go 1.19 now that Go 1.18 is unsupported.