### PR TITLE
github/workflows/main: run checkout before setup-go

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,11 +25,11 @@ jobs:
     name: cross-compilation (GOOS=${{ matrix.goos }}, GOARCH=${{ matrix.goarch }})
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3.5.2
+
       - uses: actions/setup-go@v4.0.0
         with:
           go-version: "1.20"
-
-      - uses: actions/checkout@v3.5.2
 
       - run: go build
         env:
@@ -56,12 +56,12 @@ jobs:
     name: tests (${{ matrix.os }}/go-${{ matrix.go-version }}/${{ matrix.goarch }})
     runs-on: ${{ matrix.os }}-latest
     steps:
+      - uses: actions/checkout@v3.5.2
+
       - uses: actions/setup-go@v4.0.0
         id: go
         with:
           go-version: ${{ matrix.go-version }}
-
-      - uses: actions/checkout@v3.5.2
 
       - run: go mod download
 
@@ -83,12 +83,12 @@ jobs:
     name: integration tests (${{ matrix.os }})
     runs-on: ${{ matrix.os }}-latest
     steps:
+      - uses: actions/checkout@v3.5.2
+
       - uses: actions/setup-go@v4.0.0
         id: go
         with:
           go-version: "1.20"
-
-      - uses: actions/checkout@v3.5.2
 
       - run: make integration
 


### PR DESCRIPTION
This should fix caching for `actions/setup-go` and all the warnings in CI.