### PR TITLE
ImportImageOptions: add Platform field for cross-arch image import

### DIFF
--- a/image.go
+++ b/image.go
@@ -443,6 +443,7 @@ type ImportImageOptions struct {
 	Repository string `qs:"repo"`
 	Source     string `qs:"fromSrc"`
 	Tag        string `qs:"tag"`
+	Platform   string `qs:"platform" ver:"1.32"`
 
 	InputStream       io.Reader     `qs:"-"`
 	OutputStream      io.Writer     `qs:"-"`


### PR DESCRIPTION
PullImageOptions and BuildImageOptions already expose this field.

I need this to add multi-arch support to https://github.com/involucro/involucro and by extension mulled and bioconda. The lack of this currently causes unnecessary caveat when it comes to supporting different CPU architectures. 