### PR TITLE
[testing/server] return container labels when listing containers

### DIFF
--- a/testing/server.go
+++ b/testing/server.go
@@ -433,6 +433,7 @@ loop:
 				State:   container.State.StateString(),
 				Ports:   ports,
 				Names:   []string{fmt.Sprintf("/%s", container.Name)},
+				Labels:  container.Config.Labels,
 			})
 		}
 	}

--- a/testing/server_test.go
+++ b/testing/server_test.go
@@ -207,6 +207,7 @@ func TestListContainers(t *testing.T) {
 			Ports:   container.NetworkSettings.PortMappingAPI(),
 			Names:   []string{"/" + container.Name},
 			State:   container.State.StateString(),
+			Labels:  map[string]string{"key": fmt.Sprintf("val-%d", i)},
 		}
 	}
 	sortFn := func(left, right docker.APIContainers) int {
@@ -220,7 +221,7 @@ func TestListContainers(t *testing.T) {
 	}
 	slices.SortFunc(got, sortFn)
 	if !reflect.DeepEqual(got, expected) {
-		t.Errorf("ListContainers. Want %#v. Got %#v.", expected, got)
+		t.Errorf("ListContainers.\nWant %#v.\nGot  %#v.", expected, got)
 	}
 }
 


### PR DESCRIPTION
Testing server behavior is currently different from the actual server when listing containers.

When listing containers on a testing server labels map is always `nil` and the additional call is needed to `inspectContainer`, however, this is not the case on the actual docker server.

This PR sets labels for the listed container to fix that.