### PR TITLE
Add docker CLI contexts support to NewClientFromEnv

### DIFF
--- a/client.go
+++ b/client.go
@@ -262,6 +262,10 @@ func NewVersionedTLSClient(endpoint string, cert, key, ca, apiVersionString stri
 // Docker's default logic for the environment variables DOCKER_HOST, DOCKER_TLS_VERIFY, DOCKER_CERT_PATH,
 // and DOCKER_API_VERSION.
 //
+// When DOCKER_HOST is unset, the host is resolved from the active docker CLI
+// context (DOCKER_CONTEXT, or the currentContext field of
+// $DOCKER_CONFIG/config.json), matching the docker CLI's behavior.
+//
 // See https://github.com/docker/docker/blob/1f963af697e8df3a78217f6fdbf67b8123a7db94/docker/docker.go#L68.
 // See https://github.com/docker/compose/blob/81707ef1ad94403789166d2fe042c8a718a4c748/compose/cli/docker_client.py#L7.
 // See https://github.com/moby/moby/blob/28d7dba41d0c0d9c7f0dafcc79d3c59f2b3f5dc3/client/options.go#L51
@@ -279,9 +283,24 @@ func NewClientFromEnv() (*Client, error) {
 // Docker's default logic for the environment variables DOCKER_HOST, DOCKER_TLS_VERIFY, and DOCKER_CERT_PATH,
 // and using a specific remote API version.
 //
+// When DOCKER_HOST is unset, the host is resolved from the active docker CLI
+// context (DOCKER_CONTEXT, or the currentContext field of
+// $DOCKER_CONFIG/config.json), matching the docker CLI's behavior.
+//
 // See https://github.com/docker/docker/blob/1f963af697e8df3a78217f6fdbf67b8123a7db94/docker/docker.go#L68.
 // See https://github.com/docker/compose/blob/81707ef1ad94403789166d2fe042c8a718a4c748/compose/cli/docker_client.py#L7.
 func NewVersionedClientFromEnv(apiVersionString string) (*Client, error) {
+	// DOCKER_HOST takes precedence over contexts in the docker CLI, so only
+	// look at contexts when it is unset.
+	if os.Getenv("DOCKER_HOST") == "" {
+		name, err := currentContextName()
+		if err != nil {
+			return nil, err
+		}
+		if name != "" && name != defaultContextName {
+			return NewVersionedContextClient(name, apiVersionString)
+		}
+	}
 	dockerEnv, err := getDockerEnv()
 	if err != nil {
 		return nil, err

--- a/context.go
+++ b/context.go
@@ -1,0 +1,220 @@
+// Copyright 2026 go-dockerclient authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package docker
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	// defaultContextName is the reserved name docker CLI uses for the
+	// implicit context (DOCKER_HOST / default socket).
+	defaultContextName = "default"
+
+	// contextDockerEndpoint is the key under Endpoints in a context's
+	// meta.json that holds the docker engine endpoint.
+	contextDockerEndpoint = "docker"
+)
+
+// contextMeta mirrors the JSON written by docker CLI in
+// $DOCKER_CONFIG/contexts/meta/<id>/meta.json.
+type contextMeta struct {
+	Name      string                         `json:"Name"`
+	Metadata  map[string]any                 `json:"Metadata"`
+	Endpoints map[string]contextMetaEndpoint `json:"Endpoints"`
+}
+
+type contextMetaEndpoint struct {
+	Host          string `json:"Host"`
+	SkipTLSVerify bool   `json:"SkipTLSVerify"`
+}
+
+type dockerConfigJSON struct {
+	CurrentContext string `json:"currentContext"`
+}
+
+type contextTLSData struct {
+	CA   []byte
+	Cert []byte
+	Key  []byte
+}
+
+// resolvedContext is the resolved view of a docker CLI context: a host plus
+// optional TLS material loaded from $DOCKER_CONFIG/contexts/tls/<id>/docker.
+type resolvedContext struct {
+	Name    string
+	Host    string
+	TLSData *contextTLSData
+}
+
+// dockerConfigDir returns the docker CLI config directory, honoring
+// DOCKER_CONFIG and falling back to ~/.docker.
+func dockerConfigDir() (string, error) {
+	if dir := os.Getenv("DOCKER_CONFIG"); dir != "" {
+		return dir, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	if home == "" {
+		return "", errors.New("could not determine docker config dir: HOME is not set")
+	}
+	return filepath.Join(home, ".docker"), nil
+}
+
+// currentContextName returns the context name docker CLI would use when
+// DOCKER_HOST is unset. It honors DOCKER_CONTEXT first, then the
+// currentContext field of config.json, and falls back to "default".
+func currentContextName() (string, error) {
+	if name := os.Getenv("DOCKER_CONTEXT"); name != "" {
+		return name, nil
+	}
+	dir, err := dockerConfigDir()
+	if err != nil {
+		return "", err
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "config.json"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return defaultContextName, nil
+		}
+		return "", err
+	}
+	var cfg dockerConfigJSON
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return "", fmt.Errorf("invalid docker config file: %w", err)
+	}
+	if cfg.CurrentContext == "" {
+		return defaultContextName, nil
+	}
+	return cfg.CurrentContext, nil
+}
+
+// contextDirID returns the directory name docker CLI uses to store a
+// context's metadata and TLS data: the hex-encoded sha256 of the name.
+func contextDirID(name string) string {
+	sum := sha256.Sum256([]byte(name))
+	return hex.EncodeToString(sum[:])
+}
+
+// loadContext loads the docker CLI context with the given name. The reserved
+// name "default" (and the empty string) resolve to the platform default host
+// without consulting any files on disk.
+func loadContext(name string) (*resolvedContext, error) {
+	if name == "" || name == defaultContextName {
+		return &resolvedContext{Name: defaultContextName, Host: defaultHost}, nil
+	}
+	dir, err := dockerConfigDir()
+	if err != nil {
+		return nil, err
+	}
+	id := contextDirID(name)
+	metaPath := filepath.Join(dir, "contexts", "meta", id, "meta.json")
+	data, err := os.ReadFile(metaPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("docker context %q not found", name)
+		}
+		return nil, err
+	}
+	var meta contextMeta
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return nil, fmt.Errorf("invalid metadata for docker context %q: %w", name, err)
+	}
+	ep, ok := meta.Endpoints[contextDockerEndpoint]
+	if !ok {
+		return nil, fmt.Errorf("docker context %q has no %q endpoint", name, contextDockerEndpoint)
+	}
+	if ep.Host == "" {
+		return nil, fmt.Errorf("docker context %q has an empty host", name)
+	}
+	if strings.HasPrefix(ep.Host, "ssh://") {
+		return nil, fmt.Errorf("docker context %q uses an ssh:// endpoint, which is not supported by go-dockerclient", name)
+	}
+	tlsDir := filepath.Join(dir, "contexts", "tls", id, contextDockerEndpoint)
+	tlsData, err := loadContextTLSData(tlsDir)
+	if err != nil {
+		return nil, fmt.Errorf("loading TLS data for docker context %q: %w", name, err)
+	}
+	return &resolvedContext{Name: name, Host: ep.Host, TLSData: tlsData}, nil
+}
+
+// loadContextTLSData reads ca.pem, cert.pem, and key.pem from dir. Missing
+// files are silently skipped — docker CLI itself allows partial TLS data, and
+// returning nil here means "no TLS for this context".
+func loadContextTLSData(dir string) (*contextTLSData, error) {
+	if _, err := os.Stat(dir); err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	out := &contextTLSData{}
+	entries := []struct {
+		name string
+		dst  *[]byte
+	}{
+		{"ca.pem", &out.CA},
+		{"cert.pem", &out.Cert},
+		{"key.pem", &out.Key},
+	}
+	for _, e := range entries {
+		b, err := os.ReadFile(filepath.Join(dir, e.name))
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, err
+		}
+		*e.dst = b
+	}
+	if out.CA == nil && out.Cert == nil && out.Key == nil {
+		return nil, nil
+	}
+	return out, nil
+}
+
+// NewContextClient returns a Client built from the named docker CLI context.
+// Pass "default" (or "") to use the platform default host. The named context
+// must already exist in $DOCKER_CONFIG/contexts (created via `docker context
+// create`).
+func NewContextClient(name string) (*Client, error) {
+	return NewVersionedContextClient(name, "")
+}
+
+// NewVersionedContextClient is like NewContextClient but pins the client to a
+// specific remote API version.
+func NewVersionedContextClient(name, apiVersionString string) (*Client, error) {
+	ctx, err := loadContext(name)
+	if err != nil {
+		return nil, err
+	}
+	return clientFromResolvedContext(ctx, apiVersionString)
+}
+
+func clientFromResolvedContext(ctx *resolvedContext, apiVersionString string) (*Client, error) {
+	var (
+		client *Client
+		err    error
+	)
+	if ctx.TLSData != nil {
+		client, err = NewVersionedTLSClientFromBytes(ctx.Host, ctx.TLSData.Cert, ctx.TLSData.Key, ctx.TLSData.CA, apiVersionString)
+	} else {
+		client, err = NewVersionedClient(ctx.Host, apiVersionString)
+	}
+	if err != nil {
+		return nil, err
+	}
+	client.SkipServerVersionCheck = apiVersionString == ""
+	return client, nil
+}

