### PR TITLE
feat: add platform parameter to container create

### DIFF
--- a/container_create.go
+++ b/container_create.go
@@ -17,6 +17,7 @@ var ErrContainerAlreadyExists = errors.New("container already exists")
 // See https://goo.gl/tyzwVM for more details.
 type CreateContainerOptions struct {
 	Name             string
+	Platform         string
 	Config           *Config           `qs:"-"`
 	HostConfig       *HostConfig       `qs:"-"`
 	NetworkingConfig *NetworkingConfig `qs:"-"`

--- a/container_create_test.go
+++ b/container_create_test.go
@@ -127,3 +127,20 @@ func TestPassingNameOptToCreateContainerReturnsItInContainer(t *testing.T) {
 		t.Errorf("Container name expected to be TestCreateContainer, was %s", container.Name)
 	}
 }
+
+func TestPassingPlatformOpt(t *testing.T) {
+	t.Parallel()
+	fakeRT := &FakeRoundTripper{message: "{}", status: http.StatusOK}
+	client := newTestClient(fakeRT)
+	config := Config{}
+	opts := CreateContainerOptions{Name: "TestCreateContainerWithPlatform", Platform: "darwin/arm64", Config: &config}
+	_, err := client.CreateContainer(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := fakeRT.requests[0]
+	gotQs := req.URL.Query().Get("platform")
+	if gotQs != "darwin/arm64" {
+		t.Errorf("CreateContainer: missing expected platform query string (%v)", req.URL.RequestURI())
+	}
+}


### PR DESCRIPTION
Hi there :wave:! Hoping to add the `platform` query string to `/containers/create` API to support creating containers from a multi-platform image. If it's useful to add this into other APIs, I'd be happy to add it there as well.

Related: https://github.com/GoogleContainerTools/container-structure-test/issues/373