### PR TITLE
Drop Go 1.19

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: actions/setup-go@v4.0.1
         with:
-          go-version: "1.20"
+          go-version: "1.x"
 
       - run: go build
         env:
@@ -40,9 +40,8 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - 1.19
           - "1.20"
-          - "1.21.0-rc.2"
+          - "1.21"
         os:
           - macos
           - ubuntu
@@ -67,7 +66,7 @@ jobs:
       - run: go mod download
 
       - run: make staticcheck
-        if: matrix.go-version == '1.20'
+        if: matrix.go-version == '1.21'
 
       - run: make gotest
         env:
@@ -89,7 +88,7 @@ jobs:
       - uses: actions/setup-go@v4.0.1
         id: go
         with:
-          go-version: "1.20"
+          go-version: "1.x"
 
       - run: make integration
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fsouza/go-dockerclient
 
-go 1.19
+go 1.20
 
 require (
 	github.com/Microsoft/go-winio v0.6.1


### PR DESCRIPTION
Also update CI config to use the final release of Go 1.21.