--- a/context_test.go
+++ b/context_test.go
@@ -1,0 +1,329 @@
+// Copyright 2026 go-dockerclient authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package docker
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeContext writes a docker CLI context with the given name and endpoint
+// host into dir, plus optional TLS files. It mirrors the on-disk layout
+// produced by `docker context create`.
+func writeContext(t *testing.T, dir, name, host string, tls *contextTLSData) {
+	t.Helper()
+	id := contextDirID(name)
+	metaDir := filepath.Join(dir, "contexts", "meta", id)
+	if err := os.MkdirAll(metaDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	meta := contextMeta{
+		Name: name,
+		Endpoints: map[string]contextMetaEndpoint{
+			contextDockerEndpoint: {Host: host},
+		},
+	}
+	data, err := json.Marshal(meta)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(metaDir, "meta.json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if tls == nil {
+		return
+	}
+	tlsDir := filepath.Join(dir, "contexts", "tls", id, contextDockerEndpoint)
+	if err := os.MkdirAll(tlsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if tls.CA != nil {
+		if err := os.WriteFile(filepath.Join(tlsDir, "ca.pem"), tls.CA, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if tls.Cert != nil {
+		if err := os.WriteFile(filepath.Join(tlsDir, "cert.pem"), tls.Cert, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if tls.Key != nil {
+		if err := os.WriteFile(filepath.Join(tlsDir, "key.pem"), tls.Key, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// writeConfigCurrentContext writes a docker config.json that selects name as
+// the current context.
+func writeConfigCurrentContext(t *testing.T, dir, name string) {
+	t.Helper()
+	data, err := json.Marshal(dockerConfigJSON{CurrentContext: name})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config.json"), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestContextDirIDIsSha256(t *testing.T) {
+	t.Parallel()
+	// Cross-check against the docker CLI's published value for "default".
+	// echo -n default | sha256sum
+	got := contextDirID("default")
+	want := "37a8eec1ce19687d132fe29051dca629d164e2c4958ba141d5f4133a33f0688f"
+	if got != want {
+		t.Errorf("contextDirID(%q) = %q, want %q", "default", got, want)
+	}
+}
+
+func TestLoadContext_Default(t *testing.T) {
+	t.Parallel()
+	ctx, err := loadContext("default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ctx.Host != defaultHost {
+		t.Errorf("default context host = %q, want %q", ctx.Host, defaultHost)
+	}
+	if ctx.TLSData != nil {
+		t.Errorf("default context should have no TLS data, got %+v", ctx.TLSData)
+	}
+}
+
+func TestLoadContext_FromDisk(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("DOCKER_CONFIG", dir)
+	writeContext(t, dir, "remote", "tcp://example.com:2375", nil)
+
+	ctx, err := loadContext("remote")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ctx.Host != "tcp://example.com:2375" {
+		t.Errorf("host = %q, want %q", ctx.Host, "tcp://example.com:2375")
+	}
+	if ctx.TLSData != nil {
+		t.Errorf("expected no TLS data, got %+v", ctx.TLSData)
+	}
+}
+
+func TestLoadContext_WithTLSData(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("DOCKER_CONFIG", dir)
+	ca := []byte("-----BEGIN CERTIFICATE-----\nca\n-----END CERTIFICATE-----\n")
+	cert := []byte("-----BEGIN CERTIFICATE-----\ncert\n-----END CERTIFICATE-----\n")
+	key := []byte("-----BEGIN RSA PRIVATE KEY-----\nkey\n-----END RSA PRIVATE KEY-----\n")
+	writeContext(t, dir, "secure", "tcp://secure.example.com:2376", &contextTLSData{
+		CA: ca, Cert: cert, Key: key,
+	})
+
+	ctx, err := loadContext("secure")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ctx.TLSData == nil {
+		t.Fatal("expected TLS data, got nil")
+	}
+	if string(ctx.TLSData.CA) != string(ca) {
+		t.Error("ca mismatch")
+	}
+	if string(ctx.TLSData.Cert) != string(cert) {
+		t.Error("cert mismatch")
+	}
+	if string(ctx.TLSData.Key) != string(key) {
+		t.Error("key mismatch")
+	}
+}
+
+func TestLoadContext_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("DOCKER_CONFIG", dir)
+	_, err := loadContext("missing")
+	if err == nil {
+		t.Fatal("expected error for missing context, got nil")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected 'not found' error, got %q", err)
+	}
+}
+
+func TestLoadContext_SSHIsRejected(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("DOCKER_CONFIG", dir)
+	writeContext(t, dir, "ssh-ctx", "ssh://user@host", nil)
+	_, err := loadContext("ssh-ctx")
+	if err == nil {
+		t.Fatal("expected error for ssh:// context, got nil")
+	}
+	if !strings.Contains(err.Error(), "ssh://") {
+		t.Errorf("error should mention ssh://, got %q", err)
+	}
+}
+
+func TestCurrentContextName_DOCKER_CONTEXT_wins(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("DOCKER_CONFIG", dir)
+	writeConfigCurrentContext(t, dir, "from-config")
+	t.Setenv("DOCKER_CONTEXT", "from-env")
+
+	name, err := currentContextName()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if name != "from-env" {
+		t.Errorf("got %q, want %q", name, "from-env")
+	}
+}
+
+func TestCurrentContextName_FromConfig(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("DOCKER_CONFIG", dir)
+	t.Setenv("DOCKER_CONTEXT", "")
+	writeConfigCurrentContext(t, dir, "from-config")
+
+	name, err := currentContextName()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if name != "from-config" {
+		t.Errorf("got %q, want %q", name, "from-config")
+	}
+}
+
+func TestCurrentContextName_NoConfig(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("DOCKER_CONFIG", dir)
+	t.Setenv("DOCKER_CONTEXT", "")
+
+	name, err := currentContextName()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if name != defaultContextName {
+		t.Errorf("got %q, want %q", name, defaultContextName)
+	}
+}
+
+func TestNewContextClient(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("DOCKER_CONFIG", dir)
+	writeContext(t, dir, "remote", "tcp://example.com:2375", nil)
+
+	client, err := NewContextClient("remote")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if client.endpoint != "tcp://example.com:2375" {
+		t.Errorf("endpoint = %q, want %q", client.endpoint, "tcp://example.com:2375")
+	}
+	if !client.SkipServerVersionCheck {
+		t.Error("expected SkipServerVersionCheck to be true when no API version is requested")
+	}
+}
+
+func TestNewContextClient_Default(t *testing.T) {
+	t.Parallel()
+	client, err := NewContextClient("default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if client.endpoint != defaultHost {
+		t.Errorf("endpoint = %q, want %q", client.endpoint, defaultHost)
+	}
+}
+
+func TestNewVersionedContextClient(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("DOCKER_CONFIG", dir)
+	writeContext(t, dir, "remote", "tcp://example.com:2375", nil)
+
+	client, err := NewVersionedContextClient("remote", "1.40")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if client.endpoint != "tcp://example.com:2375" {
+		t.Errorf("endpoint = %q, want %q", client.endpoint, "tcp://example.com:2375")
+	}
+	if got := client.requestedAPIVersion.String(); got != "1.40" {
+		t.Errorf("requestedAPIVersion = %q, want %q", got, "1.40")
+	}
+	if client.SkipServerVersionCheck {
+		t.Error("expected SkipServerVersionCheck to be false when an API version is requested")
+	}
+}
+
+func TestNewClientFromEnv_UsesCurrentContext(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("DOCKER_CONFIG", dir)
+	t.Setenv("DOCKER_HOST", "")
+	t.Setenv("DOCKER_CONTEXT", "")
+	t.Setenv("DOCKER_TLS_VERIFY", "")
+	writeContext(t, dir, "remote", "tcp://example.com:2375", nil)
+	writeConfigCurrentContext(t, dir, "remote")
+
+	client, err := NewClientFromEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if client.endpoint != "tcp://example.com:2375" {
+		t.Errorf("endpoint = %q, want %q", client.endpoint, "tcp://example.com:2375")
+	}
+}
+
+func TestNewClientFromEnv_DOCKER_CONTEXT_env(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("DOCKER_CONFIG", dir)
+	t.Setenv("DOCKER_HOST", "")
+	t.Setenv("DOCKER_TLS_VERIFY", "")
+	writeContext(t, dir, "via-env", "tcp://env.example.com:2375", nil)
+	t.Setenv("DOCKER_CONTEXT", "via-env")
+
+	client, err := NewClientFromEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if client.endpoint != "tcp://env.example.com:2375" {
+		t.Errorf("endpoint = %q, want %q", client.endpoint, "tcp://env.example.com:2375")
+	}
+}
+
+func TestNewClientFromEnv_DOCKER_HOST_overrides_context(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("DOCKER_CONFIG", dir)
+	t.Setenv("DOCKER_TLS_VERIFY", "")
+	writeContext(t, dir, "remote", "tcp://context.example.com:2375", nil)
+	writeConfigCurrentContext(t, dir, "remote")
+	t.Setenv("DOCKER_HOST", "tcp://override.example.com:2375")
+
+	client, err := NewClientFromEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if client.endpoint != "tcp://override.example.com:2375" {
+		t.Errorf("endpoint = %q, want %q", client.endpoint, "tcp://override.example.com:2375")
+	}
+}
+
+func TestNewClientFromEnv_DefaultContext_FallsBack(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("DOCKER_CONFIG", dir)
+	t.Setenv("DOCKER_HOST", "")
+	t.Setenv("DOCKER_CONTEXT", "")
+	t.Setenv("DOCKER_TLS_VERIFY", "")
+	writeConfigCurrentContext(t, dir, "default")
+
+	client, err := NewClientFromEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if client.endpoint != defaultHost {
+		t.Errorf("endpoint = %q, want default %q", client.endpoint, defaultHost)
+	}
+}


### PR DESCRIPTION
## Summary
- New `NewContextClient(name)` / `NewVersionedContextClient(name, apiVersion)` build a client from a named docker CLI context by reading `$DOCKER_CONFIG/contexts/meta/<sha256(name)>/meta.json` and the optional TLS bundle under `contexts/tls/<id>/docker/`. The reserved name `default` (or `""`) resolves to the platform default host.
- `NewClientFromEnv` / `NewVersionedClientFromEnv` now match the docker CLI's resolution order: `DOCKER_HOST` keeps full precedence; when it's unset the client falls back to `DOCKER_CONTEXT`, then the `currentContext` field of `config.json`, then the default socket.
- `ssh://` context endpoints are rejected with a clear error since this library has no SSH dialer.

## Test plan
- [x] `go test ./...` (unit tests, Linux/macOS)
- [x] Manual smoke test on Windows
- [ ] `NewClientFromEnv` with `DOCKER_HOST` set still hits that host (existing tests cover this)
- [ ] `NewClientFromEnv` with a `docker context use <name>` selecting a `tcp://` context picks up that host
- [ ] `NewContextClient("default")` resolves to the platform default host without touching disk
- [ ] `NewContextClient` on a missing context returns a clear "not found" error
- [ ] `NewContextClient` on an `ssh://` context returns an explanatory error

🤖 Generated with [Claude Code](https://claude.com/claude-code)