### PR TITLE
fix:make sure event chan consume quickly to prevent deadlock

### DIFF
--- a/event.go
+++ b/event.go
@@ -271,11 +271,15 @@ func (eventState *eventMonitoringState) monitorEvents(c *Client, opts EventsOpti
 				return
 			}
 			if ev == EOFEvent {
-				eventState.disableEventMonitoring()
+				go func() {
+					eventState.disableEventMonitoring()
+				}()
 				return
 			}
-			eventState.updateLastSeen(ev)
-			eventState.sendEvent(ev)
+			go func() {
+				eventState.updateLastSeen(ev)
+				eventState.sendEvent(ev)
+			}()
 		case err = <-eventState.errC:
 			if errors.Is(err, ErrNoListeners) {
 				eventState.disableEventMonitoring()

--- a/event.go
+++ b/event.go
@@ -271,15 +271,13 @@ func (eventState *eventMonitoringState) monitorEvents(c *Client, opts EventsOpti
 				return
 			}
 			if ev == EOFEvent {
-				go func() {
-					eventState.disableEventMonitoring()
-				}()
+				go eventState.disableEventMonitoring()
 				return
 			}
-			go func() {
+			go func(ev *APIEvents) {
 				eventState.updateLastSeen(ev)
 				eventState.sendEvent(ev)
-			}()
+			}(ev)
 		case err = <-eventState.errC:
 			if errors.Is(err, ErrNoListeners) {
 				eventState.disableEventMonitoring()

--- a/event_test.go
+++ b/event_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -267,10 +268,15 @@ loop:
 			t.Fatalf("%s: timed out waiting on events after %d events", testName, i)
 		}
 	}
-	cmpr := cmp.Comparer(func(e1, e2 APIEvents) bool {
+	cmpInt := func(e1, e2 APIEvents) int {
+		return int(e1.TimeNano - e2.TimeNano)
+	}
+	slices.SortFunc(events, cmpInt)
+	slices.SortFunc(wantedEvents, cmpInt)
+	cmpEqual := cmp.Comparer(func(e1, e2 APIEvents) bool {
 		return e1.Action == e2.Action && e1.Actor.ID == e2.Actor.ID
 	})
-	if dff := cmp.Diff(events, wantedEvents, cmpr); dff != "" {
+	if dff := cmp.Diff(events, wantedEvents, cmpEqual); dff != "" {
 		t.Errorf("wrong events:\n%s", dff)
 	}
 }


### PR DESCRIPTION
I find a dead lock 
```
goroutine 62 [chan send, 10621 minutes]:
github.com/fsouza/go-dockerclient.(*Client).eventHijack.func1(0xc00018c0c0?, 0xc00019a090?)
         github.com/fsouza/go-dockerclient/event.go:353 +0x265
created by github.com/fsouza/go-dockerclient.(*Client).eventHijack
         github.com/fsouza/go-dockerclient/event.go:329 +0x42b

goroutine 19 [sync.RWMutex.Lock, 10621 minutes]:
sync.runtime_SemacquireRWMutex(0xc00018c480?, 0x40?, 0xc00037df20?)
        /usr/local/go/src/runtime/sema.go:87 +0x26
sync.(*RWMutex).Lock(0x5f5e100?)
        /usr/local/go/src/sync/rwmutex.go:152 +0x71
github.com/fsouza/go-dockerclient.(*eventMonitoringState).updateLastSeen(0xc00018c0c0, 0xc0001f5400)
         github.com/fsouza/go-dockerclient/event.go:288 +0x46
github.com/fsouza/go-dockerclient.(*eventMonitoringState).monitorEvents(0xc00018c0c0, 0xc00019a090)
         github.com/fsouza/go-dockerclient/event.go:219 +0x1c5
created by github.com/fsouza/go-dockerclient.(*eventMonitoringState).enableEventMonitoring
         github.com/fsouza/go-dockerclient/event.go:177 +0x159
```
@fsouza 