### PR TITLE
github/workflows/main: add cross compilation targets for arm64

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,8 +18,11 @@ jobs:
           - freebsd
           - linux
           - windows
+        goarch:
+          - amd64
+          - arm64
 
-    name: cross-compilation (GOOS=${{ matrix.goos }})
+    name: cross-compilation (GOOS=${{ matrix.goos }}, GOARCH=${{ matrix.goarch }})
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-go@v3.5.0
@@ -31,6 +34,7 @@ jobs:
       - run: go build
         env:
           GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
 
   test:
     strategy:


### PR DESCRIPTION
GitHub Actions doesn't offer hosted nodes with arm64 yet, so we can't run tests, but let's at least try to compile it (similar to freebsd).