### PR TITLE
Improve API version handling

### DIFF
--- a/client.go
+++ b/client.go
@@ -146,9 +146,11 @@ type Client struct {
 	endpointURL         *url.URL
 	eventMonitor        *eventMonitoringState
 	requestedAPIVersion APIVersion
-	serverAPIVersion    atomic.Value
-	expectedAPIVersion  atomic.Value
-	versionMu           sync.Mutex
+	// serverAPIVersion and expectedAPIVersion are read while requests are built,
+	// so keep access lock-free after the first version probe completes.
+	serverAPIVersion   atomic.Pointer[APIVersion]
+	expectedAPIVersion atomic.Pointer[APIVersion]
+	versionMu          sync.Mutex
 }
 
 // Dialer is an interface that allows network connections to be dialed
@@ -365,7 +367,7 @@ func (c *Client) getExpectedVersion() APIVersion {
 	if v == nil {
 		return nil
 	}
-	return v.(APIVersion)
+	return *v
 }
 
 func (c *Client) getServerVersion() APIVersion {
@@ -373,7 +375,11 @@ func (c *Client) getServerVersion() APIVersion {
 	if v == nil {
 		return nil
 	}
-	return v.(APIVersion)
+	return *v
+}
+
+func storeAPIVersion(p *atomic.Pointer[APIVersion], v APIVersion) {
+	p.Store(&v)
 }
 
 func (c *Client) ensureAPIVersion() error {
@@ -383,14 +389,16 @@ func (c *Client) ensureAPIVersion() error {
 	return c.ensureServerVersion()
 }
 
+// setExpectedVersion records the version used in request URLs. It may differ
+// from the server version when the caller requested an explicit API version.
 func (c *Client) setExpectedVersion(serverVersion APIVersion) {
 	if c.SkipServerVersionCheck || c.getExpectedVersion() != nil {
 		return
 	}
 	if c.requestedAPIVersion != nil {
-		c.expectedAPIVersion.Store(c.requestedAPIVersion)
+		storeAPIVersion(&c.expectedAPIVersion, c.requestedAPIVersion)
 	} else {
-		c.expectedAPIVersion.Store(serverVersion)
+		storeAPIVersion(&c.expectedAPIVersion, serverVersion)
 	}
 }
 
@@ -413,11 +421,14 @@ func (c *Client) ensureServerVersion() error {
 	if err != nil {
 		return err
 	}
-	c.serverAPIVersion.Store(serverAPIVersion)
+	storeAPIVersion(&c.serverAPIVersion, serverAPIVersion)
 	c.setExpectedVersion(serverAPIVersion)
 	return nil
 }
 
+// ensureServerVersionForCompatibility probes /version only to decide old API
+// compatibility behavior. Respect SkipServerVersionCheck by preserving the old
+// best-effort semantics when that probe fails.
 func (c *Client) ensureServerVersionForCompatibility() error {
 	err := c.ensureServerVersion()
 	if c.SkipServerVersionCheck {

--- a/client.go
+++ b/client.go
@@ -403,6 +403,8 @@ func (c *Client) ensureServerVersion() error {
 		c.setExpectedVersion(serverVersion)
 		return nil
 	}
+	// Serialize only the first /version request; version reads stay lock-free
+	// once the server version has been cached.
 	c.versionMu.Lock()
 	defer c.versionMu.Unlock()
 	if serverVersion := c.serverAPIVersion.Load(); serverVersion != nil {
@@ -420,17 +422,6 @@ func (c *Client) ensureServerVersion() error {
 	c.serverAPIVersion.Store(serverAPIVersion)
 	c.setExpectedVersion(serverAPIVersion)
 	return nil
-}
-
-// ensureServerVersionForCompatibility probes /version only to decide old API
-// compatibility behavior. Respect SkipServerVersionCheck by preserving the old
-// best-effort semantics when that probe fails.
-func (c *Client) ensureServerVersionForCompatibility() error {
-	err := c.ensureServerVersion()
-	if c.SkipServerVersionCheck {
-		return nil
-	}
-	return err
 }
 
 // Endpoint returns the current endpoint. It's useful for getting the endpoint
@@ -946,6 +937,8 @@ func (c *Client) pathVersionCheck(basepath, queryStr string, requiredAPIVersion 
 				basepath, requiredAPIVersion, expected)
 		}
 	}
+	// Return only a request path. The caller applies the endpoint and selected
+	// API version later through getURL.
 	return fmt.Sprintf("%s?%s", basepath, queryStr), nil
 }
 

--- a/client.go
+++ b/client.go
@@ -148,8 +148,8 @@ type Client struct {
 	requestedAPIVersion APIVersion
 	// serverAPIVersion and expectedAPIVersion are read while requests are built,
 	// so keep access lock-free after the first version probe completes.
-	serverAPIVersion   atomic.Pointer[APIVersion]
-	expectedAPIVersion atomic.Pointer[APIVersion]
+	serverAPIVersion   atomicAPIVersion
+	expectedAPIVersion atomicAPIVersion
 	versionMu          sync.Mutex
 }
 
@@ -362,28 +362,24 @@ func (c *Client) SetTimeout(t time.Duration) {
 	}
 }
 
-func (c *Client) getExpectedVersion() APIVersion {
-	v := c.expectedAPIVersion.Load()
-	if v == nil {
-		return nil
-	}
-	return *v
+type atomicAPIVersion struct {
+	p atomic.Pointer[APIVersion]
 }
 
-func (c *Client) getServerVersion() APIVersion {
-	v := c.serverAPIVersion.Load()
-	if v == nil {
+func (v *atomicAPIVersion) Load() APIVersion {
+	version := v.p.Load()
+	if version == nil {
 		return nil
 	}
-	return *v
+	return *version
 }
 
-func storeAPIVersion(p *atomic.Pointer[APIVersion], v APIVersion) {
-	p.Store(&v)
+func (v *atomicAPIVersion) Store(version APIVersion) {
+	v.p.Store(&version)
 }
 
 func (c *Client) ensureAPIVersion() error {
-	if c.SkipServerVersionCheck || c.getExpectedVersion() != nil {
+	if c.SkipServerVersionCheck || c.expectedAPIVersion.Load() != nil {
 		return nil
 	}
 	return c.ensureServerVersion()
@@ -392,24 +388,24 @@ func (c *Client) ensureAPIVersion() error {
 // setExpectedVersion records the version used in request URLs. It may differ
 // from the server version when the caller requested an explicit API version.
 func (c *Client) setExpectedVersion(serverVersion APIVersion) {
-	if c.SkipServerVersionCheck || c.getExpectedVersion() != nil {
+	if c.SkipServerVersionCheck || c.expectedAPIVersion.Load() != nil {
 		return
 	}
 	if c.requestedAPIVersion != nil {
-		storeAPIVersion(&c.expectedAPIVersion, c.requestedAPIVersion)
+		c.expectedAPIVersion.Store(c.requestedAPIVersion)
 	} else {
-		storeAPIVersion(&c.expectedAPIVersion, serverVersion)
+		c.expectedAPIVersion.Store(serverVersion)
 	}
 }
 
 func (c *Client) ensureServerVersion() error {
-	if serverVersion := c.getServerVersion(); serverVersion != nil {
+	if serverVersion := c.serverAPIVersion.Load(); serverVersion != nil {
 		c.setExpectedVersion(serverVersion)
 		return nil
 	}
 	c.versionMu.Lock()
 	defer c.versionMu.Unlock()
-	if serverVersion := c.getServerVersion(); serverVersion != nil {
+	if serverVersion := c.serverAPIVersion.Load(); serverVersion != nil {
 		c.setExpectedVersion(serverVersion)
 		return nil
 	}
@@ -421,7 +417,7 @@ func (c *Client) ensureServerVersion() error {
 	if err != nil {
 		return err
 	}
-	storeAPIVersion(&c.serverAPIVersion, serverAPIVersion)
+	c.serverAPIVersion.Store(serverAPIVersion)
 	c.setExpectedVersion(serverAPIVersion)
 	return nil
 }
@@ -919,7 +915,7 @@ func (c *Client) getURL(path string) string {
 	if c.endpointURL.Scheme == unixProtocol || c.endpointURL.Scheme == namedPipeProtocol {
 		urlStr = ""
 	}
-	if expected := c.getExpectedVersion(); expected != nil {
+	if expected := c.expectedAPIVersion.Load(); expected != nil {
 		return fmt.Sprintf("%s/v%s%s", urlStr, expected, path)
 	}
 	if c.requestedAPIVersion != nil {
@@ -944,7 +940,7 @@ func (c *Client) pathVersionCheck(basepath, queryStr string, requiredAPIVersion 
 	if err := c.ensureAPIVersion(); err != nil {
 		return "", err
 	}
-	if expected := c.getExpectedVersion(); expected != nil {
+	if expected := c.expectedAPIVersion.Load(); expected != nil {
 		if requiredAPIVersion != nil && !expected.GreaterThanOrEqualTo(requiredAPIVersion) {
 			return "", fmt.Errorf("API %s requires version %s, server version %s is insufficient",
 				basepath, requiredAPIVersion, expected)
@@ -963,7 +959,7 @@ func (c *Client) getFakeNativeURL(path string) string {
 	u.Host = "unix.sock" // Doesn't matter what this is - it's not used.
 	u.Path = ""
 	urlStr := strings.TrimRight(u.String(), "/")
-	if expected := c.getExpectedVersion(); expected != nil {
+	if expected := c.expectedAPIVersion.Load(); expected != nil {
 		return fmt.Sprintf("%s/v%s%s", urlStr, expected, path)
 	}
 	if c.requestedAPIVersion != nil {

--- a/client.go
+++ b/client.go
@@ -27,6 +27,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -145,8 +146,9 @@ type Client struct {
 	endpointURL         *url.URL
 	eventMonitor        *eventMonitoringState
 	requestedAPIVersion APIVersion
-	serverAPIVersion    APIVersion
-	expectedAPIVersion  APIVersion
+	serverAPIVersion    atomic.Value
+	expectedAPIVersion  atomic.Value
+	versionMu           sync.Mutex
 }
 
 // Dialer is an interface that allows network connections to be dialed
@@ -358,21 +360,70 @@ func (c *Client) SetTimeout(t time.Duration) {
 	}
 }
 
-func (c *Client) checkAPIVersion() error {
+func (c *Client) getExpectedVersion() APIVersion {
+	v := c.expectedAPIVersion.Load()
+	if v == nil {
+		return nil
+	}
+	return v.(APIVersion)
+}
+
+func (c *Client) getServerVersion() APIVersion {
+	v := c.serverAPIVersion.Load()
+	if v == nil {
+		return nil
+	}
+	return v.(APIVersion)
+}
+
+func (c *Client) ensureAPIVersion() error {
+	if c.SkipServerVersionCheck || c.getExpectedVersion() != nil {
+		return nil
+	}
+	return c.ensureServerVersion()
+}
+
+func (c *Client) setExpectedVersion(serverVersion APIVersion) {
+	if c.SkipServerVersionCheck || c.getExpectedVersion() != nil {
+		return
+	}
+	if c.requestedAPIVersion != nil {
+		c.expectedAPIVersion.Store(c.requestedAPIVersion)
+	} else {
+		c.expectedAPIVersion.Store(serverVersion)
+	}
+}
+
+func (c *Client) ensureServerVersion() error {
+	if serverVersion := c.getServerVersion(); serverVersion != nil {
+		c.setExpectedVersion(serverVersion)
+		return nil
+	}
+	c.versionMu.Lock()
+	defer c.versionMu.Unlock()
+	if serverVersion := c.getServerVersion(); serverVersion != nil {
+		c.setExpectedVersion(serverVersion)
+		return nil
+	}
 	serverAPIVersionString, err := c.getServerAPIVersionString()
 	if err != nil {
 		return err
 	}
-	c.serverAPIVersion, err = NewAPIVersion(serverAPIVersionString)
+	serverAPIVersion, err := NewAPIVersion(serverAPIVersionString)
 	if err != nil {
 		return err
 	}
-	if c.requestedAPIVersion == nil {
-		c.expectedAPIVersion = c.serverAPIVersion
-	} else {
-		c.expectedAPIVersion = c.requestedAPIVersion
-	}
+	c.serverAPIVersion.Store(serverAPIVersion)
+	c.setExpectedVersion(serverAPIVersion)
 	return nil
+}
+
+func (c *Client) ensureServerVersionForCompatibility() error {
+	err := c.ensureServerVersion()
+	if c.SkipServerVersionCheck {
+		return nil
+	}
+	return err
 }
 
 // Endpoint returns the current endpoint. It's useful for getting the endpoint
@@ -441,9 +492,8 @@ func (c *Client) do(method, path string, doOptions doOptions) (*http.Response, e
 		}
 		params = bytes.NewBuffer(buf)
 	}
-	if path != "/version" && !c.SkipServerVersionCheck && c.expectedAPIVersion == nil {
-		err := c.checkAPIVersion()
-		if err != nil {
+	if path != "/version" {
+		if err := c.ensureAPIVersion(); err != nil {
 			return nil, err
 		}
 	}
@@ -520,9 +570,8 @@ func (c *Client) stream(method, path string, streamOptions streamOptions) error 
 	if (method == http.MethodPost || method == http.MethodPut) && streamOptions.in == nil {
 		streamOptions.in = bytes.NewReader(nil)
 	}
-	if path != "/version" && !c.SkipServerVersionCheck && c.expectedAPIVersion == nil {
-		err := c.checkAPIVersion()
-		if err != nil {
+	if path != "/version" {
+		if err := c.ensureAPIVersion(); err != nil {
 			return err
 		}
 	}
@@ -532,12 +581,6 @@ func (c *Client) stream(method, path string, streamOptions streamOptions) error 
 func (c *Client) streamURL(method, url string, streamOptions streamOptions) error {
 	if (method == http.MethodPost || method == http.MethodPut) && streamOptions.in == nil {
 		streamOptions.in = bytes.NewReader(nil)
-	}
-	if !c.SkipServerVersionCheck && c.expectedAPIVersion == nil {
-		err := c.checkAPIVersion()
-		if err != nil {
-			return err
-		}
 	}
 
 	// make a sub-context so that our active cancellation does not affect parent
@@ -728,9 +771,8 @@ type closerFunc func() error
 func (c closerFunc) Close() error { return c() }
 
 func (c *Client) hijack(method, path string, hijackOptions hijackOptions) (CloseWaiter, error) {
-	if path != "/version" && !c.SkipServerVersionCheck && c.expectedAPIVersion == nil {
-		err := c.checkAPIVersion()
-		if err != nil {
+	if path != "/version" {
+		if err := c.ensureAPIVersion(); err != nil {
 			return nil, err
 		}
 	}
@@ -866,6 +908,9 @@ func (c *Client) getURL(path string) string {
 	if c.endpointURL.Scheme == unixProtocol || c.endpointURL.Scheme == namedPipeProtocol {
 		urlStr = ""
 	}
+	if expected := c.getExpectedVersion(); expected != nil {
+		return fmt.Sprintf("%s/v%s%s", urlStr, expected, path)
+	}
 	if c.requestedAPIVersion != nil {
 		return fmt.Sprintf("%s/v%s%s", urlStr, c.requestedAPIVersion, path)
 	}
@@ -878,30 +923,23 @@ func (c *Client) getPath(basepath string, opts any) (string, error) {
 }
 
 func (c *Client) pathVersionCheck(basepath, queryStr string, requiredAPIVersion APIVersion) (string, error) {
-	urlStr := strings.TrimRight(c.endpointURL.String(), "/")
-	if c.endpointURL.Scheme == unixProtocol || c.endpointURL.Scheme == namedPipeProtocol {
-		urlStr = ""
-	}
 	if c.requestedAPIVersion != nil {
 		if requiredAPIVersion != nil && !c.requestedAPIVersion.GreaterThanOrEqualTo(requiredAPIVersion) {
 			return "", fmt.Errorf("API %s requires version %s, requested version %s is insufficient",
 				basepath, requiredAPIVersion, c.requestedAPIVersion)
 		}
-		return fmt.Sprintf("%s/v%s%s?%s", urlStr, c.requestedAPIVersion, basepath, queryStr), nil
+		return fmt.Sprintf("%s?%s", basepath, queryStr), nil
 	}
-	if !c.SkipServerVersionCheck {
-		if c.expectedAPIVersion == nil {
-			if err := c.checkAPIVersion(); err != nil {
-				return "", err
-			}
-		}
-		if requiredAPIVersion != nil && !c.expectedAPIVersion.GreaterThanOrEqualTo(requiredAPIVersion) {
+	if err := c.ensureAPIVersion(); err != nil {
+		return "", err
+	}
+	if expected := c.getExpectedVersion(); expected != nil {
+		if requiredAPIVersion != nil && !expected.GreaterThanOrEqualTo(requiredAPIVersion) {
 			return "", fmt.Errorf("API %s requires version %s, server version %s is insufficient",
-				basepath, requiredAPIVersion, c.expectedAPIVersion)
+				basepath, requiredAPIVersion, expected)
 		}
-		return fmt.Sprintf("%s/v%s%s?%s", urlStr, c.expectedAPIVersion, basepath, queryStr), nil
 	}
-	return fmt.Sprintf("%s%s?%s", urlStr, basepath, queryStr), nil
+	return fmt.Sprintf("%s?%s", basepath, queryStr), nil
 }
 
 // getFakeNativeURL returns the URL needed to make an HTTP request over a UNIX
@@ -914,6 +952,9 @@ func (c *Client) getFakeNativeURL(path string) string {
 	u.Host = "unix.sock" // Doesn't matter what this is - it's not used.
 	u.Path = ""
 	urlStr := strings.TrimRight(u.String(), "/")
+	if expected := c.getExpectedVersion(); expected != nil {
+		return fmt.Sprintf("%s/v%s%s", urlStr, expected, path)
+	}
 	if c.requestedAPIVersion != nil {
 		return fmt.Sprintf("%s/v%s%s", urlStr, c.requestedAPIVersion, path)
 	}

--- a/client.go
+++ b/client.go
@@ -382,7 +382,7 @@ func (c *Client) ensureAPIVersion() error {
 	if c.SkipServerVersionCheck || c.expectedAPIVersion.Load() != nil {
 		return nil
 	}
-	return c.ensureServerVersion()
+	return c.probeServerVersion()
 }
 
 // setExpectedVersion records the version used in request URLs. It may differ
@@ -398,7 +398,7 @@ func (c *Client) setExpectedVersion(serverVersion APIVersion) {
 	}
 }
 
-func (c *Client) ensureServerVersion() error {
+func (c *Client) probeServerVersion() error {
 	if serverVersion := c.serverAPIVersion.Load(); serverVersion != nil {
 		c.setExpectedVersion(serverVersion)
 		return nil

--- a/client.go
+++ b/client.go
@@ -883,14 +883,23 @@ func (c *Client) pathVersionCheck(basepath, queryStr string, requiredAPIVersion 
 		urlStr = ""
 	}
 	if c.requestedAPIVersion != nil {
-		if c.requestedAPIVersion.GreaterThanOrEqualTo(requiredAPIVersion) {
-			return fmt.Sprintf("%s/v%s%s?%s", urlStr, c.requestedAPIVersion, basepath, queryStr), nil
+		if requiredAPIVersion != nil && !c.requestedAPIVersion.GreaterThanOrEqualTo(requiredAPIVersion) {
+			return "", fmt.Errorf("API %s requires version %s, requested version %s is insufficient",
+				basepath, requiredAPIVersion, c.requestedAPIVersion)
 		}
-		return "", fmt.Errorf("API %s requires version %s, requested version %s is insufficient",
-			basepath, requiredAPIVersion, c.requestedAPIVersion)
+		return fmt.Sprintf("%s/v%s%s?%s", urlStr, c.requestedAPIVersion, basepath, queryStr), nil
 	}
-	if requiredAPIVersion != nil {
-		return fmt.Sprintf("%s/v%s%s?%s", urlStr, requiredAPIVersion, basepath, queryStr), nil
+	if !c.SkipServerVersionCheck {
+		if c.expectedAPIVersion == nil {
+			if err := c.checkAPIVersion(); err != nil {
+				return "", err
+			}
+		}
+		if requiredAPIVersion != nil && !c.expectedAPIVersion.GreaterThanOrEqualTo(requiredAPIVersion) {
+			return "", fmt.Errorf("API %s requires version %s, server version %s is insufficient",
+				basepath, requiredAPIVersion, c.expectedAPIVersion)
+		}
+		return fmt.Sprintf("%s/v%s%s?%s", urlStr, c.expectedAPIVersion, basepath, queryStr), nil
 	}
 	return fmt.Sprintf("%s%s?%s", urlStr, basepath, queryStr), nil
 }

--- a/client_test.go
+++ b/client_test.go
@@ -543,7 +543,7 @@ func TestPathVersionCheckServerVersionInsufficient(t *testing.T) {
 	t.Parallel()
 	client := newTestClient(&FakeRoundTripper{message: "", status: http.StatusOK})
 	client.SkipServerVersionCheck = false
-	storeAPIVersion(&client.expectedAPIVersion, apiVersion124)
+	client.expectedAPIVersion.Store(apiVersion124)
 	requiredAPIVersion, err := NewAPIVersion("1.32")
 	if err != nil {
 		t.Fatal(err)
@@ -566,7 +566,7 @@ func TestPathVersionCheckNilRequiredVersion(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	storeAPIVersion(&client.expectedAPIVersion, expectedAPIVersion)
+	client.expectedAPIVersion.Store(expectedAPIVersion)
 	got, err := client.pathVersionCheck("/build", "q=1", nil)
 	if err != nil {
 		t.Fatal(err)

--- a/client_test.go
+++ b/client_test.go
@@ -460,6 +460,119 @@ func TestAPIVersions(t *testing.T) {
 	}
 }
 
+func TestPathVersionCheckExplicitVersion(t *testing.T) {
+	t.Parallel()
+	client, err := NewVersionedClient("http://localhost:4243", "1.44")
+	if err != nil {
+		t.Fatal(err)
+	}
+	requiredAPIVersion, err := NewAPIVersion("1.32")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := client.pathVersionCheck("/build", "q=1", requiredAPIVersion)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "http://localhost:4243/v1.44/build?q=1"
+	if got != want {
+		t.Fatalf("pathVersionCheck: wrong path. Want %q. Got %q.", want, got)
+	}
+}
+
+func TestPathVersionCheckExplicitVersionInsufficient(t *testing.T) {
+	t.Parallel()
+	client, err := NewVersionedClient("http://localhost:4243", "1.24")
+	if err != nil {
+		t.Fatal(err)
+	}
+	requiredAPIVersion, err := NewAPIVersion("1.32")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = client.pathVersionCheck("/build", "q=1", requiredAPIVersion)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	want := "API /build requires version 1.32, requested version 1.24 is insufficient"
+	if err.Error() != want {
+		t.Fatalf("wrong error. Want %q. Got %q.", want, err.Error())
+	}
+}
+
+func TestPathVersionCheckSkipServerVersionCheck(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(&FakeRoundTripper{message: "", status: http.StatusOK})
+	requiredAPIVersion, err := NewAPIVersion("1.32")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := client.pathVersionCheck("/build", "q=1", requiredAPIVersion)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "http://localhost:4243/build?q=1"
+	if got != want {
+		t.Fatalf("pathVersionCheck: wrong path. Want %q. Got %q.", want, got)
+	}
+}
+
+func TestPathVersionCheckServerVersion(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(&FakeRoundTripper{message: `{"ApiVersion":"1.52"}`, status: http.StatusOK})
+	client.SkipServerVersionCheck = false
+	requiredAPIVersion, err := NewAPIVersion("1.32")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := client.pathVersionCheck("/build", "q=1", requiredAPIVersion)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "http://localhost:4243/v1.52/build?q=1"
+	if got != want {
+		t.Fatalf("pathVersionCheck: wrong path. Want %q. Got %q.", want, got)
+	}
+}
+
+func TestPathVersionCheckServerVersionInsufficient(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(&FakeRoundTripper{message: "", status: http.StatusOK})
+	client.SkipServerVersionCheck = false
+	client.expectedAPIVersion = apiVersion124
+	requiredAPIVersion, err := NewAPIVersion("1.32")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = client.pathVersionCheck("/build", "q=1", requiredAPIVersion)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	want := "API /build requires version 1.32, server version 1.24 is insufficient"
+	if err.Error() != want {
+		t.Fatalf("wrong error. Want %q. Got %q.", want, err.Error())
+	}
+}
+
+func TestPathVersionCheckNilRequiredVersion(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(&FakeRoundTripper{message: "", status: http.StatusOK})
+	client.SkipServerVersionCheck = false
+	expectedAPIVersion, err := NewAPIVersion("1.52")
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.expectedAPIVersion = expectedAPIVersion
+	got, err := client.pathVersionCheck("/build", "q=1", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "http://localhost:4243/v1.52/build?q=1"
+	if got != want {
+		t.Fatalf("pathVersionCheck: wrong path. Want %q. Got %q.", want, got)
+	}
+}
+
 func TestPing(t *testing.T) {
 	t.Parallel()
 	fakeRT := &FakeRoundTripper{message: "", status: http.StatusOK}

--- a/client_test.go
+++ b/client_test.go
@@ -543,7 +543,7 @@ func TestPathVersionCheckServerVersionInsufficient(t *testing.T) {
 	t.Parallel()
 	client := newTestClient(&FakeRoundTripper{message: "", status: http.StatusOK})
 	client.SkipServerVersionCheck = false
-	client.expectedAPIVersion.Store(apiVersion124)
+	storeAPIVersion(&client.expectedAPIVersion, apiVersion124)
 	requiredAPIVersion, err := NewAPIVersion("1.32")
 	if err != nil {
 		t.Fatal(err)
@@ -566,7 +566,7 @@ func TestPathVersionCheckNilRequiredVersion(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	client.expectedAPIVersion.Store(expectedAPIVersion)
+	storeAPIVersion(&client.expectedAPIVersion, expectedAPIVersion)
 	got, err := client.pathVersionCheck("/build", "q=1", nil)
 	if err != nil {
 		t.Fatal(err)

--- a/client_test.go
+++ b/client_test.go
@@ -474,7 +474,7 @@ func TestPathVersionCheckExplicitVersion(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := "http://localhost:4243/v1.44/build?q=1"
+	want := "/build?q=1"
 	if got != want {
 		t.Fatalf("pathVersionCheck: wrong path. Want %q. Got %q.", want, got)
 	}
@@ -511,7 +511,7 @@ func TestPathVersionCheckSkipServerVersionCheck(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := "http://localhost:4243/build?q=1"
+	want := "/build?q=1"
 	if got != want {
 		t.Fatalf("pathVersionCheck: wrong path. Want %q. Got %q.", want, got)
 	}
@@ -519,7 +519,11 @@ func TestPathVersionCheckSkipServerVersionCheck(t *testing.T) {
 
 func TestPathVersionCheckServerVersion(t *testing.T) {
 	t.Parallel()
-	client := newTestClient(&FakeRoundTripper{message: `{"ApiVersion":"1.52"}`, status: http.StatusOK})
+	client, err := NewClient("http://localhost:4243")
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.HTTPClient = &http.Client{Transport: &FakeRoundTripper{message: `{"ApiVersion":"1.52"}`, status: http.StatusOK}}
 	client.SkipServerVersionCheck = false
 	requiredAPIVersion, err := NewAPIVersion("1.32")
 	if err != nil {
@@ -529,7 +533,7 @@ func TestPathVersionCheckServerVersion(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := "http://localhost:4243/v1.52/build?q=1"
+	want := "/build?q=1"
 	if got != want {
 		t.Fatalf("pathVersionCheck: wrong path. Want %q. Got %q.", want, got)
 	}
@@ -539,7 +543,7 @@ func TestPathVersionCheckServerVersionInsufficient(t *testing.T) {
 	t.Parallel()
 	client := newTestClient(&FakeRoundTripper{message: "", status: http.StatusOK})
 	client.SkipServerVersionCheck = false
-	client.expectedAPIVersion = apiVersion124
+	client.expectedAPIVersion.Store(apiVersion124)
 	requiredAPIVersion, err := NewAPIVersion("1.32")
 	if err != nil {
 		t.Fatal(err)
@@ -562,12 +566,12 @@ func TestPathVersionCheckNilRequiredVersion(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	client.expectedAPIVersion = expectedAPIVersion
+	client.expectedAPIVersion.Store(expectedAPIVersion)
 	got, err := client.pathVersionCheck("/build", "q=1", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := "http://localhost:4243/v1.52/build?q=1"
+	want := "/build?q=1"
 	if got != want {
 		t.Fatalf("pathVersionCheck: wrong path. Want %q. Got %q.", want, got)
 	}
@@ -1019,6 +1023,17 @@ func (rt *FakeRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
 
 func (rt *FakeRoundTripper) Reset() {
 	rt.requests = nil
+}
+
+func newHTTPTestClient(t *testing.T, handler http.HandlerFunc) (*Client, func()) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	client, err := NewClient(srv.URL)
+	if err != nil {
+		srv.Close()
+		t.Fatal(err)
+	}
+	return client, srv.Close
 }
 
 type person struct {

--- a/container_copy.go
+++ b/container_copy.go
@@ -26,7 +26,7 @@ func (c *Client) CopyFromContainer(opts CopyFromContainerOptions) error {
 	if opts.Container == "" {
 		return &NoSuchContainer{ID: opts.Container}
 	}
-	c.ensureServerVersion()
+	c.probeServerVersion()
 	if v := c.serverAPIVersion.Load(); v != nil && v.GreaterThanOrEqualTo(apiVersion124) {
 		return errors.New("go-dockerclient: CopyFromContainer is no longer available in Docker >= 1.12, use DownloadFromContainer instead")
 	}

--- a/container_copy.go
+++ b/container_copy.go
@@ -26,9 +26,7 @@ func (c *Client) CopyFromContainer(opts CopyFromContainerOptions) error {
 	if opts.Container == "" {
 		return &NoSuchContainer{ID: opts.Container}
 	}
-	if err := c.ensureServerVersionForCompatibility(); err != nil {
-		return err
-	}
+	c.ensureServerVersion()
 	if v := c.serverAPIVersion.Load(); v != nil && v.GreaterThanOrEqualTo(apiVersion124) {
 		return errors.New("go-dockerclient: CopyFromContainer is no longer available in Docker >= 1.12, use DownloadFromContainer instead")
 	}

--- a/container_copy.go
+++ b/container_copy.go
@@ -26,10 +26,10 @@ func (c *Client) CopyFromContainer(opts CopyFromContainerOptions) error {
 	if opts.Container == "" {
 		return &NoSuchContainer{ID: opts.Container}
 	}
-	if c.serverAPIVersion == nil {
-		c.checkAPIVersion()
+	if err := c.ensureServerVersionForCompatibility(); err != nil {
+		return err
 	}
-	if c.serverAPIVersion != nil && c.serverAPIVersion.GreaterThanOrEqualTo(apiVersion124) {
+	if v := c.getServerVersion(); v != nil && v.GreaterThanOrEqualTo(apiVersion124) {
 		return errors.New("go-dockerclient: CopyFromContainer is no longer available in Docker >= 1.12, use DownloadFromContainer instead")
 	}
 	url := fmt.Sprintf("/containers/%s/copy", opts.Container)

--- a/container_copy.go
+++ b/container_copy.go
@@ -29,7 +29,7 @@ func (c *Client) CopyFromContainer(opts CopyFromContainerOptions) error {
 	if err := c.ensureServerVersionForCompatibility(); err != nil {
 		return err
 	}
-	if v := c.getServerVersion(); v != nil && v.GreaterThanOrEqualTo(apiVersion124) {
+	if v := c.serverAPIVersion.Load(); v != nil && v.GreaterThanOrEqualTo(apiVersion124) {
 		return errors.New("go-dockerclient: CopyFromContainer is no longer available in Docker >= 1.12, use DownloadFromContainer instead")
 	}
 	url := fmt.Sprintf("/containers/%s/copy", opts.Container)

--- a/container_copy_test.go
+++ b/container_copy_test.go
@@ -65,7 +65,7 @@ func TestCopyFromContainerEmptyContainer(t *testing.T) {
 func TestCopyFromContainerDockerAPI124(t *testing.T) {
 	t.Parallel()
 	client := newTestClient(&FakeRoundTripper{status: http.StatusOK})
-	storeAPIVersion(&client.serverAPIVersion, apiVersion124)
+	client.serverAPIVersion.Store(apiVersion124)
 	opts := CopyFromContainerOptions{
 		Container: "a123456",
 	}

--- a/container_copy_test.go
+++ b/container_copy_test.go
@@ -65,7 +65,7 @@ func TestCopyFromContainerEmptyContainer(t *testing.T) {
 func TestCopyFromContainerDockerAPI124(t *testing.T) {
 	t.Parallel()
 	client := newTestClient(&FakeRoundTripper{status: http.StatusOK})
-	client.serverAPIVersion.Store(apiVersion124)
+	storeAPIVersion(&client.serverAPIVersion, apiVersion124)
 	opts := CopyFromContainerOptions{
 		Container: "a123456",
 	}

--- a/container_copy_test.go
+++ b/container_copy_test.go
@@ -24,6 +24,34 @@ func TestCopyFromContainer(t *testing.T) {
 	}
 }
 
+func TestCopyFromContainerSkipServerVersionCheckIgnoresVersionError(t *testing.T) {
+	t.Parallel()
+	content := "File content"
+	client, cleanup := newHTTPTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/version":
+			w.WriteHeader(http.StatusInternalServerError)
+		case "/containers/a123456/copy":
+			w.Write([]byte(content))
+		default:
+			t.Errorf("unexpected request path %q", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	defer cleanup()
+	out := stdoutMock{bytes.NewBuffer(nil)}
+	err := client.CopyFromContainer(CopyFromContainerOptions{
+		Container:    "a123456",
+		OutputStream: &out,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.String() != content {
+		t.Errorf("CopyFromContainer: wrong stdout. Want %#v. Got %#v.", content, out.String())
+	}
+}
+
 func TestCopyFromContainerEmptyContainer(t *testing.T) {
 	t.Parallel()
 	client := newTestClient(&FakeRoundTripper{status: http.StatusOK})
@@ -37,7 +65,7 @@ func TestCopyFromContainerEmptyContainer(t *testing.T) {
 func TestCopyFromContainerDockerAPI124(t *testing.T) {
 	t.Parallel()
 	client := newTestClient(&FakeRoundTripper{status: http.StatusOK})
-	client.serverAPIVersion = apiVersion124
+	client.serverAPIVersion.Store(apiVersion124)
 	opts := CopyFromContainerOptions{
 		Container: "a123456",
 	}

--- a/container_start.go
+++ b/container_start.go
@@ -37,7 +37,7 @@ func (c *Client) startContainer(id string, hostConfig *HostConfig, opts doOption
 	if err := c.ensureServerVersionForCompatibility(); err != nil {
 		return err
 	}
-	if v := c.getServerVersion(); v != nil && v.LessThan(apiVersion124) {
+	if v := c.serverAPIVersion.Load(); v != nil && v.LessThan(apiVersion124) {
 		opts.data = hostConfig
 		opts.forceJSON = true
 	}

--- a/container_start.go
+++ b/container_start.go
@@ -34,9 +34,7 @@ func (c *Client) StartContainerWithContext(id string, hostConfig *HostConfig, ct
 
 func (c *Client) startContainer(id string, hostConfig *HostConfig, opts doOptions) error {
 	path := "/containers/" + id + "/start"
-	if err := c.ensureServerVersionForCompatibility(); err != nil {
-		return err
-	}
+	c.ensureServerVersion()
 	if v := c.serverAPIVersion.Load(); v != nil && v.LessThan(apiVersion124) {
 		opts.data = hostConfig
 		opts.forceJSON = true

--- a/container_start.go
+++ b/container_start.go
@@ -34,7 +34,7 @@ func (c *Client) StartContainerWithContext(id string, hostConfig *HostConfig, ct
 
 func (c *Client) startContainer(id string, hostConfig *HostConfig, opts doOptions) error {
 	path := "/containers/" + id + "/start"
-	c.ensureServerVersion()
+	c.probeServerVersion()
 	if v := c.serverAPIVersion.Load(); v != nil && v.LessThan(apiVersion124) {
 		opts.data = hostConfig
 		opts.forceJSON = true

--- a/container_start.go
+++ b/container_start.go
@@ -34,10 +34,10 @@ func (c *Client) StartContainerWithContext(id string, hostConfig *HostConfig, ct
 
 func (c *Client) startContainer(id string, hostConfig *HostConfig, opts doOptions) error {
 	path := "/containers/" + id + "/start"
-	if c.serverAPIVersion == nil {
-		c.checkAPIVersion()
+	if err := c.ensureServerVersionForCompatibility(); err != nil {
+		return err
 	}
-	if c.serverAPIVersion != nil && c.serverAPIVersion.LessThan(apiVersion124) {
+	if v := c.getServerVersion(); v != nil && v.LessThan(apiVersion124) {
 		opts.data = hostConfig
 		opts.forceJSON = true
 	}

--- a/container_start_test.go
+++ b/container_start_test.go
@@ -58,7 +58,7 @@ func TestStartContainerHostConfigAPI124(t *testing.T) {
 	t.Parallel()
 	fakeRT := &FakeRoundTripper{message: "", status: http.StatusOK}
 	client := newTestClient(fakeRT)
-	client.serverAPIVersion.Store(apiVersion124)
+	storeAPIVersion(&client.serverAPIVersion, apiVersion124)
 	id := "4fa6e0f0c6786287e131c3852c58a2e01cc697a68231826813597e4994f1d6e2"
 	err := client.StartContainer(id, &HostConfig{})
 	if err != nil {

--- a/container_start_test.go
+++ b/container_start_test.go
@@ -34,11 +34,31 @@ func TestStartContainer(t *testing.T) {
 	}
 }
 
+func TestStartContainerSkipServerVersionCheckIgnoresVersionError(t *testing.T) {
+	t.Parallel()
+	id := "4fa6e0f0c6786287e131c3852c58a2e01cc697a68231826813597e4994f1d6e2"
+	client, cleanup := newHTTPTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/version":
+			w.WriteHeader(http.StatusInternalServerError)
+		case "/containers/" + id + "/start":
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Errorf("unexpected request path %q", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	defer cleanup()
+	if err := client.StartContainer(id, &HostConfig{}); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestStartContainerHostConfigAPI124(t *testing.T) {
 	t.Parallel()
 	fakeRT := &FakeRoundTripper{message: "", status: http.StatusOK}
 	client := newTestClient(fakeRT)
-	client.serverAPIVersion = apiVersion124
+	client.serverAPIVersion.Store(apiVersion124)
 	id := "4fa6e0f0c6786287e131c3852c58a2e01cc697a68231826813597e4994f1d6e2"
 	err := client.StartContainer(id, &HostConfig{})
 	if err != nil {

--- a/container_start_test.go
+++ b/container_start_test.go
@@ -58,7 +58,7 @@ func TestStartContainerHostConfigAPI124(t *testing.T) {
 	t.Parallel()
 	fakeRT := &FakeRoundTripper{message: "", status: http.StatusOK}
 	client := newTestClient(fakeRT)
-	storeAPIVersion(&client.serverAPIVersion, apiVersion124)
+	client.serverAPIVersion.Store(apiVersion124)
 	id := "4fa6e0f0c6786287e131c3852c58a2e01cc697a68231826813597e4994f1d6e2"
 	err := client.StartContainer(id, &HostConfig{})
 	if err != nil {

--- a/exec.go
+++ b/exec.go
@@ -44,9 +44,7 @@ type CreateExecOptions struct {
 //
 // See https://goo.gl/60TeBP for more details
 func (c *Client) CreateExec(opts CreateExecOptions) (*Exec, error) {
-	if err := c.ensureServerVersionForCompatibility(); err != nil {
-		return nil, err
-	}
+	c.ensureServerVersion()
 	v := c.serverAPIVersion.Load()
 	if len(opts.Env) > 0 && (v == nil || v.LessThan(apiVersion125)) {
 		return nil, errors.New("exec configuration Env is only supported in API#1.25 and above")

--- a/exec.go
+++ b/exec.go
@@ -44,13 +44,14 @@ type CreateExecOptions struct {
 //
 // See https://goo.gl/60TeBP for more details
 func (c *Client) CreateExec(opts CreateExecOptions) (*Exec, error) {
-	if c.serverAPIVersion == nil {
-		c.checkAPIVersion()
+	if err := c.ensureServerVersionForCompatibility(); err != nil {
+		return nil, err
 	}
-	if len(opts.Env) > 0 && c.serverAPIVersion.LessThan(apiVersion125) {
+	v := c.getServerVersion()
+	if len(opts.Env) > 0 && (v == nil || v.LessThan(apiVersion125)) {
 		return nil, errors.New("exec configuration Env is only supported in API#1.25 and above")
 	}
-	if len(opts.WorkingDir) > 0 && c.serverAPIVersion.LessThan(apiVersion135) {
+	if len(opts.WorkingDir) > 0 && (v == nil || v.LessThan(apiVersion135)) {
 		return nil, errors.New("exec configuration WorkingDir is only supported in API#1.35 and above")
 	}
 	path := fmt.Sprintf("/containers/%s/exec", opts.Container)

--- a/exec.go
+++ b/exec.go
@@ -44,7 +44,7 @@ type CreateExecOptions struct {
 //
 // See https://goo.gl/60TeBP for more details
 func (c *Client) CreateExec(opts CreateExecOptions) (*Exec, error) {
-	c.ensureServerVersion()
+	c.probeServerVersion()
 	v := c.serverAPIVersion.Load()
 	if len(opts.Env) > 0 && (v == nil || v.LessThan(apiVersion125)) {
 		return nil, errors.New("exec configuration Env is only supported in API#1.25 and above")

--- a/exec.go
+++ b/exec.go
@@ -47,7 +47,7 @@ func (c *Client) CreateExec(opts CreateExecOptions) (*Exec, error) {
 	if err := c.ensureServerVersionForCompatibility(); err != nil {
 		return nil, err
 	}
-	v := c.getServerVersion()
+	v := c.serverAPIVersion.Load()
 	if len(opts.Env) > 0 && (v == nil || v.LessThan(apiVersion125)) {
 		return nil, errors.New("exec configuration Env is only supported in API#1.25 and above")
 	}

--- a/exec_test.go
+++ b/exec_test.go
@@ -129,7 +129,7 @@ func TestExecCreateWithEnv(t *testing.T) {
 		endpointURL:            u,
 		SkipServerVersionCheck: true,
 	}
-	storeAPIVersion(&client.serverAPIVersion, testAPIVersion)
+	client.serverAPIVersion.Store(testAPIVersion)
 	config := CreateExecOptions{
 		Container:    "test",
 		AttachStdin:  true,
@@ -222,7 +222,7 @@ func TestExecCreateWithWorkingDir(t *testing.T) {
 		endpointURL:            u,
 		SkipServerVersionCheck: true,
 	}
-	storeAPIVersion(&client.serverAPIVersion, testAPIVersion)
+	client.serverAPIVersion.Store(testAPIVersion)
 	config := CreateExecOptions{
 		Container:    "test",
 		AttachStdin:  true,

--- a/exec_test.go
+++ b/exec_test.go
@@ -58,6 +58,32 @@ func TestExecCreate(t *testing.T) {
 	}
 }
 
+func TestExecCreateSkipServerVersionCheckIgnoresVersionError(t *testing.T) {
+	t.Parallel()
+	client, cleanup := newHTTPTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/version":
+			w.WriteHeader(http.StatusInternalServerError)
+		case "/containers/test/exec":
+			w.Write([]byte(`{"Id":"exec-id"}`))
+		default:
+			t.Errorf("unexpected request path %q", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	defer cleanup()
+	exec, err := client.CreateExec(CreateExecOptions{
+		Container: "test",
+		Cmd:       []string{"touch", "/tmp/file"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exec.ID != "exec-id" {
+		t.Fatalf("CreateExec: wrong ID. Want %q. Got %q.", "exec-id", exec.ID)
+	}
+}
+
 func TestExecCreateWithEnvErr(t *testing.T) {
 	t.Parallel()
 	jsonContainer := `{"Id": "4fa6e0f0c6786287e131c3852c58a2e01cc697a68231826813597e4994f1d6e2"}`
@@ -102,8 +128,8 @@ func TestExecCreateWithEnv(t *testing.T) {
 		endpoint:               endpoint,
 		endpointURL:            u,
 		SkipServerVersionCheck: true,
-		serverAPIVersion:       testAPIVersion,
 	}
+	client.serverAPIVersion.Store(testAPIVersion)
 	config := CreateExecOptions{
 		Container:    "test",
 		AttachStdin:  true,
@@ -117,6 +143,37 @@ func TestExecCreateWithEnv(t *testing.T) {
 	_, err = client.CreateExec(config)
 	if err != nil {
 		t.Error(err)
+	}
+}
+
+func TestExecCreateWithEnvExplicitVersionUsesServerVersion(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/version", "/v1.25/version":
+			w.Write([]byte(`{"ApiVersion":"1.25"}`))
+		case "/v1.25/containers/test/exec":
+			w.Write([]byte(`{"Id":"exec-id"}`))
+		default:
+			t.Errorf("unexpected request path %q", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+	client, err := NewVersionedClient(srv.URL, "1.25")
+	if err != nil {
+		t.Fatal(err)
+	}
+	exec, err := client.CreateExec(CreateExecOptions{
+		Container: "test",
+		Env:       []string{"foo=bar"},
+		Cmd:       []string{"touch", "/tmp/file"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exec.ID != "exec-id" {
+		t.Fatalf("CreateExec: wrong ID. Want %q. Got %q.", "exec-id", exec.ID)
 	}
 }
 
@@ -164,8 +221,8 @@ func TestExecCreateWithWorkingDir(t *testing.T) {
 		endpoint:               endpoint,
 		endpointURL:            u,
 		SkipServerVersionCheck: true,
-		serverAPIVersion:       testAPIVersion,
 	}
+	client.serverAPIVersion.Store(testAPIVersion)
 	config := CreateExecOptions{
 		Container:    "test",
 		AttachStdin:  true,

--- a/exec_test.go
+++ b/exec_test.go
@@ -129,7 +129,7 @@ func TestExecCreateWithEnv(t *testing.T) {
 		endpointURL:            u,
 		SkipServerVersionCheck: true,
 	}
-	client.serverAPIVersion.Store(testAPIVersion)
+	storeAPIVersion(&client.serverAPIVersion, testAPIVersion)
 	config := CreateExecOptions{
 		Container:    "test",
 		AttachStdin:  true,
@@ -222,7 +222,7 @@ func TestExecCreateWithWorkingDir(t *testing.T) {
 		endpointURL:            u,
 		SkipServerVersionCheck: true,
 	}
-	client.serverAPIVersion.Store(testAPIVersion)
+	storeAPIVersion(&client.serverAPIVersion, testAPIVersion)
 	config := CreateExecOptions{
 		Container:    "test",
 		AttachStdin:  true,

--- a/image.go
+++ b/image.go
@@ -443,6 +443,7 @@ type ImportImageOptions struct {
 	Repository string `qs:"repo"`
 	Source     string `qs:"fromSrc"`
 	Tag        string `qs:"tag"`
+	Platform   string `qs:"platform" ver:"1.32"`
 
 	InputStream       io.Reader     `qs:"-"`
 	OutputStream      io.Writer     `qs:"-"`

--- a/image.go
+++ b/image.go
@@ -635,7 +635,7 @@ func (c *Client) BuildImage(opts BuildImageOptions) error {
 func (c *Client) versionedAuthConfigs(authConfigs AuthConfigurations) registryAuth {
 	// If the server version cannot be discovered, keep the legacy auth config
 	// shape. This matches the previous best-effort version check behavior.
-	c.ensureServerVersion()
+	c.probeServerVersion()
 	v := c.serverAPIVersion.Load()
 	if v != nil && v.GreaterThanOrEqualTo(apiVersion119) {
 		return AuthConfigurations119(authConfigs.Configs)

--- a/image.go
+++ b/image.go
@@ -215,7 +215,7 @@ func (c *Client) InspectImage(name string) (*Image, error) {
 	var image Image
 
 	// if the caller elected to skip checking the server's version, assume it's the latest
-	if c.SkipServerVersionCheck || c.expectedAPIVersion.GreaterThanOrEqualTo(apiVersion112) {
+	if c.SkipServerVersionCheck || c.getExpectedVersion().GreaterThanOrEqualTo(apiVersion112) {
 		if err := json.NewDecoder(resp.Body).Decode(&image); err != nil {
 			return nil, err
 		}
@@ -331,11 +331,11 @@ func (c *Client) PullImage(opts PullImageOptions, auth AuthConfiguration) error 
 }
 
 func (c *Client) createImage(opts any, headers map[string]string, in io.Reader, w io.Writer, rawJSONStream bool, timeout time.Duration, context context.Context) error {
-	url, err := c.getPath("/images/create", opts)
+	path, err := c.getPath("/images/create", opts)
 	if err != nil {
 		return err
 	}
-	return c.streamURL(http.MethodPost, url, streamOptions{
+	return c.stream(http.MethodPost, path, streamOptions{
 		setRawTerminal:    true,
 		headers:           headers,
 		in:                in,
@@ -408,27 +408,36 @@ func (c *Client) ExportImages(opts ExportImagesOptions) error {
 	}
 	// API < 1.25 allows multiple name values
 	// 1.25 says name must be a comma separated list
+	if err := c.ensureAPIVersion(); err != nil {
+		return err
+	}
 	var err error
-	var exporturl string
-	if c.requestedAPIVersion.GreaterThanOrEqualTo(apiVersion125) {
+	var exportpath string
+	var effectiveVersion APIVersion
+	if expected := c.getExpectedVersion(); expected != nil {
+		effectiveVersion = expected
+	} else if c.requestedAPIVersion != nil {
+		effectiveVersion = c.requestedAPIVersion
+	}
+	if effectiveVersion != nil && effectiveVersion.GreaterThanOrEqualTo(apiVersion125) {
 		var str strings.Builder
 		str.WriteString(opts.Names[0])
 		for _, val := range opts.Names[1:] {
 			str.WriteString("," + val)
 		}
-		exporturl, err = c.getPath("/images/get", ExportImagesOptions{
+		exportpath, err = c.getPath("/images/get", ExportImagesOptions{
 			Names:             []string{str.String()},
 			OutputStream:      opts.OutputStream,
 			InactivityTimeout: opts.InactivityTimeout,
 			Context:           opts.Context,
 		})
 	} else {
-		exporturl, err = c.getPath("/images/get", &opts)
+		exportpath, err = c.getPath("/images/get", &opts)
 	}
 	if err != nil {
 		return err
 	}
-	return c.streamURL(http.MethodGet, exporturl, streamOptions{
+	return c.stream(http.MethodGet, exportpath, streamOptions{
 		setRawTerminal:    true,
 		stdout:            opts.OutputStream,
 		inactivityTimeout: opts.InactivityTimeout,
@@ -603,12 +612,12 @@ func (c *Client) BuildImage(opts BuildImageOptions) error {
 		}
 	}
 
-	buildURL, err := c.pathVersionCheck("/build", qs, ver)
+	buildPath, err := c.pathVersionCheck("/build", qs, ver)
 	if err != nil {
 		return err
 	}
 
-	return c.streamURL(http.MethodPost, buildURL, streamOptions{
+	return c.stream(http.MethodPost, buildPath, streamOptions{
 		setRawTerminal:    true,
 		rawJSONStream:     opts.RawJSONStream,
 		headers:           headers,
@@ -620,10 +629,9 @@ func (c *Client) BuildImage(opts BuildImageOptions) error {
 }
 
 func (c *Client) versionedAuthConfigs(authConfigs AuthConfigurations) registryAuth {
-	if c.serverAPIVersion == nil {
-		c.checkAPIVersion()
-	}
-	if c.serverAPIVersion != nil && c.serverAPIVersion.GreaterThanOrEqualTo(apiVersion119) {
+	c.ensureServerVersion()
+	v := c.getServerVersion()
+	if v != nil && v.GreaterThanOrEqualTo(apiVersion119) {
 		return AuthConfigurations119(authConfigs.Configs)
 	}
 	return authConfigs

--- a/image.go
+++ b/image.go
@@ -215,7 +215,11 @@ func (c *Client) InspectImage(name string) (*Image, error) {
 	var image Image
 
 	// if the caller elected to skip checking the server's version, assume it's the latest
-	if c.SkipServerVersionCheck || c.expectedAPIVersion.Load().GreaterThanOrEqualTo(apiVersion112) {
+	if c.SkipServerVersionCheck {
+		if err := json.NewDecoder(resp.Body).Decode(&image); err != nil {
+			return nil, err
+		}
+	} else if v := c.expectedAPIVersion.Load(); v != nil && v.GreaterThanOrEqualTo(apiVersion112) {
 		if err := json.NewDecoder(resp.Body).Decode(&image); err != nil {
 			return nil, err
 		}
@@ -629,6 +633,8 @@ func (c *Client) BuildImage(opts BuildImageOptions) error {
 }
 
 func (c *Client) versionedAuthConfigs(authConfigs AuthConfigurations) registryAuth {
+	// If the server version cannot be discovered, keep the legacy auth config
+	// shape. This matches the previous best-effort version check behavior.
 	c.ensureServerVersion()
 	v := c.serverAPIVersion.Load()
 	if v != nil && v.GreaterThanOrEqualTo(apiVersion119) {

--- a/image.go
+++ b/image.go
@@ -215,7 +215,7 @@ func (c *Client) InspectImage(name string) (*Image, error) {
 	var image Image
 
 	// if the caller elected to skip checking the server's version, assume it's the latest
-	if c.SkipServerVersionCheck || c.getExpectedVersion().GreaterThanOrEqualTo(apiVersion112) {
+	if c.SkipServerVersionCheck || c.expectedAPIVersion.Load().GreaterThanOrEqualTo(apiVersion112) {
 		if err := json.NewDecoder(resp.Body).Decode(&image); err != nil {
 			return nil, err
 		}
@@ -414,7 +414,7 @@ func (c *Client) ExportImages(opts ExportImagesOptions) error {
 	var err error
 	var exportpath string
 	var effectiveVersion APIVersion
-	if expected := c.getExpectedVersion(); expected != nil {
+	if expected := c.expectedAPIVersion.Load(); expected != nil {
 		effectiveVersion = expected
 	} else if c.requestedAPIVersion != nil {
 		effectiveVersion = c.requestedAPIVersion
@@ -630,7 +630,7 @@ func (c *Client) BuildImage(opts BuildImageOptions) error {
 
 func (c *Client) versionedAuthConfigs(authConfigs AuthConfigurations) registryAuth {
 	c.ensureServerVersion()
-	v := c.getServerVersion()
+	v := c.serverAPIVersion.Load()
 	if v != nil && v.GreaterThanOrEqualTo(apiVersion119) {
 		return AuthConfigurations119(authConfigs.Configs)
 	}

--- a/image_test.go
+++ b/image_test.go
@@ -31,7 +31,7 @@ func newTestClient(rt http.RoundTripper) *Client {
 		endpointURL:            u,
 		SkipServerVersionCheck: true,
 	}
-	client.serverAPIVersion.Store(testAPIVersion)
+	storeAPIVersion(&client.serverAPIVersion, testAPIVersion)
 	return client
 }
 

--- a/image_test.go
+++ b/image_test.go
@@ -661,6 +661,36 @@ func TestImportImageFromUrl(t *testing.T) {
 	}
 }
 
+func TestImportImagePlatformDoesNotForceURLVersion(t *testing.T) {
+	t.Parallel()
+	fakeRT := &FakeRoundTripper{message: "", status: http.StatusOK}
+	client := newTestClient(fakeRT)
+	var buf bytes.Buffer
+	opts := ImportImageOptions{
+		Source:       "http://mycompany.com/file.tar",
+		Repository:   "testimage",
+		Platform:     "linux/arm64",
+		OutputStream: &buf,
+	}
+	err := client.ImportImage(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := fakeRT.requests[0]
+	expected := map[string][]string{
+		"fromSrc":  {opts.Source},
+		"repo":     {opts.Repository},
+		"platform": {opts.Platform},
+	}
+	got := map[string][]string(req.URL.Query())
+	if !reflect.DeepEqual(got, expected) {
+		t.Errorf("ImportImage: wrong query string. Want %#v. Got %#v.", expected, got)
+	}
+	if req.URL.Path != "/images/create" {
+		t.Errorf("ImportImage: wrong request path. Want %q. Got %q.", "/images/create", req.URL.Path)
+	}
+}
+
 func TestImportImageFromInput(t *testing.T) {
 	t.Parallel()
 	fakeRT := &FakeRoundTripper{message: "", status: http.StatusOK}
@@ -833,9 +863,9 @@ func TestBuildImageParameters(t *testing.T) {
 	if !reflect.DeepEqual(got, expected) {
 		t.Errorf("BuildImage: wrong query string. Want %#v.\n Got %#v.", expected, got)
 	}
-	expectedPrefix := "http://localhost:4243/v1.25/"
+	expectedPrefix := "http://localhost:4243/build?"
 	if !strings.HasPrefix(req.URL.String(), expectedPrefix) {
-		t.Errorf("BuildImage: wrong URL version Want Prefix %s.\n Got URL: %s", expectedPrefix, req.URL.String())
+		t.Errorf("BuildImage: wrong URL. Want Prefix %s.\n Got URL: %s", expectedPrefix, req.URL.String())
 	}
 }
 

--- a/image_test.go
+++ b/image_test.go
@@ -20,18 +20,18 @@ import (
 	"time"
 )
 
-func newTestClient(rt http.RoundTripper) Client {
+func newTestClient(rt http.RoundTripper) *Client {
 	endpoint := "http://localhost:4243"
 	u, _ := parseEndpoint("http://localhost:4243", false)
 	testAPIVersion, _ := NewAPIVersion("1.17")
-	client := Client{
+	client := &Client{
 		HTTPClient:             &http.Client{Transport: rt},
 		Dialer:                 &net.Dialer{},
 		endpoint:               endpoint,
 		endpointURL:            u,
 		SkipServerVersionCheck: true,
-		serverAPIVersion:       testAPIVersion,
 	}
+	client.serverAPIVersion.Store(testAPIVersion)
 	return client
 }
 
@@ -1098,6 +1098,69 @@ func TestExportImages(t *testing.T) {
 	got = req.URL.String()
 	if !reflect.DeepEqual(got, expected) {
 		t.Errorf("ExportImages: wrong path. Expected %q. Got %q.", expected, got)
+	}
+}
+
+func TestExportImagesSkipServerVersionCheckNoVersion(t *testing.T) {
+	t.Parallel()
+	var gotRawQuery string
+	client, cleanup := newHTTPTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/images/get":
+			gotRawQuery = r.URL.RawQuery
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Errorf("unexpected request path %q", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	defer cleanup()
+	var buf bytes.Buffer
+	err := client.ExportImages(ExportImagesOptions{
+		Names:        []string{"testimage1", "testimage2:latest"},
+		OutputStream: &buf,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantRawQuery := "names=testimage1&names=testimage2%3Alatest"
+	if gotRawQuery != wantRawQuery {
+		t.Fatalf("ExportImages: wrong query. Want %q. Got %q.", wantRawQuery, gotRawQuery)
+	}
+}
+
+func TestExportImagesNegotiatedVersionFirstCall(t *testing.T) {
+	t.Parallel()
+	var gotPath, gotRawQuery string
+	client, cleanup := newHTTPTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/version":
+			w.Write([]byte(`{"ApiVersion":"1.25"}`))
+		case "/v1.25/images/get":
+			gotPath = r.URL.Path
+			gotRawQuery = r.URL.RawQuery
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Errorf("unexpected request path %q", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	defer cleanup()
+	client.SkipServerVersionCheck = false
+	var buf bytes.Buffer
+	err := client.ExportImages(ExportImagesOptions{
+		Names:        []string{"testimage1", "testimage2:latest"},
+		OutputStream: &buf,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotPath != "/v1.25/images/get" {
+		t.Fatalf("ExportImages: wrong path. Want %q. Got %q.", "/v1.25/images/get", gotPath)
+	}
+	wantRawQuery := "names=testimage1%2Ctestimage2%3Alatest"
+	if gotRawQuery != wantRawQuery {
+		t.Fatalf("ExportImages: wrong query. Want %q. Got %q.", wantRawQuery, gotRawQuery)
 	}
 }
 

--- a/image_test.go
+++ b/image_test.go
@@ -31,7 +31,7 @@ func newTestClient(rt http.RoundTripper) *Client {
 		endpointURL:            u,
 		SkipServerVersionCheck: true,
 	}
-	storeAPIVersion(&client.serverAPIVersion, testAPIVersion)
+	client.serverAPIVersion.Store(testAPIVersion)
 	return client
 }
 

--- a/race_test.go
+++ b/race_test.go
@@ -1,0 +1,38 @@
+package docker
+
+import (
+	"net/http"
+	"sync"
+	"testing"
+)
+
+func TestCheckAPIVersionRace(t *testing.T) {
+	t.Parallel()
+	client, cleanup := newHTTPTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/version" {
+			w.Write([]byte(`{"ApiVersion":"1.44"}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	defer cleanup()
+	client.SkipServerVersionCheck = false // Trigger the logic
+
+	var wg sync.WaitGroup
+	const workers = 100
+	errs := make(chan error, workers)
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			errs <- client.Ping()
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}

--- a/race_test.go
+++ b/race_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func TestCheckAPIVersionRace(t *testing.T) {
+func TestProbeServerVersionRace(t *testing.T) {
 	t.Parallel()
 	client, cleanup := newHTTPTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/version" {


### PR DESCRIPTION
The client requests the lowest API version containing all the features used in a request. This used to just provide support for older docker versions if newer features simply weren't used. It causes the client to be rejeceted by new docker versions because old API versions are explicitly no longer supported. This changes API version negotiation to be compatible with newer docker versions

This makes versioning negotiation somewhat more complex, requiring the other changes to make thread safe. 
The race conditions were technically preexisting but rarely triggered because checking the server version was skipped most of the time

Closes #1030.