### PR TITLE
Use nanoserver for integration tests on Windows

### DIFF
--- a/integration_windows_test.go
+++ b/integration_windows_test.go
@@ -6,13 +6,13 @@
 
 package docker
 
-const integrationDockerImage = "mcr.microsoft.com/windows/servercore:ltsc2022"
+const integrationDockerImage = "mcr.microsoft.com/windows/nanoserver:ltsc2022"
 
 func integrationCreateContainerOpts(imageName string, hostConfig *HostConfig) CreateContainerOptions {
 	return CreateContainerOptions{
 		Config: &Config{
 			Image: imageName,
-			Cmd:   []string{"powershell", "-Command", `Write-Host "hello hello"`},
+			Cmd:   []string{"cmd", "/S", "/C", "echo hello hello"},
 		},
 		HostConfig: hostConfig,
 	}


### PR DESCRIPTION
nanoserver is smaller, but doesn't have powershell. We don't really care though.

Let's see if this makes things faster.